### PR TITLE
StdLib Sources Cleanup

### DIFF
--- a/lib_classes.i
+++ b/lib_classes.i
@@ -263,7 +263,7 @@ EVERY clothing ISA OBJECT
 
 
     -- all clothing acquired and worn by the hero or an NPC mid-game is checked to
-           -- show correctly when the possessions of an actor are listed:
+    -- show correctly when the possessions of an actor are listed:
 
 
     SCHEDULE worn_clothing_check AFTER 0.
@@ -274,7 +274,7 @@ EVERY clothing ISA OBJECT
   -- to allow for example a wallet to be put into a jacket
 
   -- If the clothing contains something, for example if a jacket contains a wallet,
-      -- the wallet will be mentioned by default when the jacket is examined:
+  -- the wallet will be mentioned by default when the jacket is examined:
 
 
   VERB examine
@@ -738,24 +738,25 @@ END EVENT.
 -- create nasty bugs:
 
 
--- Clothing       Headcover Topcover  Botcover  Footcover   Handcover
-
--- hat        2   0   0   0   0
--- vest/bra               0         2           0   0   0
--- undies/panties   0   0   2   0   0
--- teddy        0   4   4   0   0
--- blouse/shirt/T-shirt 0   8   0   0   0
--- dress/coveralls    0   8   32    0   0
--- skirt        0   0   32    0   0
--- trousers/shorts    0   0   16    0   0
--- sweater/pullover   0   16    0   0   0
--- jacket       0   32    0   0   0
--- coat       0   64    64    0   0
--- socks/stockings    0   0   0   2   0
--- tights/pantiehose    0   0   8   2   0
--- shoes/boots      0   0   0   4   0
--- gloves       0   0   0   0   2
-
+--+--------------------------+----------+----------+-----------+-----------+
+--| Clothing     | Headcover | Topcover | Botcover | Footcover | Handcover |
+--+--------------------------+----------+----------+-----------+-----------+
+--| hat                    2 |        0 |        0 |         0 |         0 |
+--| vest/bra               0 |        2 |        0 |         0 |         0 |
+--| undies/panties         0 |        0 |        2 |         0 |         0 |
+--| teddy                  0 |        4 |        4 |         0 |         0 |
+--| blouse/shirt/T-shirt   0 |        8 |        0 |         0 |         0 |
+--| dress/coveralls        0 |        8 |       32 |         0 |         0 |
+--| skirt                  0 |        0 |       32 |         0 |         0 |
+--| trousers/shorts        0 |        0 |       16 |         0 |         0 |
+--| sweater/pullover       0 |       16 |        0 |         0 |         0 |
+--| jacket                 0 |       32 |        0 |         0 |         0 |
+--| coat                   0 |       64 |       64 |         0 |         0 |
+--| socks/stockings        0 |        0 |        0 |         2 |         0 |
+--| tights/pantiehose      0 |        0 |        8 |         2 |         0 |
+--| shoes/boots            0 |        0 |        0 |         4 |         0 |
+--| gloves                 0 |        0 |        0 |         0 |         2 |
+--+--------------------------+----------+----------+-----------+-----------+
 
 
 

--- a/lib_classes.i
+++ b/lib_classes.i
@@ -2,22 +2,22 @@
 -- Classes (file name: 'lib_classes.i')
 
 
--- This library file defines various object and actor classes. 
--- Many of these classes are frequently  used in verb definitions in 'lib_verbs.i' 
--- so they should be edited or removed with caution. However, to ease things up, 
+-- This library file defines various object and actor classes.
+-- Many of these classes are frequently  used in verb definitions in 'lib_verbs.i'
+-- so they should be edited or removed with caution. However, to ease things up,
 -- it is mentioned at the beginning of every class below if and where the class
 -- is cross-referenced in the other library files.
 
 
----- First, we define the default description for scenery objects 
-		-- = no description at all 
+---- First, we define the default description for scenery objects
+    -- = no description at all
 
 
 ADD TO EVERY OBJECT
 
-	DESCRIPTION
-  		CHECK THIS IS NOT scenery
-			ELSE SAY "".
+  DESCRIPTION
+      CHECK THIS IS NOT scenery
+      ELSE SAY "".
 
 END ADD.
 
@@ -28,79 +28,79 @@ END ADD.
 
 -- Contents:
 
-	
+
 
 
 
 -- 1. OBJECT CLASSES
--- ================= 
+-- =================
 
 
 
--- CLOTHING    
-	-- Is a piece of clothing that behaves according to Alan Bampton's 'xwear.i' extension.
-     -- The said extension has been fully assimilated to this library. 
-     -- This extension prevents clothes from being worn in an illogical order, for example you 
-	-- cannot put on a shirt if you are already wearing a jacket, and so forth.
-	-- This only applies to the hero; NPCs cannot be made to wear clothing in layers.
-	-- Also the verbs 'wear', 'remove' and 'undress' are defined here.
+-- CLOTHING
+  -- Is a piece of clothing that behaves according to Alan Bampton's 'xwear.i' extension.
+     -- The said extension has been fully assimilated to this library.
+     -- This extension prevents clothes from being worn in an illogical order, for example you
+  -- cannot put on a shirt if you are already wearing a jacket, and so forth.
+  -- This only applies to the hero; NPCs cannot be made to wear clothing in layers.
+  -- Also the verbs 'wear', 'remove' and 'undress' are defined here.
 
 
--- DEVICE  
-	-- Is a  machine or an electronic device, for example a TV. Can be turned 
-	-- (=switched) on and off if it is not broken.
-	-- Attributes: 'on' and NOT 'on', NOT broken.
-      -- Is described by default as being either on or off when examined. 
+-- DEVICE
+  -- Is a  machine or an electronic device, for example a TV. Can be turned
+  -- (=switched) on and off if it is not broken.
+  -- Attributes: 'on' and NOT 'on', NOT broken.
+      -- Is described by default as being either on or off when examined.
 
 
--- DOOR 
-	-- Can be opened, closed, and optionally locked and unlocked. 
-	-- Is by default not open, not lockable.
-	-- all default attributes: openable, NOT open, NOT lockable, NOT locked; not takeable.
-	-- Is described by default as being either open or closed when examined.
+-- DOOR
+  -- Can be opened, closed, and optionally locked and unlocked.
+  -- Is by default not open, not lockable.
+  -- all default attributes: openable, NOT open, NOT lockable, NOT locked; not takeable.
+  -- Is described by default as being either open or closed when examined.
 
 
--- LIQUID 
-	-- Can only be taken if it is in a container. You can fill something with it, 
-	-- and you can pour it somewhere.
-	-- A liquid is by default NOT drinkable.
+-- LIQUID
+  -- Can only be taken if it is in a container. You can fill something with it,
+  -- and you can pour it somewhere.
+  -- A liquid is by default NOT drinkable.
 
 
--- LIGHTSOURCE 
-	-- IS natural or NOT natural 
-	-- (a natural lightsource is for example a match or a torch).
-	-- Can be turned on and off, lighted and extinguished (= put out) if it 
-      -- is not broken. A natural lightsource 
-	-- cannot be turned on or off, it can only be lighted and extinguished (= put out).
-	-- When examined, a lightsource is automatically supplied with a description of
-	-- whether it is providing light or not.
+-- LIGHTSOURCE
+  -- IS natural or NOT natural
+  -- (a natural lightsource is for example a match or a torch).
+  -- Can be turned on and off, lighted and extinguished (= put out) if it
+      -- is not broken. A natural lightsource
+  -- cannot be turned on or off, it can only be lighted and extinguished (= put out).
+  -- When examined, a lightsource is automatically supplied with a description of
+  -- whether it is providing light or not.
 
 
 -- LISTED_CONTAINER
-	-- Is a container object. The contents of a listed_container will be listed both after 
-	-- 'look' (= in the room description), 'look in' and 'examine' (if the container is open). 
-	-- (The contents of a normal container object are not listed after 'examine' by default, but only 
-	-- after 'look' (=room description) and 'look in').
+  -- Is a container object. The contents of a listed_container will be listed both after
+  -- 'look' (= in the room description), 'look in' and 'examine' (if the container is open).
+  -- (The contents of a normal container object are not listed after 'examine' by default, but only
+  -- after 'look' (=room description) and 'look in').
 
 
--- SOUND 
-	-- Can be listened to but not examined, searched, smelled or manipulated.
+-- SOUND
+  -- Can be listened to but not examined, searched, smelled or manipulated.
      -- (Can be turned on and off if desirable.)
 
 
--- SUPPORTER 
-	-- You can put things on this and you can stand on this. It is declared a container, 
-	-- so you can take things from it, as well. When there's something on a supporter, 
+-- SUPPORTER
+  -- You can put things on this and you can stand on this. It is declared a container,
+  -- so you can take things from it, as well. When there's something on a supporter,
       -- a default listing of it will appear in the room description and after 'examine'.
 
 
--- WEAPON  
-	-- IS fireable (for example a cannon) or NOT fireable (for example a baseball bat).
+-- WEAPON
+  -- IS fireable (for example a cannon) or NOT fireable (for example a baseball bat).
 
 
--- WINDOW 
-	-- Can be opened, closed, looked through and out of.
-	-- Will be by default described as being either open or closed when examined.
+-- WINDOW
+  -- Can be opened, closed, looked through and out of.
+  -- Will be by default described as being either open or closed when examined.
 
 
 
@@ -108,34 +108,34 @@ END ADD.
 -- ================
 
 -- the ACTORS are defined to be NOT inanimate CONTAINERS (so that they can for example
--- receive and carry things. 
+-- receive and carry things.
 --
 -- Actors are usually preceded by an article in-game:
 -- for example "You see a man here."
---	  "There is nothing special about the dog."
+--    "There is nothing special about the dog."
 -- unless they are declared as 'named'.
 --
 -- The following classes for actors are defined in this library:
 
 
--- PERSON 
-	-- is able to talk (= 'CAN talk'). 
+-- PERSON
+  -- is able to talk (= 'CAN talk').
 
 
 -- FEMALE
-	-- a subclass of person (= is able to talk)
+  -- a subclass of person (= is able to talk)
       -- can be referred to with the pronoun 'her'
 
 
 -- MALE
-	-- a subclass of person (= is able to talk)
+  -- a subclass of person (= is able to talk)
       -- can be referred to with the pronoun 'him'
 
 
 
 
 
--- The contents end here. 
+-- The contents end here.
 
 
 
@@ -157,13 +157,13 @@ END ADD.
 -- ==============================================================
 
 
------ CLOTHING     
+----- CLOTHING
 
 
 -- ==============================================================
 
 
--- (See the file 'lib_verbs.i', verbs 'inventory' and 'take' where the 
+-- (See the file 'lib_verbs.i', verbs 'inventory' and 'take' where the
 -- container 'worn', defined below, is used in the verb definitions.)
 
 
@@ -171,7 +171,7 @@ END ADD.
 -- code below.
 
 -- This class makes use of Alan Bampton's 'xwear.i' extension
--- written originally for ALAN V2, converted here to V3 and 
+-- written originally for ALAN V2, converted here to V3 and
 -- assimilated fully to the present library. Thanks to Alan Bampton
 -- for the permission to use the code here.
 
@@ -185,10 +185,10 @@ END ADD.
 -- This container is only used internally in the library; ignore.
 
 
-THE worn ISA ENTITY 							
-	CONTAINER TAKING CLOTHING.			
-		HEADER SAY hero_worn_header OF my_game.
-		ELSE SAY hero_worn_else OF my_game.
+THE worn ISA ENTITY
+  CONTAINER TAKING CLOTHING.
+    HEADER SAY hero_worn_header OF my_game.
+    ELSE SAY hero_worn_else OF my_game.
 END THE.
 
 
@@ -196,115 +196,115 @@ END THE.
 
 
 -------------------------------------------------------------------
--- Now, we define some common attributes for clothing as well as 
+-- Now, we define some common attributes for clothing as well as
 -- how the verbs 'remove', 'undress' and 'wear' (and their synonyms) behave with this class.
 -------------------------------------------------------------------
 
 
 EVERY clothing ISA OBJECT
 
-	IS wearable.
+  IS wearable.
 
-	IS sex 0.
+  IS sex 0.
 
-	IS headcover 0.
-	IS handscover 0.
-	IS feetcover 0.
-	IS topcover 0.
-	IS botcover 0.
+  IS headcover 0.
+  IS handscover 0.
+  IS feetcover 0.
+  IS topcover 0.
+  IS botcover 0.
 
-	IS NOT donned. -- not in the 'wearing' set of any actor; this attribute
-				-- is used internally in the library; ignore
-
-
-	INITIALIZE  
+  IS NOT donned. -- not in the 'wearing' set of any actor; this attribute
+        -- is used internally in the library; ignore
 
 
-		-- the set attribute 'IS wearing' is defined to work for both the hero
-		-- and NPCs:
-
-		IF THIS IN worn
-			THEN INCLUDE THIS IN wearing OF hero.
-		END IF.
-
-		FOR EACH ac ISA ACTOR
-			DO
-				IF ac = hero 
-					THEN
-						IF THIS IN wearing OF hero AND THIS <> null_clothing
-							THEN 
-								IF THIS NOT IN worn
-									THEN LOCATE THIS IN worn.
-								END IF.	
-								MAKE THIS donned.
-						END IF.
-				ELSIF THIS IN wearing OF ac AND THIS <> null_clothing
-						THEN 
-							IF THIS NOT IN ac
-								THEN 
-									LOCATE THIS IN ac.
-							END IF.
-							MAKE THIS donned.
-				END IF.
-		END FOR.
+  INITIALIZE
 
 
+    -- the set attribute 'IS wearing' is defined to work for both the hero
+    -- and NPCs:
 
-		-- all objects found in a piece of clothing, for example a wallet in a jacket,
-		-- will be allowed back in the piece of clothing once taken from there:
+    IF THIS IN worn
+      THEN INCLUDE THIS IN wearing OF hero.
+    END IF.
 
-		
-		FOR EACH o ISA OBJECT, DIRECTLY IN THIS
-			DO 
-				INCLUDE o IN allowed OF THIS.
-		END FOR.
-		
-		
+    FOR EACH ac ISA ACTOR
+      DO
+        IF ac = hero
+          THEN
+            IF THIS IN wearing OF hero AND THIS <> null_clothing
+              THEN
+                IF THIS NOT IN worn
+                  THEN LOCATE THIS IN worn.
+                END IF.
+                MAKE THIS donned.
+            END IF.
+        ELSIF THIS IN wearing OF ac AND THIS <> null_clothing
+            THEN
+              IF THIS NOT IN ac
+                THEN
+                  LOCATE THIS IN ac.
+              END IF.
+              MAKE THIS donned.
+        END IF.
+    END FOR.
 
 
-		-- all clothing acquired and worn by the hero or an NPC mid-game is checked to 
+
+    -- all objects found in a piece of clothing, for example a wallet in a jacket,
+    -- will be allowed back in the piece of clothing once taken from there:
+
+
+    FOR EACH o ISA OBJECT, DIRECTLY IN THIS
+      DO
+        INCLUDE o IN allowed OF THIS.
+    END FOR.
+
+
+
+
+    -- all clothing acquired and worn by the hero or an NPC mid-game is checked to
            -- show correctly when the possessions of an actor are listed:
 
 
-		SCHEDULE worn_clothing_check AFTER 0.
-		
-
-
-	CONTAINER			
-	-- to allow for example a wallet to be put into a jacket
-
-	-- If the clothing contains something, for example if a jacket contains a wallet,
-    	-- the wallet will be mentioned by default when the jacket is examined: 
-
-
-	VERB examine
-		DOES AFTER
-			IF THIS IS NOT OPAQUE
-				THEN 
-					IF COUNT ISA OBJECT, DIRECTLY IN THIS > 0		
-						THEN LIST THIS.					
-					END IF.							
-			END IF.									
-	END VERB.
+    SCHEDULE worn_clothing_check AFTER 0.
 
 
 
-  	VERB wear
+  CONTAINER
+  -- to allow for example a wallet to be put into a jacket
 
-		CHECK sex OF THIS = sex OF hero OR sex OF THIS = 0
-			ELSE SAY check_clothing_sex OF my_game.
-		
-		DOES ONLY
+  -- If the clothing contains something, for example if a jacket contains a wallet,
+      -- the wallet will be mentioned by default when the jacket is examined:
+
+
+  VERB examine
+    DOES AFTER
+      IF THIS IS NOT OPAQUE
+        THEN
+          IF COUNT ISA OBJECT, DIRECTLY IN THIS > 0
+            THEN LIST THIS.
+          END IF.
+      END IF.
+  END VERB.
+
+
+
+    VERB wear
+
+    CHECK sex OF THIS = sex OF hero OR sex OF THIS = 0
+      ELSE SAY check_clothing_sex OF my_game.
+
+    DOES ONLY
 
 
 --------------------------------------------------------------------
--- 'wear_flag' is a multi-purpose flag used for several purposes in 
+-- 'wear_flag' is a multi-purpose flag used for several purposes in
 -- this library, here it is reset to 0 before proceeding as a matter
 -- of 'housekeeping' for the code.
 --------------------------------------------------------------------
 
 
-		SET wear_flag OF hero TO 0.
+    SET wear_flag OF hero TO 0.
 
 
 --------------------------------------------------------------------
@@ -314,14 +314,14 @@ EVERY clothing ISA OBJECT
 --------------------------------------------------------------------
 
 
-		IF THIS NOT IN hero 
-			THEN
-				SET wear_flag OF hero TO 1.
-		END IF.
+    IF THIS NOT IN hero
+      THEN
+        SET wear_flag OF hero TO 1.
+    END IF.
 
-	
+
 --------------------------------------------------------------------
---  Now see if the player can put this item on by testing 
+--  Now see if the player can put this item on by testing
 --  all of its coverage attributes against the player's state.
 --------------------------------------------------------------------
 
@@ -329,88 +329,88 @@ EVERY clothing ISA OBJECT
 --------------------------------------------------------------------
 -- First check the 'topcover' attributes, if 'obj' fails this test
 -- then it means the hero is already wearing clothes that cover the
--- topcover area and those clothes are of the same layer or a layer 
--- that belongs on top of the 'obj' item. In either case it would 
+-- topcover area and those clothes are of the same layer or a layer
+-- that belongs on top of the 'obj' item. In either case it would
 -- NOT be possible to put on the 'obj'. To 'flag' this condition add
 -- 5 to the 'wear_flag' attribute as an indicator this test failed.
 --------------------------------------------------------------------
 
 
-		IF topcover OF THIS <> 0 AND topcover OF THIS <= SUM OF topcover DIRECTLY IN worn 
-			THEN
-				INCREASE wear_flag OF hero BY 5.
-		END IF.
+    IF topcover OF THIS <> 0 AND topcover OF THIS <= SUM OF topcover DIRECTLY IN worn
+      THEN
+        INCREASE wear_flag OF hero BY 5.
+    END IF.
 
-	
+
 --------------------------------------------------------------------
 -- Perform a similar test for other attributes.
 --------------------------------------------------------------------
 
 
-		--IF THIS IN tempworn 
-			--THEN
-			
-		IF handscover OF THIS <> 0 AND handscover OF THIS <= SUM OF handscover DIRECTLY IN worn 
-			THEN
-				INCREASE wear_flag OF hero BY 5.
-		END IF.
-	
+    --IF THIS IN tempworn
+      --THEN
 
-		IF feetcover OF THIS <> 0 AND feetcover OF THIS <= SUM OF feetcover DIRECTLY IN worn 
-			THEN
-				INCREASE wear_flag OF hero BY 5.	
-		END IF.
+    IF handscover OF THIS <> 0 AND handscover OF THIS <= SUM OF handscover DIRECTLY IN worn
+      THEN
+        INCREASE wear_flag OF hero BY 5.
+    END IF.
 
-	
-		IF headcover OF THIS <> 0 AND headcover OF THIS <= SUM OF headcover DIRECTLY IN worn 
-			THEN
-				INCREASE wear_flag OF hero BY 5.	
-		END IF.
+
+    IF feetcover OF THIS <> 0 AND feetcover OF THIS <= SUM OF feetcover DIRECTLY IN worn
+      THEN
+        INCREASE wear_flag OF hero BY 5.
+    END IF.
+
+
+    IF headcover OF THIS <> 0 AND headcover OF THIS <= SUM OF headcover DIRECTLY IN worn
+      THEN
+        INCREASE wear_flag OF hero BY 5.
+    END IF.
 
 
 --------------------------------------------------------------------
---  botcover is a special case, adjust the 'tempcovered OF hero' 
+--  botcover is a special case, adjust the 'tempcovered OF hero'
 --  attribute so that the code rejects non sensible options.
---  First of all, discount any coatlike clothes as these never 
+--  First of all, discount any coatlike clothes as these never
 --  affect ability to put on other lower body only garments.
 --------------------------------------------------------------------
 
 
-		SET tempcovered OF hero TO SUM OF botcover DIRECTLY IN worn.
-		
-		IF tempcovered OF hero >63 and botcover OF THIS < 33
-			THEN 
-				SET tempcovered OF hero TO tempcovered OF hero -64.
-		END IF.
+    SET tempcovered OF hero TO SUM OF botcover DIRECTLY IN worn.
+
+    IF tempcovered OF hero >63 and botcover OF THIS < 33
+      THEN
+        SET tempcovered OF hero TO tempcovered OF hero -64.
+    END IF.
 
 
 --------------------------------------------------------------------
--- Now discount any dress/ skirt coverall like clothes as these do 
+-- Now discount any dress/ skirt coverall like clothes as these do
 -- not technically affect ability to put on lower body only clothes.
 -- Special clause here excludes the full body coverage 'teddy' type
--- garment - as a skirt WOULD prevent that from being removed. 
--- ( dress/coat garments automatically prevent this by virtue of 
+-- garment - as a skirt WOULD prevent that from being removed.
+-- ( dress/coat garments automatically prevent this by virtue of
 -- having higher 'topcover' settings than the teddy )
 --------------------------------------------------------------------
 
 
-		IF tempcovered OF hero >31 AND botcover OF THIS < 16 and botcover OF THIS <> 4 
-			THEN
-				SET tempcovered OF hero TO tempcovered OF hero -32.
-		END IF.
+    IF tempcovered OF hero >31 AND botcover OF THIS < 16 and botcover OF THIS <> 4
+      THEN
+        SET tempcovered OF hero TO tempcovered OF hero -32.
+    END IF.
 
 
 --------------------------------------------------------------------
--- IF tempcovered OF hero is still > 15 then must have trousers 
+-- IF tempcovered OF hero is still > 15 then must have trousers
 -- type clothing on - therefore disallow wearing dress type clothing
--- because, although technically possible, it is not very sensible. 
+-- because, although technically possible, it is not very sensible.
 --------------------------------------------------------------------
 
 
-		IF tempcovered OF hero >15 AND botcover OF THIS > 16 
-			THEN
-				SET tempcovered OF hero TO tempcovered OF hero +16.
-		END IF.
+    IF tempcovered OF hero >15 AND botcover OF THIS > 16
+      THEN
+        SET tempcovered OF hero TO tempcovered OF hero +16.
+    END IF.
 
 
 --------------------------------------------------------------------
@@ -418,110 +418,110 @@ EVERY clothing ISA OBJECT
 --------------------------------------------------------------------
 
 
-		IF botcover OF THIS <> 0  AND botcover OF THIS <= tempcovered OF hero 
-			THEN
-				INCREASE wear_flag OF hero BY 5.		
-		END IF.
+    IF botcover OF THIS <> 0  AND botcover OF THIS <= tempcovered OF hero
+      THEN
+        INCREASE wear_flag OF hero BY 5.
+    END IF.
 
-	
+
 --------------------------------------------------------------------
 -- At this point, 'wear_flag' will be 0 if the obj was held by the
--- player and can be put on, or l if he picked it up this turn and 
--- it can be put on. Any higher value means one or more of the 
--- tests failed and the player cannot put on these clothes. 
+-- player and can be put on, or l if he picked it up this turn and
+-- it can be put on. Any higher value means one or more of the
+-- tests failed and the player cannot put on these clothes.
 --------------------------------------------------------------------
 
 
-		IF wear_flag OF hero >1 
-			THEN
-				IF THIS NOT IN hero 
-					THEN "You pick up the" SAY THE THIS. "."
-				END IF.
-				
-				LOCATE THIS IN hero.
-				EMPTY worn IN tempworn.	
-				LIST tempworn.
+    IF wear_flag OF hero >1
+      THEN
+        IF THIS NOT IN hero
+          THEN "You pick up the" SAY THE THIS. "."
+        END IF.
 
-				"Trying to put" SAY THE THIS. "on isn't very sensible."
+        LOCATE THIS IN hero.
+        EMPTY worn IN tempworn.
+        LIST tempworn.
 
-				EMPTY tempworn IN worn.
+        "Trying to put" SAY THE THIS. "on isn't very sensible."
 
-		ELSIF wear_flag OF hero = 1 
-			THEN
-				LOCATE THIS IN worn.
+        EMPTY tempworn IN worn.
 
-				"You pick up the" SAY THE THIS.
+    ELSIF wear_flag OF hero = 1
+      THEN
+        LOCATE THIS IN worn.
 
-				IF THIS IS NOT plural 
-					THEN "and put it on."
-					ELSE "and put them on."
-				END IF.
+        "You pick up the" SAY THE THIS.
 
-		ELSE
-			LOCATE THIS IN worn.
-			MAKE THIS donned.
-			INCLUDE THIS IN wearing OF hero.
-			"You put on" SAY THE THIS. "."
-		END IF.
+        IF THIS IS NOT plural
+          THEN "and put it on."
+          ELSE "and put them on."
+        END IF.
+
+    ELSE
+      LOCATE THIS IN worn.
+      MAKE THIS donned.
+      INCLUDE THIS IN wearing OF hero.
+      "You put on" SAY THE THIS. "."
+    END IF.
 
 END VERB.
 
 
 
 VERB remove
-	CHECK THIS IN worn
-		ELSE SAY check_obj_in_worn OF my_game.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
+  CHECK THIS IN worn
+    ELSE SAY check_obj_in_worn OF my_game.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
 
-	DOES ONLY
-	
-	SET wear_flag OF hero TO 0.
+  DOES ONLY
 
-	
+  SET wear_flag OF hero TO 0.
+
+
 --------------------------------------------------------------------
 -- Check the total 'topcover' of items worn. Because of the number
--- sequence used, by dividing the sum of the worn attributes by two 
+-- sequence used, by dividing the sum of the worn attributes by two
 -- and then comparing the result to the individual 'topcover' of the
--- obj in question, ( the former can only ever be greater than the 
--- latter if an article of clothing is worn that goes over 'obj' ) 
+-- obj in question, ( the former can only ever be greater than the
+-- latter if an article of clothing is worn that goes over 'obj' )
 -- it's easy to tell if the obj ought to be removable. A temporary
 -- attribute is used here because it needs to be manipulated. Once
 -- again 'wear_flag' is used to indicate the results.
 --------------------------------------------------------------------
 
 
-	SET tempcovered OF hero TO SUM OF topcover DIRECTLY IN worn /2.
-	IF topcover OF THIS <> 0 AND topcover OF THIS < tempcovered OF hero
-		 THEN
-			INCREASE wear_flag OF hero BY 1.
-	END IF.
+  SET tempcovered OF hero TO SUM OF topcover DIRECTLY IN worn /2.
+  IF topcover OF THIS <> 0 AND topcover OF THIS < tempcovered OF hero
+     THEN
+      INCREASE wear_flag OF hero BY 1.
+  END IF.
 
-		
+
 --------------------------------------------------------------------
 -- Perform a similar test for other attributes.
 --------------------------------------------------------------------
 
 
-	SET tempcovered OF hero TO SUM OF handscover DIRECTLY IN worn /2.
-	IF handscover OF THIS <> 0 AND handscover OF THIS < tempcovered OF hero 
-		THEN
-			INCREASE wear_flag OF hero BY 1.
-	END IF.		
+  SET tempcovered OF hero TO SUM OF handscover DIRECTLY IN worn /2.
+  IF handscover OF THIS <> 0 AND handscover OF THIS < tempcovered OF hero
+    THEN
+      INCREASE wear_flag OF hero BY 1.
+  END IF.
 
 
-	SET tempcovered OF hero TO SUM OF feetcover DIRECTLY IN worn /2.
-	IF feetcover OF THIS <> 0 AND feetcover OF THIS < tempcovered OF hero 
-		THEN
-			INCREASE wear_flag OF hero BY 1.		
-	END IF.	
+  SET tempcovered OF hero TO SUM OF feetcover DIRECTLY IN worn /2.
+  IF feetcover OF THIS <> 0 AND feetcover OF THIS < tempcovered OF hero
+    THEN
+      INCREASE wear_flag OF hero BY 1.
+  END IF.
 
 
-	SET tempcovered OF hero TO SUM OF headcover DIRECTLY IN worn /2.
-	IF headcover OF THIS <> 0 AND headcover OF THIS < tempcovered OF hero 
-		THEN
-			INCREASE wear_flag OF hero BY 1.
-	END IF.		
+  SET tempcovered OF hero TO SUM OF headcover DIRECTLY IN worn /2.
+  IF headcover OF THIS <> 0 AND headcover OF THIS < tempcovered OF hero
+    THEN
+      INCREASE wear_flag OF hero BY 1.
+  END IF.
 
 
 --------------------------------------------------------------------
@@ -530,24 +530,24 @@ VERB remove
 --------------------------------------------------------------------
 
 
-	SET tempcovered OF hero TO SUM OF botcover DIRECTLY IN worn.
-	IF tempcovered OF hero >63 
-		THEN 
-			SET tempcovered OF hero TO tempcovered OF hero -64.
-	END IF.
+  SET tempcovered OF hero TO SUM OF botcover DIRECTLY IN worn.
+  IF tempcovered OF hero >63
+    THEN
+      SET tempcovered OF hero TO tempcovered OF hero -64.
+  END IF.
 
 
 --------------------------------------------------------------------
--- Now discount any dress/ skirt coverall like clothes as these do 
--- not affect ability to take off other lower garments.	The 'teddy'
+-- Now discount any dress/ skirt coverall like clothes as these do
+-- not affect ability to take off other lower garments. The 'teddy'
 -- type garment is expressly NOT included in the exclusion here.
 --------------------------------------------------------------------
 
 
-	IF tempcovered OF hero >31 and botcover OF THIS <>4 
-		THEN
-			SET tempcovered OF hero TO tempcovered OF hero -32.
-	END IF.
+  IF tempcovered OF hero >31 and botcover OF THIS <>4
+    THEN
+      SET tempcovered OF hero TO tempcovered OF hero -32.
+  END IF.
 
 
 --------------------------------------------------------------------
@@ -555,30 +555,30 @@ VERB remove
 --------------------------------------------------------------------
 
 
-	SET tempcovered OF hero TO tempcovered OF hero /2.
-	IF botcover OF THIS <> 0 AND botcover OF THIS < tempcovered OF hero 
-		THEN
-			INCREASE wear_flag OF hero BY 1.
-	END IF.
+  SET tempcovered OF hero TO tempcovered OF hero /2.
+  IF botcover OF THIS <> 0 AND botcover OF THIS < tempcovered OF hero
+    THEN
+      INCREASE wear_flag OF hero BY 1.
+  END IF.
 
 
 --------------------------------------------------------------------
 -- Depending on the value of 'wear_flag' print and process the obj
--- as needed. If 'wear_flag' is NOT 0 then the clothes cannot be 
+-- as needed. If 'wear_flag' is NOT 0 then the clothes cannot be
 -- removed.
 --------------------------------------------------------------------
 
 
-	IF wear_flag OF hero > 0 
-		THEN
-			LIST worn.
-			"Trying to take" SAY THE THIS. "off isn't very sensible."
-		ELSE
-			LOCATE THIS IN hero.
-			"You take off" SAY THE THIS. "." 
-			EXCLUDE THIS FROM wearing OF hero.
-			MAKE THIS NOT donned.
-	END IF.
+  IF wear_flag OF hero > 0
+    THEN
+      LIST worn.
+      "Trying to take" SAY THE THIS. "off isn't very sensible."
+    ELSE
+      LOCATE THIS IN hero.
+      "You take off" SAY THE THIS. "."
+      EXCLUDE THIS FROM wearing OF hero.
+      MAKE THIS NOT donned.
+  END IF.
 END VERB.
 
 
@@ -587,50 +587,50 @@ END EVERY.
 
 
 --------------------------------------------------------------------
--- These attributes are used internally in the library - ignore! 
+-- These attributes are used internally in the library - ignore!
 --------------------------------------------------------------------
 
 ADD TO EVERY ACTOR
-	IS tempcovered 0.
-	IS wear_flag 0.
-	IS sex 0.
+  IS tempcovered 0.
+  IS wear_flag 0.
+  IS sex 0.
 END ADD TO.
-	
+
 
 --------------------------------------------------------------------
--- A container used to provide a temporary storage space - ignore! 
+-- A container used to provide a temporary storage space - ignore!
 --------------------------------------------------------------------
 
 THE tempworn ISA OBJECT
-	CONTAINER TAKING CLOTHING.
-	HEADER "You're already wearing"
+  CONTAINER TAKING CLOTHING.
+  HEADER "You're already wearing"
 END THE tempworn.
 
 
 --------------------------------------------------------------------
--- An event checking that clothing acquired and worn by an actor 
+-- An event checking that clothing acquired and worn by an actor
 -- mid-game is recognised to be worn by the actor:
 --------------------------------------------------------------------
 
 
 EVENT worn_clothing_check
-   FOR EACH ac ISA ACTOR 
-	DO
-		FOR EACH cl ISA CLOTHING, IN wearing OF ac
-			DO 				
-				IF ac = hero
-					THEN  
-						IF cl NOT IN worn
-							THEN LOCATE cl IN worn.
-								MAKE cl donned.
-						END IF.
-					ELSE 
-						IF cl NOT IN ac
-							THEN LOCATE cl IN ac.
-								MAKE cl donned.
-						END IF.
-				END IF.
-		END FOR.
+   FOR EACH ac ISA ACTOR
+  DO
+    FOR EACH cl ISA CLOTHING, IN wearing OF ac
+      DO
+        IF ac = hero
+          THEN
+            IF cl NOT IN worn
+              THEN LOCATE cl IN worn.
+                MAKE cl donned.
+            END IF.
+          ELSE
+            IF cl NOT IN ac
+              THEN LOCATE cl IN ac.
+                MAKE cl donned.
+            END IF.
+        END IF.
+    END FOR.
    END FOR.
    SCHEDULE worn_clothing_check AFTER 1.
 END EVENT.
@@ -641,32 +641,32 @@ END EVENT.
 --------------------------------------------------------------------
 
 -----------------------------------------------------------------------
--- INSTRUCTIONS FOR USING THE CLOTHING CLASS 
+-- INSTRUCTIONS FOR USING THE CLOTHING CLASS
 -----------------------------------------------------------------------
 
 
--- Here is a quick overview for using the class 'clothing'. 
+-- Here is a quick overview for using the class 'clothing'.
 
--- A piece of clothing in your game code should look 
+-- A piece of clothing in your game code should look
 -- something similar to the following four examples:
 
 
 -- THE jacket ISA CLOTHING AT lobby
--- 	IS topcover 32.
+--  IS topcover 32.
 -- END THE.
 
 
 -- use IN to refer to containers:
 
--- THE jeans ISA CLOTHING IN wardrobe		
---	IS botcover 16.					
+-- THE jeans ISA CLOTHING IN wardrobe
+--  IS botcover 16.
 -- END THE.
 
 
 -- IN worn = worn by the player character (hero):
 
--- THE hat ISA CLOTHING IN hero   -- declaring the initial location is optional  		 
---	IS headcover 2.
+-- THE hat ISA CLOTHING IN hero   -- declaring the initial location is optional
+--  IS headcover 2.
 -- END THE.
 
 -- THE hero ISA ACTOR
@@ -676,14 +676,14 @@ END EVENT.
 
 -- worn by an NPC called Joe:
 
--- THE sweater ISA CLOTHING IN joe    -- declaring the initial location is optional 
-	-- Don't declare clothing attributes for NPCs (unless the hero is meant to take 
-	-- and wear the NPC's clothing).
-	-- NPCs cannot wear clothing in layers!   			
--- END THE. 			
-		
+-- THE sweater ISA CLOTHING IN joe    -- declaring the initial location is optional
+  -- Don't declare clothing attributes for NPCs (unless the hero is meant to take
+  -- and wear the NPC's clothing).
+  -- NPCs cannot wear clothing in layers!
+-- END THE.
+
 -- THE joe ISA ACTOR AT room1
-	-- IS wearing {sweater}.
+  -- IS wearing {sweater}.
 -- END THE joe.
 
 -- Note that if the piece of clothing worn
@@ -702,7 +702,7 @@ END EVENT.
 
 --  3) A number 2, 4, 8, 16, 32 or 64 needs to be added after the above attribute.
 --  You cannot decide the number yourself; look it up from the clothing table below.
---  If the value of an attribute for a piece of clothing is 0 in the table, don't mention 
+--  If the value of an attribute for a piece of clothing is 0 in the table, don't mention
 --  this attribute in connection with your clothing object.
 
 -- If the piece of clothing is initially worn by either the hero or another actor,
@@ -714,7 +714,7 @@ END EVENT.
 -- END THE hero.
 
 -- THE jill ISA ACTOR
-	-- IS wearing {dress}.
+  -- IS wearing {dress}.
 -- END THE jill.
 
 
@@ -723,38 +723,38 @@ END EVENT.
 -- The above is enough; the rest is then handled automatically by the library.
 
 
--- The quick guide ends here.  
+-- The quick guide ends here.
 
 
 -- The clothing table
 -----------------------
 
 
--- Here is the chart showing a selection of fairly typical clothing items and the values to 
+-- Here is the chart showing a selection of fairly typical clothing items and the values to
 -- set to obtain appropriate behaviour. Should you wish to create an article of clothing not
--- listed, usually a bit of lateral thought as to what it is most like and where it fits into 
--- the scheme of things will suggest a workable set of values, but be aware that you MUST use 
--- values in this chart, simply adding things with intermediate values is probably going to 
+-- listed, usually a bit of lateral thought as to what it is most like and where it fits into
+-- the scheme of things will suggest a workable set of values, but be aware that you MUST use
+-- values in this chart, simply adding things with intermediate values is probably going to
 -- create nasty bugs:
 
 
--- Clothing 			Headcover	Topcover 	Botcover 	Footcover 	Handcover
+-- Clothing       Headcover Topcover  Botcover  Footcover   Handcover
 
--- hat				2		0		0		0		0
--- vest/bra             	0        	2         	0		0		0
--- undies/panties		0		0		2		0		0
--- teddy				0		4		4		0		0
--- blouse/shirt/T-shirt	0		8		0		0		0
--- dress/coveralls		0		8		32		0		0
--- skirt				0		0		32		0		0
--- trousers/shorts		0		0		16		0		0
--- sweater/pullover		0		16		0		0		0
--- jacket				0		32		0		0		0
--- coat				0		64		64		0		0
--- socks/stockings		0		0		0		2		0
--- tights/pantiehose		0		0		8		2		0
--- shoes/boots			0		0		0		4		0			
--- gloves				0		0		0		0		2
+-- hat        2   0   0   0   0
+-- vest/bra               0         2           0   0   0
+-- undies/panties   0   0   2   0   0
+-- teddy        0   4   4   0   0
+-- blouse/shirt/T-shirt 0   8   0   0   0
+-- dress/coveralls    0   8   32    0   0
+-- skirt        0   0   32    0   0
+-- trousers/shorts    0   0   16    0   0
+-- sweater/pullover   0   16    0   0   0
+-- jacket       0   32    0   0   0
+-- coat       0   64    64    0   0
+-- socks/stockings    0   0   0   2   0
+-- tights/pantiehose    0   0   8   2   0
+-- shoes/boots      0   0   0   4   0
+-- gloves       0   0   0   0   2
 
 
 
@@ -772,115 +772,115 @@ END EVENT.
 
 
 EVERY device ISA OBJECT
-	
-
-	VERB examine
-		DOES AFTER
-			IF THIS IS NOT plural
-				THEN "It is" 
-				ELSE "They are"
-			END IF.
-			
-			IF THIS IS 'on'
-				THEN "currently on."
-				ELSE "currently off."
-			END IF.
-	END VERB.
 
 
-	VERB turn_on
-		CHECK THIS IS NOT 'on'
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_device_not_on_sg OF my_game. 
-					ELSE SAY check_device_not_on_pl OF my_game.
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND THIS IS reachable AND THIS IS NOT distant
-			ELSE 
-				IF THIS IS NOT reachable
-					THEN 
-						IF THIS IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF THIS IS distant
-					THEN
-						IF THIS IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND THIS IS NOT broken
-			ELSE SAY check_obj_not_broken OF my_game.
-		DOES ONLY
-			"You turn on" SAY THE THIS. "."
-			MAKE THIS 'on'.
-	END VERB.
+  VERB examine
+    DOES AFTER
+      IF THIS IS NOT plural
+        THEN "It is"
+        ELSE "They are"
+      END IF.
+
+      IF THIS IS 'on'
+        THEN "currently on."
+        ELSE "currently off."
+      END IF.
+  END VERB.
 
 
-	VERB turn_off
-		CHECK THIS IS 'on'
-			ELSE 
-				 IF THIS IS NOT plural
-					THEN SAY check_device_on_sg OF my_game.
-					ELSE SAY check_device_on_pl OF my_game.
-				 END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND THIS IS reachable AND THIS IS NOT distant
-			ELSE 
-				IF THIS IS NOT reachable
-					THEN
-						IF THIS IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF THIS IS distant
-					THEN
-						IF THIS IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES ONLY 
-			"You turn off" SAY THE THIS. "."
-			MAKE THIS NOT 'on'.
-	END VERB.
+  VERB turn_on
+    CHECK THIS IS NOT 'on'
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_device_not_on_sg OF my_game.
+          ELSE SAY check_device_not_on_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND THIS IS reachable AND THIS IS NOT distant
+      ELSE
+        IF THIS IS NOT reachable
+          THEN
+            IF THIS IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF THIS IS distant
+          THEN
+            IF THIS IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND THIS IS NOT broken
+      ELSE SAY check_obj_not_broken OF my_game.
+    DOES ONLY
+      "You turn on" SAY THE THIS. "."
+      MAKE THIS 'on'.
+  END VERB.
+
+
+  VERB turn_off
+    CHECK THIS IS 'on'
+      ELSE
+         IF THIS IS NOT plural
+          THEN SAY check_device_on_sg OF my_game.
+          ELSE SAY check_device_on_pl OF my_game.
+         END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND THIS IS reachable AND THIS IS NOT distant
+      ELSE
+        IF THIS IS NOT reachable
+          THEN
+            IF THIS IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF THIS IS distant
+          THEN
+            IF THIS IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES ONLY
+      "You turn off" SAY THE THIS. "."
+      MAKE THIS NOT 'on'.
+  END VERB.
 
 
 -- The following verb switches a device off if the device is on, and vice versa.
 
-	
-	VERB switch
-		CHECK CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND THIS IS reachable AND THIS IS NOT distant
-			ELSE
-				IF THIS IS NOT reachable
-					THEN  
-						IF THIS IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF THIS IS distant
-					THEN
-						IF THIS IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND THIS IS NOT broken
-			ELSE SAY check_obj_not_broken OF my_game.
-		DOES ONLY
-			IF THIS IS 'on'
-				THEN "You switch off" SAY THE THIS. "."
-					MAKE THIS NOT 'on'.
-				ELSE "You switch on" SAY THE THIS. "."
-					MAKE THIS 'on'.
-			END IF.
-	END VERB.
+
+  VERB switch
+    CHECK CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND THIS IS reachable AND THIS IS NOT distant
+      ELSE
+        IF THIS IS NOT reachable
+          THEN
+            IF THIS IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF THIS IS distant
+          THEN
+            IF THIS IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND THIS IS NOT broken
+      ELSE SAY check_obj_not_broken OF my_game.
+    DOES ONLY
+      IF THIS IS 'on'
+        THEN "You switch off" SAY THE THIS. "."
+          MAKE THIS NOT 'on'.
+        ELSE "You switch on" SAY THE THIS. "."
+          MAKE THIS 'on'.
+      END IF.
+  END VERB.
 
 END EVERY.
 
@@ -899,184 +899,184 @@ END EVERY.
 
 
 EVERY door ISA OBJECT
-	IS openable.
-	IS NOT open.
-	IS NOT lockable.
-	IS NOT locked.
-	IS NOT takeable.
+  IS openable.
+  IS NOT open.
+  IS NOT lockable.
+  IS NOT locked.
+  IS NOT takeable.
 
 
-	HAS otherside null_door.
-	-- The other side of the door in the next room will be automatically taken care of
-	-- so that it shows correctly in any room or object descriptions. 
-	-- 'null_door' is a dummy default that can be ignored.
-			
-
-
-	INITIALIZE
-
-		-- ensuring that the author didn't forget to declare a locked door closed (= NOT open), as well. This is
-		-- just double-checking, as any door is by default closed (= "NOT open") at the start of the game:
-
-		IF THIS IS locked
-			THEN
-				IF THIS IS open
-					THEN MAKE THIS NOT open.
-				END IF.
-		END IF.
-
-		-- ensuring that if a door has an otherside attribute declared, this otherside will have the original
-		-- door as its otherside in turn:
-
-		IF otherside OF THIS <> null_door
-			THEN 
-				SET otherside OF otherside OF THIS TO THIS.
-
-				
-			-- next, ensuring that some attributes are correctly assigned to the otherside of the door, as well.
-			-- Only some non-default cases need to be addressed here:
-
-				IF THIS IS NOT openable
-					THEN MAKE otherside OF THIS NOT openable.
-				END IF.
-
-				IF THIS IS open
-					THEN MAKE otherside OF THIS open.
-				END IF.
-
-				IF THIS IS lockable
-					THEN MAKE otherside OF THIS lockable.
-				END IF.
-
-				IF THIS IS locked
-					THEN MAKE otherside OF THIS locked.
-				END IF.
-
-		END IF.
-
-
-		-- making the same matching_key open both sides of a door: 
-
-		IF otherside OF THIS <> null_door AND matching_key OF THIS <> null_key
-			THEN SET matching_key OF otherside OF THIS TO matching_key OF THIS.
-		END IF. 
-		
-
-	-- If a door is lockable/locked, you should state at the door instance
-	-- which object will unlock it, with the matching_key attribute. 
-		-- for example
-
-		-- THE attic_door ISA DOOR
-			-- HAS matching_key brass_key.
-			-- ...
-		--   END THE.
-
-		-- THE brass_key ISA OBJECT AT basement
-		-- END THE.
-
-	-- (null_key is a default dummy object that can be ignored.)
-
-	
-
-	VERB examine
-		DOES AFTER
-			IF THIS IS NOT plural
-				THEN "It is" 
-				ELSE "They are"
-			END IF.
-		
-			IF THIS IS NOT open
-				THEN "currently closed."
-				ELSE "currently open."
-			END IF.
-	END VERB.
-
-		
-
-	VERB knock
-		DOES ONLY
-			IF THIS IS NOT open
-				THEN "You knock on" SAY THE THIS. "$$. There is no reply."
-				ELSE "You don't find it purposeful to knock on the open door"
-					IF THIS IS NOT plural
-						THEN "."
-						ELSE "$$s."
-					END IF.
-					
-			END IF.
-	END VERB.
+  HAS otherside null_door.
+  -- The other side of the door in the next room will be automatically taken care of
+  -- so that it shows correctly in any room or object descriptions.
+  -- 'null_door' is a dummy default that can be ignored.
 
 
 
-	VERB look_behind
-		DOES ONLY 
-			IF THIS IS NOT open
-				THEN "You cannot look behind"
-					IF THIS IS NOT plural
-						THEN "the door - it is closed."
-						ELSE "the doors - they are closed."
-					END IF.
-				ELSE "You notice nothing special behind the door"
-					IF THIS IS NOT plural
-						THEN "."
-						ELSE "$$s."
-					END IF.
-			END IF.
-	END VERB.
+  INITIALIZE
+
+    -- ensuring that the author didn't forget to declare a locked door closed (= NOT open), as well. This is
+    -- just double-checking, as any door is by default closed (= "NOT open") at the start of the game:
+
+    IF THIS IS locked
+      THEN
+        IF THIS IS open
+          THEN MAKE THIS NOT open.
+        END IF.
+    END IF.
+
+    -- ensuring that if a door has an otherside attribute declared, this otherside will have the original
+    -- door as its otherside in turn:
+
+    IF otherside OF THIS <> null_door
+      THEN
+        SET otherside OF otherside OF THIS TO THIS.
+
+
+      -- next, ensuring that some attributes are correctly assigned to the otherside of the door, as well.
+      -- Only some non-default cases need to be addressed here:
+
+        IF THIS IS NOT openable
+          THEN MAKE otherside OF THIS NOT openable.
+        END IF.
+
+        IF THIS IS open
+          THEN MAKE otherside OF THIS open.
+        END IF.
+
+        IF THIS IS lockable
+          THEN MAKE otherside OF THIS lockable.
+        END IF.
+
+        IF THIS IS locked
+          THEN MAKE otherside OF THIS locked.
+        END IF.
+
+    END IF.
+
+
+    -- making the same matching_key open both sides of a door:
+
+    IF otherside OF THIS <> null_door AND matching_key OF THIS <> null_key
+      THEN SET matching_key OF otherside OF THIS TO matching_key OF THIS.
+    END IF.
+
+
+  -- If a door is lockable/locked, you should state at the door instance
+  -- which object will unlock it, with the matching_key attribute.
+    -- for example
+
+    -- THE attic_door ISA DOOR
+      -- HAS matching_key brass_key.
+      -- ...
+    --   END THE.
+
+    -- THE brass_key ISA OBJECT AT basement
+    -- END THE.
+
+  -- (null_key is a default dummy object that can be ignored.)
 
 
 
-	VERB look_under
-		DOES ONLY
-			IF THIS IS NOT open
-				THEN "The gap under the closed door"
-					IF THIS IS plural 
-						THEN "$$s"
-					END IF.
-					"is so narrow that you can't
-					see anything of what lies on the other side."
-				ELSE "You notice nothing special under the door"
-					IF THIS IS plural
-						THEN "$$s."
-						ELSE "."
-					END IF.
-			END IF.
-	END VERB.
+  VERB examine
+    DOES AFTER
+      IF THIS IS NOT plural
+        THEN "It is"
+        ELSE "They are"
+      END IF.
 
-	
-	
-	VERB close
-		DOES 
-			IF otherside OF THIS <> null_door
-				THEN MAKE otherside OF THIS NOT open.
-			END IF.
-	END VERB.
+      IF THIS IS NOT open
+        THEN "currently closed."
+        ELSE "currently open."
+      END IF.
+  END VERB.
 
 
-	VERB lock 
-		DOES 
-			IF otherside OF THIS <> null_door
-				THEN MAKE otherside OF THIS NOT open.
-					MAKE otherside OF THIS locked.
-			END IF.
-	END VERB.
+
+  VERB knock
+    DOES ONLY
+      IF THIS IS NOT open
+        THEN "You knock on" SAY THE THIS. "$$. There is no reply."
+        ELSE "You don't find it purposeful to knock on the open door"
+          IF THIS IS NOT plural
+            THEN "."
+            ELSE "$$s."
+          END IF.
+
+      END IF.
+  END VERB.
 
 
-	VERB open 
-		DOES 
-			IF otherside OF THIS <> null_door
-				THEN MAKE otherside OF THIS open.
-					MAKE otherside OF THIS NOT locked.
-			END IF.
-	END VERB.
+
+  VERB look_behind
+    DOES ONLY
+      IF THIS IS NOT open
+        THEN "You cannot look behind"
+          IF THIS IS NOT plural
+            THEN "the door - it is closed."
+            ELSE "the doors - they are closed."
+          END IF.
+        ELSE "You notice nothing special behind the door"
+          IF THIS IS NOT plural
+            THEN "."
+            ELSE "$$s."
+          END IF.
+      END IF.
+  END VERB.
 
 
-	VERB unlock 
-		DOES 
-			IF otherside OF THIS <> null_door
-				THEN MAKE otherside OF THIS NOT locked.
-			END IF.
-	END VERB.
+
+  VERB look_under
+    DOES ONLY
+      IF THIS IS NOT open
+        THEN "The gap under the closed door"
+          IF THIS IS plural
+            THEN "$$s"
+          END IF.
+          "is so narrow that you can't
+          see anything of what lies on the other side."
+        ELSE "You notice nothing special under the door"
+          IF THIS IS plural
+            THEN "$$s."
+            ELSE "."
+          END IF.
+      END IF.
+  END VERB.
+
+
+
+  VERB close
+    DOES
+      IF otherside OF THIS <> null_door
+        THEN MAKE otherside OF THIS NOT open.
+      END IF.
+  END VERB.
+
+
+  VERB lock
+    DOES
+      IF otherside OF THIS <> null_door
+        THEN MAKE otherside OF THIS NOT open.
+          MAKE otherside OF THIS locked.
+      END IF.
+  END VERB.
+
+
+  VERB open
+    DOES
+      IF otherside OF THIS <> null_door
+        THEN MAKE otherside OF THIS open.
+          MAKE otherside OF THIS NOT locked.
+      END IF.
+  END VERB.
+
+
+  VERB unlock
+    DOES
+      IF otherside OF THIS <> null_door
+        THEN MAKE otherside OF THIS NOT locked.
+      END IF.
+  END VERB.
 
 
 END EVERY.
@@ -1104,151 +1104,151 @@ END THE.
 
 
 EVERY lightsource ISA OBJECT
-	IS NOT lit.
-	IS natural. 	-- A natural lightsource is for example a candle, a match or a torch. 
-				-- A NOT natural lightsource is for example a flashlight or a lamp.
-				-- You cannot switch on or off a natural lightsource.
+  IS NOT lit.
+  IS natural.   -- A natural lightsource is for example a candle, a match or a torch.
+        -- A NOT natural lightsource is for example a flashlight or a lamp.
+        -- You cannot switch on or off a natural lightsource.
 
 
-	VERB examine
-		DOES AFTER
-			IF THIS IS lit
-				THEN 
-					IF THIS IS natural
-						THEN 
-							IF THIS IS NOT plural
-								THEN "It is"
-								ELSE "They are"
-							END IF.
-							"currently lit."
-						ELSE 
-							IF THIS IS NOT plural
-								THEN "It is"
-								ELSE "They are"
-							END IF.
-							"currently on."
-					END IF.
-				ELSE
-					IF THIS IS natural
-						THEN 
-							IF THIS IS NOT plural
-								THEN "It is"
-								ELSE "They are"
-							END IF.
-							"currently not lit."
-						ELSE 
-							IF THIS IS NOT plural
-								THEN "It is"
-								ELSE "They are"
-							END IF.
-							"currently off."
-					END IF.
-			END IF.
-	END VERB.
-
-	
-	VERB light
-		CHECK THIS IS NOT lit
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_lightsource_not_lit_sg OF my_game.
-					ELSE SAY check_lightsource_not_lit_pl OF my_game.
-				END IF.
-		AND THIS IS NOT broken
-			ELSE SAY check_obj_not_broken OF my_game.
-		DOES ONLY
-			IF THIS IS natural
-				THEN "You light" SAY THE THIS. "." 
-					MAKE THIS lit.
-				ELSE "You turn on" SAY THE THIS. "."
-					MAKE THIS lit.
-			END IF.
-	END VERB.
+  VERB examine
+    DOES AFTER
+      IF THIS IS lit
+        THEN
+          IF THIS IS natural
+            THEN
+              IF THIS IS NOT plural
+                THEN "It is"
+                ELSE "They are"
+              END IF.
+              "currently lit."
+            ELSE
+              IF THIS IS NOT plural
+                THEN "It is"
+                ELSE "They are"
+              END IF.
+              "currently on."
+          END IF.
+        ELSE
+          IF THIS IS natural
+            THEN
+              IF THIS IS NOT plural
+                THEN "It is"
+                ELSE "They are"
+              END IF.
+              "currently not lit."
+            ELSE
+              IF THIS IS NOT plural
+                THEN "It is"
+                ELSE "They are"
+              END IF.
+              "currently off."
+          END IF.
+      END IF.
+  END VERB.
 
 
-	VERB extinguish
-		CHECK THIS IS lit
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_lightsource_lit_sg OF my_game.
-					ELSE SAY check_lightsource_lit_pl OF my_game.
-				END IF.
-		DOES ONLY "You extinguish" SAY THE THIS. "."
-			MAKE THIS NOT lit.
-	END VERB.
+  VERB light
+    CHECK THIS IS NOT lit
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_lightsource_not_lit_sg OF my_game.
+          ELSE SAY check_lightsource_not_lit_pl OF my_game.
+        END IF.
+    AND THIS IS NOT broken
+      ELSE SAY check_obj_not_broken OF my_game.
+    DOES ONLY
+      IF THIS IS natural
+        THEN "You light" SAY THE THIS. "."
+          MAKE THIS lit.
+        ELSE "You turn on" SAY THE THIS. "."
+          MAKE THIS lit.
+      END IF.
+  END VERB.
 
 
-	VERB turn_on
-		CHECK THIS IS NOT natural
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_obj_suitable_on_sg OF my_game.
-					ELSE SAY check_obj_suitable_on_pl OF my_game.
-				END IF.
-		AND THIS IS NOT lit
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_lightsource_not_lit_sg OF my_game.
-					ELSE SAY check_lightsource_not_lit_pl OF my_game.
-				END IF.
-		AND THIS IS NOT broken
-			ELSE SAY check_obj_not_broken OF my_game.
-		DOES ONLY
-			"You turn on" SAY THE THIS. "."
-			MAKE THIS lit.
-					
-	END VERB.
+  VERB extinguish
+    CHECK THIS IS lit
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_lightsource_lit_sg OF my_game.
+          ELSE SAY check_lightsource_lit_pl OF my_game.
+        END IF.
+    DOES ONLY "You extinguish" SAY THE THIS. "."
+      MAKE THIS NOT lit.
+  END VERB.
 
 
-	VERB turn_off
-		CHECK THIS IS NOT natural
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_obj_suitable_off_sg OF my_game.
-					ELSE SAY check_obj_suitable_off_pl OF my_game.
-				END IF.
-		AND THIS IS lit
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_lightsource_lit_sg OF my_game.
-					ELSE SAY check_lightsource_lit_sg OF my_game.
-				END IF.
-				
-		DOES ONLY 
-			"You turn off" SAY THE THIS. "."
-			MAKE THIS NOT lit.	
-			  
-	END VERB.
+  VERB turn_on
+    CHECK THIS IS NOT natural
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_obj_suitable_on_sg OF my_game.
+          ELSE SAY check_obj_suitable_on_pl OF my_game.
+        END IF.
+    AND THIS IS NOT lit
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_lightsource_not_lit_sg OF my_game.
+          ELSE SAY check_lightsource_not_lit_pl OF my_game.
+        END IF.
+    AND THIS IS NOT broken
+      ELSE SAY check_obj_not_broken OF my_game.
+    DOES ONLY
+      "You turn on" SAY THE THIS. "."
+      MAKE THIS lit.
+
+  END VERB.
+
+
+  VERB turn_off
+    CHECK THIS IS NOT natural
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_obj_suitable_off_sg OF my_game.
+          ELSE SAY check_obj_suitable_off_pl OF my_game.
+        END IF.
+    AND THIS IS lit
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_lightsource_lit_sg OF my_game.
+          ELSE SAY check_lightsource_lit_sg OF my_game.
+        END IF.
+
+    DOES ONLY
+      "You turn off" SAY THE THIS. "."
+      MAKE THIS NOT lit.
+
+  END VERB.
 
 
 -- The following verb switches a NOT natural lightsource on if it is off, and vice versa
 -- (when the player forgets, or doesn't bother, to type 'on' or 'off' after 'switch').
 
 
-	VERB switch
-		CHECK THIS IS NOT natural
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_lightsource_switchable_sg OF my_game.
-					ELSE SAY check_lightsource_switchable_pl OF my_game.
-				END IF.
-		AND THIS IS reachable
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_obj_reachable_sg OF my_game.
-					ELSE SAY check_obj_reachable_pl OF my_game.
-				END IF.
-		AND THIS IS NOT broken
-			ELSE SAY check_obj_not_broken OF my_game.	
-		DOES ONLY
-			IF THIS IS lit
-				THEN "You switch off" SAY THE THIS. "."
-					MAKE THIS NOT lit.
-				ELSE "You switch on" SAY THE THIS. "."
-					MAKE THIS lit.
-			END IF.
-	END VERB.
-	
+  VERB switch
+    CHECK THIS IS NOT natural
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_lightsource_switchable_sg OF my_game.
+          ELSE SAY check_lightsource_switchable_pl OF my_game.
+        END IF.
+    AND THIS IS reachable
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_obj_reachable_sg OF my_game.
+          ELSE SAY check_obj_reachable_pl OF my_game.
+        END IF.
+    AND THIS IS NOT broken
+      ELSE SAY check_obj_not_broken OF my_game.
+    DOES ONLY
+      IF THIS IS lit
+        THEN "You switch off" SAY THE THIS. "."
+          MAKE THIS NOT lit.
+        ELSE "You switch on" SAY THE THIS. "."
+          MAKE THIS lit.
+      END IF.
+  END VERB.
+
 
 END EVERY.
 
@@ -1266,390 +1266,390 @@ END EVERY.
 -- (In the file 'lib_verbs.i', ISA LIQUID is used in the syntax definitions of the verbs 'drink' and 'sip'.)
 
 
-EVERY liquid ISA OBJECT		
-	
-	CONTAINER
-		HEADER "In" SAY THE THIS. "you see"
-		ELSE "There is nothing in" SAY THE THIS. "."	
+EVERY liquid ISA OBJECT
 
-		-- We declare this class a container to enable player commands such as
-		-- 'throw sack into water', 'look into water' and 'take pearl from water'.
-		-- Also cases such as 'pour red potion into blue potion' require that this 
-		-- class behaves like a container. 
-	
+  CONTAINER
+    HEADER "In" SAY THE THIS. "you see"
+    ELSE "There is nothing in" SAY THE THIS. "."
 
-	HAS vessel null_vessel.	
-
-		-- The 'vessel' attribute takes care that if a liquid is
-		-- in a container, the verb 'take' will automatically take the 
-		-- container instead (if the container is takeable). Trying 				
-		-- take a liquid that is in a fixed-in-place container, as well
-		-- as trying to take a liquid outside any container, will yield 			
-		-- "You can't carry [the liquid] around in your bare hands." 
-		-- The default value 'null_vessel' tells the compiler that the liquid
-		-- is not in any container. 'null_vessel' is a dummy default that can be
-		-- ignored.
-							
-
-	INITIALIZE
-
-	-- Every object found in a liquid, for example a fish in a pond of water, 
-	-- will be allowed back in that liquid once taken out of there:
-
-		FOR EACH liq ISA LIQUID
-			DO
-				FOR EACH o ISA OBJECT, DIRECTLY IN liq
-					DO 
-						INCLUDE o IN allowed OF liq.
-				END FOR.
-		END FOR.
+    -- We declare this class a container to enable player commands such as
+    -- 'throw sack into water', 'look into water' and 'take pearl from water'.
+    -- Also cases such as 'pour red potion into blue potion' require that this
+    -- class behaves like a container.
 
 
-	-- Every liquid in a container at the start of the game 
-	-- will have that container as its vessel:
+  HAS vessel null_vessel.
 
-		FOR EACH lc ISA LISTED_CONTAINER
-			DO						
-				FOR EACH lq ISA LIQUID, DIRECTLY IN lc
-					DO
-						SET vessel OF lq TO lc.
-				END FOR.	
-		END FOR.
-
-
-	-- If you have some liquid in a container in your game, you should declare the 
-	-- liquid instance thus:
-	
- 	-- THE juice ISA LIQUID
-	--      IN bottle
-	-- END THE juice.
-
-	-- The verb 'pour', as defined in this library, also works for the container of a liquid;
-	-- i.e. if there is some juice in a bottle, 'pour bottle' and 'pour juice' will work equally well.
-	-- Note, however, that the verb 'empty' is not a synonym for 'pour';
-	-- 'empty' only works for container objects.
+    -- The 'vessel' attribute takes care that if a liquid is
+    -- in a container, the verb 'take' will automatically take the
+    -- container instead (if the container is takeable). Trying
+    -- take a liquid that is in a fixed-in-place container, as well
+    -- as trying to take a liquid outside any container, will yield
+    -- "You can't carry [the liquid] around in your bare hands."
+    -- The default value 'null_vessel' tells the compiler that the liquid
+    -- is not in any container. 'null_vessel' is a dummy default that can be
+    -- ignored.
 
 
+  INITIALIZE
 
-		SCHEDULE check_vessel AT THIS AFTER 0.		-- this event is defined further below
+  -- Every object found in a liquid, for example a fish in a pond of water,
+  -- will be allowed back in that liquid once taken out of there:
 
-
-	VERB examine
-		DOES ONLY
-			IF vessel OF THIS <> null_vessel
-				THEN 
-					IF vessel OF THIS IS open
-						THEN "You notice nothing unusual about" SAY THE THIS.
-						ELSE "You can't, since" SAY THE vessel OF THIS. 
-								IF THIS IS NOT plural
-									THEN "is"
-									ELSE "are"
-								END IF.
-								"closed."
-								-- Here we prohibit the player from examining
-								-- a liquid when the liquid is in a closed container.
-					END IF.
-				ELSE "You notice nothing unusual about" SAY THE THIS. "."
-			END IF.
-	END VERB.
-		
-
-	VERB look_in
-		DOES ONLY
-			IF vessel OF THIS <> null_vessel
-				THEN 
-					IF vessel OF THIS IS open
-						THEN "You see nothing special in" SAY THE THIS. "."
-						ELSE "You can't, since" SAY THE vessel OF THIS.
-								IF THIS IS NOT plural
-									THEN "is"
-									ELSE "are"
-								END IF.
-								"closed."
-								-- Here we prohibit the player from looking into
-								-- a liquid when the liquid is in a closed container.
-					END IF.
-				ELSE "You see nothing special in" SAY THE THIS. "."
-			END IF.
-	END VERB.
-		
-
-	VERB take
-		CHECK vessel OF THIS NOT IN hero
-			ELSE SAY check_obj_not_in_hero2 OF my_game.
-		DOES ONLY
-			IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
-				THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-			ELSE LOCATE vessel OF THIS IN hero.
-				"($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nTaken." 
-			END IF.
-	END VERB.
+    FOR EACH liq ISA LIQUID
+      DO
+        FOR EACH o ISA OBJECT, DIRECTLY IN liq
+          DO
+            INCLUDE o IN allowed OF liq.
+        END FOR.
+    END FOR.
 
 
-	VERB take_from
-	   WHEN obj
-		CHECK holder <> vessel OF THIS
-			ELSE SAY check_liquid_vessel_not_cont OF my_game.
-			-- the above is triggered when the player types for example 
-			-- >take juice from bottle   -- (when the juice is in the bottle)
-		DOES ONLY
-			IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
-				THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-			ELSE LOCATE vessel OF THIS IN hero.
-				"($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nTaken." 
-			END IF.
-	END VERB.	
+  -- Every liquid in a container at the start of the game
+  -- will have that container as its vessel:
+
+    FOR EACH lc ISA LISTED_CONTAINER
+      DO
+        FOR EACH lq ISA LIQUID, DIRECTLY IN lc
+          DO
+            SET vessel OF lq TO lc.
+        END FOR.
+    END FOR.
 
 
-	VERB drop
-		DOES ONLY
-			LOCATE vessel OF THIS AT hero.
-			"($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nDropped."
-			
-	END VERB.
+  -- If you have some liquid in a container in your game, you should declare the
+  -- liquid instance thus:
 
+  -- THE juice ISA LIQUID
+  --      IN bottle
+  -- END THE juice.
 
-	VERB ask_for
-		DOES ONLY
-			LOCATE vessel OF THIS IN hero.
-			SAY THE act. "gives" SAY THE vessel OF THIS. "of" SAY THIS. "to you."		
-	END VERB.					
-			
-
-	VERB give
-		WHEN obj
-		DOES ONLY
-			-- implicit taking:
-			IF THIS NOT IN hero
-				THEN 
-					IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
-						THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-					ELSE LOCATE vessel OF THIS IN hero.
-						"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-					END IF.
-			END IF.
-			-- end of implicit taking.
-
-			IF THIS IN hero   
-				-- i.e. if the implicit taking was successful
-				THEN
-					"You give" SAY THE vessel OF THIS. "of" SAY THIS. "to" SAY THE recipient. "."
-					LOCATE vessel OF THIS IN recipient.
-			END IF.
-		
-			-- there is no 'ELSE' statement in this last IF -clause, as the 'IF THIS NOT 
-			-- IN hero' clause above it takes care of the 'ELSE' alternative.
-
-	END VERB.
-
-
-	VERB pour
-		DOES ONLY
-			-- implicit taking:
-			IF THIS NOT IN hero
-				THEN 
-					IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
-						THEN "You can't pour" SAY THE THIS. "anywhere since you are not
-							carrying" 
-								IF THIS IS NOT plural
-									THEN "it."
-									ELSE "them."
-								END IF.
-					ELSE LOCATE vessel OF THIS IN hero.
-						"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-					END IF.
-			END IF.
-			-- end of implicit taking.
-			
-			IF THIS IN hero
-				THEN LOCATE THIS AT hero.
-					SET vessel OF THIS TO null_vessel.
-					"You pour" SAY THE THIS.
-						IF floor HERE
-							THEN "on the floor."
-							ELSE "on the ground."
-						END IF.			
-			END IF.
-
-	END VERB.
-
-
-	VERB pour_in
-		WHEN obj
-			DOES ONLY
-				-- implicit taking:
-				IF THIS NOT IN hero
-					THEN 
-						IF vessel OF THIS = null_vessel
-							THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-						ELSIF vessel OF THIS IS NOT takeable
-							THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
-						ELSE LOCATE vessel OF THIS IN hero.
-							"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-						END IF.
-				END IF.
-				-- end of implicit taking.
-
-				IF THIS IN hero		--i.e. if the implicit taking was successful
-					THEN LOCATE THIS IN cont.
-						SET vessel OF THIS TO cont.
-						"You pour" SAY THE THIS. "into" SAY THE cont. "."						
-				END IF.
-		WHEN cont
-			DOES ONLY
-				IF vessel OF THIS = null_vessel
-					THEN 
-						"There's not much sense pouring" SAY THE obj. "into" SAY THE THIS. "."
-					ELSE 
-						IF vessel OF THIS IS open
-							THEN "It wouldn't accomplish anything trying to pour" SAY THE obj. 
-								"into" SAY THE THIS. "."
-							ELSE "You can't, since" SAY THE vessel OF THIS. 
-								IF THIS IS NOT plural
-									THEN "is"
-									ELSE "are"
-								END IF.
-								"closed."
-						END IF.
-				END IF.
-	END VERB.
-
-
-	VERB pour_on
-		WHEN obj
-			DOES ONLY
-				-- implicit taking:
-				IF THIS NOT IN hero
-					THEN 
-						IF vessel OF THIS = null_vessel 
-							THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-						ELSIF vessel OF THIS IS NOT takeable
-							THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "." 
-						ELSE LOCATE vessel OF THIS IN hero.
-							"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-						END IF.
-				END IF.
-				-- end of implicit taking.
-				
-				IF THIS IN hero		
-					-- i.e. if the implicit taking was successful
-					THEN
-						IF surface = floor OR surface = ground
-							THEN LOCATE THIS AT hero.
-						 		"You pour" SAY THE THIS. "on" SAY THE surface. "."
-								SET vessel OF THIS TO null_vessel.
-						ELSIF surface ISA SUPPORTER
-							THEN LOCATE THIS IN surface.
-								"You pour" SAY THE THIS. "on" SAY THE surface. "."
-				  				SET vessel OF THIS TO null_vessel.
-						ELSE "It wouldn't be sensible to pour anything on" SAY THE surface.
-						END IF.
-				END IF.
-	END VERB.		
-
-
-	VERB fill_with
-		-- when something is filled with a liquid, this something becomes the
-		-- vessel of the liquid:
-		WHEN substance					
-			 DOES SET vessel OF THIS TO cont.   	  
-	END VERB.
-
-
-	VERB put_in
-		WHEN obj
-			DOES ONLY 
-				IF vessel OF THIS = null_vessel
-					THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-					ELSE 
-						IF vessel OF THIS IS takeable
-							THEN
-								-- implicit taking:
-								IF THIS NOT IN hero
-									THEN 
-										IF vessel OF THIS = null_vessel 
-											THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-										ELSE LOCATE vessel OF THIS IN hero.
-											"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-										END IF.
-								END IF.
-								-- end of implicit taking.
-
-								LOCATE vessel OF THIS IN cont.
-						      	"You put" SAY THE vessel OF THIS. "of" SAY THIS. "into" SAY THE cont. "."
-
-							ELSE "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
-						END IF.
-				END IF.
-	      WHEN cont
-			DOES ONLY
-			IF vessel OF THIS = null_vessel
-				THEN 
-					"There's not much sense putting" SAY THE obj. "into" SAY THE THIS. "."
-				ELSE 
-					IF vessel OF THIS IS open
-						THEN 
-							IF obj = vessel OF THIS
-								THEN "That doesn't make sense."
-								ELSE "It wouldn't accomplish anything trying to put" SAY THE obj. 
-									"into" SAY THE vessel OF THIS. "of" SAY THIS. "."
-							END IF.
-						ELSE "You can't, since" SAY THE vessel OF THIS. "of" SAY THIS.
-								IF THIS IS NOT plural
-									THEN "is"
-									ELSE "are"
-								END IF.
-							"closed."
-					END IF.
-			END IF.
-	END VERB.
-
-
-	VERB put_on
-		WHEN obj
-			DOES ONLY
-				-- implicit taking:
-				IF THIS NOT IN hero
-					THEN 
-						IF vessel OF THIS = null_vessel 
-							THEN "You can't carry" SAY THE THIS. "around in your bare hands."
-						ELSIF vessel OF THIS IS NOT takeable
-							THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "." 
-						ELSE LOCATE vessel OF THIS IN hero.
-							"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-						END IF.
-				END IF.
-				-- end of implicit taking.
-
-				IF THIS IN hero 				
-					-- i.e. if the implicit taking was successful
-					THEN "You put" SAY THE vessel OF THIS. "of" SAY THIS. "onto" SAY THE surface. "."
-				END IF.
-		WHEN surface
-			DOES ONLY "It is not possible to $v" SAY obj. "onto" SAY THE THIS. "."
-	END VERB.
+  -- The verb 'pour', as defined in this library, also works for the container of a liquid;
+  -- i.e. if there is some juice in a bottle, 'pour bottle' and 'pour juice' will work equally well.
+  -- Note, however, that the verb 'empty' is not a synonym for 'pour';
+  -- 'empty' only works for container objects.
 
 
 
+    SCHEDULE check_vessel AT THIS AFTER 0.    -- this event is defined further below
 
 
-	-- The verbs 'empty', 'empty_in' and 'empty_on' will be disabled as ungrammatical with liquids:	
+  VERB examine
+    DOES ONLY
+      IF vessel OF THIS <> null_vessel
+        THEN
+          IF vessel OF THIS IS open
+            THEN "You notice nothing unusual about" SAY THE THIS.
+            ELSE "You can't, since" SAY THE vessel OF THIS.
+                IF THIS IS NOT plural
+                  THEN "is"
+                  ELSE "are"
+                END IF.
+                "closed."
+                -- Here we prohibit the player from examining
+                -- a liquid when the liquid is in a closed container.
+          END IF.
+        ELSE "You notice nothing unusual about" SAY THE THIS. "."
+      END IF.
+  END VERB.
 
-	VERB 'empty'
-		WHEN obj
-		DOES ONLY "You can only empty containers."
-	END VERB.
 
-	VERB empty_in
-		WHEN obj
-		DOES ONLY "You can only empty containers."
-	END VERB.
+  VERB look_in
+    DOES ONLY
+      IF vessel OF THIS <> null_vessel
+        THEN
+          IF vessel OF THIS IS open
+            THEN "You see nothing special in" SAY THE THIS. "."
+            ELSE "You can't, since" SAY THE vessel OF THIS.
+                IF THIS IS NOT plural
+                  THEN "is"
+                  ELSE "are"
+                END IF.
+                "closed."
+                -- Here we prohibit the player from looking into
+                -- a liquid when the liquid is in a closed container.
+          END IF.
+        ELSE "You see nothing special in" SAY THE THIS. "."
+      END IF.
+  END VERB.
 
-	VERB empty_on
-		WHEN obj
-		DOES ONLY "You can only empty containers."
-	END VERB.
-	
+
+  VERB take
+    CHECK vessel OF THIS NOT IN hero
+      ELSE SAY check_obj_not_in_hero2 OF my_game.
+    DOES ONLY
+      IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
+        THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+      ELSE LOCATE vessel OF THIS IN hero.
+        "($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nTaken."
+      END IF.
+  END VERB.
+
+
+  VERB take_from
+     WHEN obj
+    CHECK holder <> vessel OF THIS
+      ELSE SAY check_liquid_vessel_not_cont OF my_game.
+      -- the above is triggered when the player types for example
+      -- >take juice from bottle   -- (when the juice is in the bottle)
+    DOES ONLY
+      IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
+        THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+      ELSE LOCATE vessel OF THIS IN hero.
+        "($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nTaken."
+      END IF.
+  END VERB.
+
+
+  VERB drop
+    DOES ONLY
+      LOCATE vessel OF THIS AT hero.
+      "($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nDropped."
+
+  END VERB.
+
+
+  VERB ask_for
+    DOES ONLY
+      LOCATE vessel OF THIS IN hero.
+      SAY THE act. "gives" SAY THE vessel OF THIS. "of" SAY THIS. "to you."
+  END VERB.
+
+
+  VERB give
+    WHEN obj
+    DOES ONLY
+      -- implicit taking:
+      IF THIS NOT IN hero
+        THEN
+          IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
+            THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+          ELSE LOCATE vessel OF THIS IN hero.
+            "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+          END IF.
+      END IF.
+      -- end of implicit taking.
+
+      IF THIS IN hero
+        -- i.e. if the implicit taking was successful
+        THEN
+          "You give" SAY THE vessel OF THIS. "of" SAY THIS. "to" SAY THE recipient. "."
+          LOCATE vessel OF THIS IN recipient.
+      END IF.
+
+      -- there is no 'ELSE' statement in this last IF -clause, as the 'IF THIS NOT
+      -- IN hero' clause above it takes care of the 'ELSE' alternative.
+
+  END VERB.
+
+
+  VERB pour
+    DOES ONLY
+      -- implicit taking:
+      IF THIS NOT IN hero
+        THEN
+          IF vessel OF THIS = null_vessel OR vessel OF THIS IS NOT takeable
+            THEN "You can't pour" SAY THE THIS. "anywhere since you are not
+              carrying"
+                IF THIS IS NOT plural
+                  THEN "it."
+                  ELSE "them."
+                END IF.
+          ELSE LOCATE vessel OF THIS IN hero.
+            "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+          END IF.
+      END IF.
+      -- end of implicit taking.
+
+      IF THIS IN hero
+        THEN LOCATE THIS AT hero.
+          SET vessel OF THIS TO null_vessel.
+          "You pour" SAY THE THIS.
+            IF floor HERE
+              THEN "on the floor."
+              ELSE "on the ground."
+            END IF.
+      END IF.
+
+  END VERB.
+
+
+  VERB pour_in
+    WHEN obj
+      DOES ONLY
+        -- implicit taking:
+        IF THIS NOT IN hero
+          THEN
+            IF vessel OF THIS = null_vessel
+              THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+            ELSIF vessel OF THIS IS NOT takeable
+              THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
+            ELSE LOCATE vessel OF THIS IN hero.
+              "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+            END IF.
+        END IF.
+        -- end of implicit taking.
+
+        IF THIS IN hero   --i.e. if the implicit taking was successful
+          THEN LOCATE THIS IN cont.
+            SET vessel OF THIS TO cont.
+            "You pour" SAY THE THIS. "into" SAY THE cont. "."
+        END IF.
+    WHEN cont
+      DOES ONLY
+        IF vessel OF THIS = null_vessel
+          THEN
+            "There's not much sense pouring" SAY THE obj. "into" SAY THE THIS. "."
+          ELSE
+            IF vessel OF THIS IS open
+              THEN "It wouldn't accomplish anything trying to pour" SAY THE obj.
+                "into" SAY THE THIS. "."
+              ELSE "You can't, since" SAY THE vessel OF THIS.
+                IF THIS IS NOT plural
+                  THEN "is"
+                  ELSE "are"
+                END IF.
+                "closed."
+            END IF.
+        END IF.
+  END VERB.
+
+
+  VERB pour_on
+    WHEN obj
+      DOES ONLY
+        -- implicit taking:
+        IF THIS NOT IN hero
+          THEN
+            IF vessel OF THIS = null_vessel
+              THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+            ELSIF vessel OF THIS IS NOT takeable
+              THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
+            ELSE LOCATE vessel OF THIS IN hero.
+              "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+            END IF.
+        END IF.
+        -- end of implicit taking.
+
+        IF THIS IN hero
+          -- i.e. if the implicit taking was successful
+          THEN
+            IF surface = floor OR surface = ground
+              THEN LOCATE THIS AT hero.
+                "You pour" SAY THE THIS. "on" SAY THE surface. "."
+                SET vessel OF THIS TO null_vessel.
+            ELSIF surface ISA SUPPORTER
+              THEN LOCATE THIS IN surface.
+                "You pour" SAY THE THIS. "on" SAY THE surface. "."
+                  SET vessel OF THIS TO null_vessel.
+            ELSE "It wouldn't be sensible to pour anything on" SAY THE surface.
+            END IF.
+        END IF.
+  END VERB.
+
+
+  VERB fill_with
+    -- when something is filled with a liquid, this something becomes the
+    -- vessel of the liquid:
+    WHEN substance
+       DOES SET vessel OF THIS TO cont.
+  END VERB.
+
+
+  VERB put_in
+    WHEN obj
+      DOES ONLY
+        IF vessel OF THIS = null_vessel
+          THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+          ELSE
+            IF vessel OF THIS IS takeable
+              THEN
+                -- implicit taking:
+                IF THIS NOT IN hero
+                  THEN
+                    IF vessel OF THIS = null_vessel
+                      THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+                    ELSE LOCATE vessel OF THIS IN hero.
+                      "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+                    END IF.
+                END IF.
+                -- end of implicit taking.
+
+                LOCATE vessel OF THIS IN cont.
+                    "You put" SAY THE vessel OF THIS. "of" SAY THIS. "into" SAY THE cont. "."
+
+              ELSE "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
+            END IF.
+        END IF.
+        WHEN cont
+      DOES ONLY
+      IF vessel OF THIS = null_vessel
+        THEN
+          "There's not much sense putting" SAY THE obj. "into" SAY THE THIS. "."
+        ELSE
+          IF vessel OF THIS IS open
+            THEN
+              IF obj = vessel OF THIS
+                THEN "That doesn't make sense."
+                ELSE "It wouldn't accomplish anything trying to put" SAY THE obj.
+                  "into" SAY THE vessel OF THIS. "of" SAY THIS. "."
+              END IF.
+            ELSE "You can't, since" SAY THE vessel OF THIS. "of" SAY THIS.
+                IF THIS IS NOT plural
+                  THEN "is"
+                  ELSE "are"
+                END IF.
+              "closed."
+          END IF.
+      END IF.
+  END VERB.
+
+
+  VERB put_on
+    WHEN obj
+      DOES ONLY
+        -- implicit taking:
+        IF THIS NOT IN hero
+          THEN
+            IF vessel OF THIS = null_vessel
+              THEN "You can't carry" SAY THE THIS. "around in your bare hands."
+            ELSIF vessel OF THIS IS NOT takeable
+              THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
+            ELSE LOCATE vessel OF THIS IN hero.
+              "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+            END IF.
+        END IF.
+        -- end of implicit taking.
+
+        IF THIS IN hero
+          -- i.e. if the implicit taking was successful
+          THEN "You put" SAY THE vessel OF THIS. "of" SAY THIS. "onto" SAY THE surface. "."
+        END IF.
+    WHEN surface
+      DOES ONLY "It is not possible to $v" SAY obj. "onto" SAY THE THIS. "."
+  END VERB.
+
+
+
+
+
+  -- The verbs 'empty', 'empty_in' and 'empty_on' will be disabled as ungrammatical with liquids:
+
+  VERB 'empty'
+    WHEN obj
+    DOES ONLY "You can only empty containers."
+  END VERB.
+
+  VERB empty_in
+    WHEN obj
+    DOES ONLY "You can only empty containers."
+  END VERB.
+
+  VERB empty_on
+    WHEN obj
+    DOES ONLY "You can only empty containers."
+  END VERB.
+
 
 END EVERY.
 
@@ -1660,7 +1660,7 @@ END EVERY.
 
 
 THE null_vessel ISA OBJECT
-	CONTAINER 
+  CONTAINER
 END THE.
 
 
@@ -1670,10 +1670,10 @@ END THE.
 
 
 EVENT check_vessel
-	FOR EACH liq ISA LIQUID, DIRECTLY AT CURRENT LOCATION DO	
-			SET vessel OF liq TO null_vessel.
-	END FOR.
-	SCHEDULE check_vessel AFTER 1.
+  FOR EACH liq ISA LIQUID, DIRECTLY AT CURRENT LOCATION DO
+      SET vessel OF liq TO null_vessel.
+  END FOR.
+  SCHEDULE check_vessel AFTER 1.
 END EVENT.
 
 
@@ -1691,70 +1691,70 @@ END EVENT.
 -- (This class is not cross-referenced elsewhere in this or any other library file.)
 
 
-EVERY LISTED_CONTAINER ISA OBJECT			
-	CONTAINER						 	
+EVERY LISTED_CONTAINER ISA OBJECT
+  CONTAINER
 
-		--  (ACTORS are separately defined to be containers further below.)
+    --  (ACTORS are separately defined to be containers further below.)
 
-	INITIALIZE
+  INITIALIZE
 
-	-- Every object in a container will be allowed back in that container by default if it's taken out:
+  -- Every object in a container will be allowed back in that container by default if it's taken out:
 
-		FOR EACH lc ISA LISTED_CONTAINER
-			DO
-				FOR EACH o ISA OBJECT, DIRECTLY IN lc
-					DO 
-						INCLUDE o IN allowed OF lc.
-				END FOR.
-		END FOR.
-
-
+    FOR EACH lc ISA LISTED_CONTAINER
+      DO
+        FOR EACH o ISA OBJECT, DIRECTLY IN lc
+          DO
+            INCLUDE o IN allowed OF lc.
+        END FOR.
+    END FOR.
 
 
 
-	VERB examine 
-		DOES ONLY
-			IF THIS IS NOT OPAQUE
-				THEN LIST THIS.
-				ELSE "You can't see inside" SAY THE THIS. "."
-			END IF.
-	END VERB.
 
 
-	VERB look_in
-		DOES ONLY
-			IF THIS IS NOT OPAQUE
-				THEN LIST THIS.
-				ELSE "You can't see inside" SAY THE THIS. "."
-			END IF.
-	END VERB.
+  VERB examine
+    DOES ONLY
+      IF THIS IS NOT OPAQUE
+        THEN LIST THIS.
+        ELSE "You can't see inside" SAY THE THIS. "."
+      END IF.
+  END VERB.
 
 
-	VERB search
-		DOES ONLY
-			IF THIS IS NOT OPAQUE
-				THEN LIST THIS.
-				ELSE "You can't see inside" SAY THE THIS. "."
-			END IF.
-	END VERB.
+  VERB look_in
+    DOES ONLY
+      IF THIS IS NOT OPAQUE
+        THEN LIST THIS.
+        ELSE "You can't see inside" SAY THE THIS. "."
+      END IF.
+  END VERB.
+
+
+  VERB search
+    DOES ONLY
+      IF THIS IS NOT OPAQUE
+        THEN LIST THIS.
+        ELSE "You can't see inside" SAY THE THIS. "."
+      END IF.
+  END VERB.
 
 
 
 -- Note that closed listed_containers are by default opaque and they become "not opaque" when
--- they are opened: 
+-- they are opened:
 
 
-	VERB open
- 		DOES
-			MAKE THIS NOT OPAQUE.
- 			LIST THIS.
- 	END VERB.
+  VERB open
+    DOES
+      MAKE THIS NOT OPAQUE.
+      LIST THIS.
+  END VERB.
 
 
- 	VERB close
- 		DOES
- 			MAKE THIS OPAQUE.
- 	END VERB.
+  VERB close
+    DOES
+      MAKE THIS OPAQUE.
+  END VERB.
 
 
 END EVERY.
@@ -1776,19 +1776,19 @@ END EVERY.
 
 
 EVERY sound ISA OBJECT
-	IS NOT examinable.
-	IS NOT takeable.
-	IS NOT reachable.
-	IS NOT movable.
+  IS NOT examinable.
+  IS NOT takeable.
+  IS NOT reachable.
+  IS NOT movable.
 
-	VERB smell
-		DOES ONLY
-			 IF THIS IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			 END IF.
-			"something you can smell."
-	END VERB.
+  VERB smell
+    DOES ONLY
+       IF THIS IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+       END IF.
+      "something you can smell."
+  END VERB.
 
 
 END EVERY.
@@ -1808,56 +1808,56 @@ END EVERY.
 -- 'lie_on', 'pour_on', 'put_in', 'put_on', 'sit_on', 'stand_on', and 'take_from'
 -- where SUPPORTER is used in either syntax definitions, verb checks
 -- or verb definitions.)
- 
+
 
 EVERY supporter ISA OBJECT
 
 
-	CONTAINER
-		HEADER "On" SAY THE THIS. "you see"
-		ELSE "There's nothing on" SAY THE THIS. "."	
+  CONTAINER
+    HEADER "On" SAY THE THIS. "you see"
+    ELSE "There's nothing on" SAY THE THIS. "."
 
 
-	VERB examine
-		DOES 
-			LIST THIS.
-	END VERB.
+  VERB examine
+    DOES
+      LIST THIS.
+  END VERB.
 
 
-	-- in the following, we disable some verbs that are defined to work with normal containers:
+  -- in the following, we disable some verbs that are defined to work with normal containers:
 
 
-	VERB look_in							
-		DOES ONLY 
-			IF THIS IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can look into."
-	END VERB.
+  VERB look_in
+    DOES ONLY
+      IF THIS IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can look into."
+  END VERB.
 
 
-	VERB empty_in, pour_in
-	   WHEN cont
-		DOES ONLY
-			 IF THIS IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can pour things into."
-	END VERB.
+  VERB empty_in, pour_in
+     WHEN cont
+    DOES ONLY
+       IF THIS IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can pour things into."
+  END VERB.
 
 
-	VERB put_in
-   	  WHEN cont
-		DOES ONLY "You can't put anything inside" SAY THE THIS. "."
-	END VERB.
+  VERB put_in
+      WHEN cont
+    DOES ONLY "You can't put anything inside" SAY THE THIS. "."
+  END VERB.
 
 
-	VERB throw_in
-   	  WHEN cont
-		DOES ONLY "You can't put anything inside" SAY THE THIS. "."
-	END VERB.
+  VERB throw_in
+      WHEN cont
+    DOES ONLY "You can't put anything inside" SAY THE THIS. "."
+  END VERB.
 
 
 END EVERY.
@@ -1883,7 +1883,7 @@ END EVERY.
 
 
 EVERY weapon ISA OBJECT
-	IS NOT fireable.
+  IS NOT fireable.
 END EVERY.
 
 
@@ -1901,57 +1901,57 @@ END EVERY.
 -- (This class is not cross-referenced elsewhere in this or any other library file.)
 
 
--- You can look out of and through a window. 
+-- You can look out of and through a window.
 -- When examined, a window is by default described as being either open or closed.
 
 
 EVERY window ISA OBJECT
-	IS openable.
-	IS NOT open.
-	IS NOT takeable.
+  IS openable.
+  IS NOT open.
+  IS NOT takeable.
 
 
-	VERB examine
-		DOES 
-			IF THIS IS NOT open
-				THEN 
-					IF THIS IS NOT plural
-						THEN "It is"
-						ELSE "They are"
-					END IF.
-					"currently closed."
-				ELSE 
-					IF THIS IS NOT plural
-						THEN "It is"
-						ELSE "They are"
-					END IF.
-					"currently open."
-			END IF.
-	END VERB.
+  VERB examine
+    DOES
+      IF THIS IS NOT open
+        THEN
+          IF THIS IS NOT plural
+            THEN "It is"
+            ELSE "They are"
+          END IF.
+          "currently closed."
+        ELSE
+          IF THIS IS NOT plural
+            THEN "It is"
+            ELSE "They are"
+          END IF.
+          "currently open."
+      END IF.
+  END VERB.
 
 
-	VERB look_behind
-		DOES ONLY 
-			"That's not possible."
-	END VERB.
+  VERB look_behind
+    DOES ONLY
+      "That's not possible."
+  END VERB.
 
 
-	VERB look_out_of
-		DOES ONLY "You see nothing special looking out of the"
-				IF THIS IS NOT plural
-					THEN "window."
-					ELSE "windows."
-				END IF.
-	END VERB.
+  VERB look_out_of
+    DOES ONLY "You see nothing special looking out of the"
+        IF THIS IS NOT plural
+          THEN "window."
+          ELSE "windows."
+        END IF.
+  END VERB.
 
 
-	VERB look_through
-		DOES ONLY "You see nothing special looking through the"
-				IF THIS IS NOT plural
-					THEN "window."
-					ELSE "windows."
-				END IF.
-	END VERB.
+  VERB look_through
+    DOES ONLY "You see nothing special looking through the"
+        IF THIS IS NOT plural
+          THEN "window."
+          ELSE "windows."
+        END IF.
+  END VERB.
 
 
 END EVERY.
@@ -1973,154 +1973,154 @@ END EVERY.
 
 
 ADD TO EVERY ACTOR
-   	IS NOT inanimate.
-   	IS NOT following. 
-   	IS NOT sitting.
-   	IS NOT lying_down.	
-   	IS NOT named.	
-	-- = the actor's name is not known to the player
-	IS wearing {null_clothing}.  
-	-- = the actor's clothing is not specified.
-	-- "null_clothing" is a dummy default that can be ignored.
-	IS NOT compliant.
-	-- an actor only gives something to the hero if it is in a compliant mood.
-	-- In practice, this happens by default when the hero asks the actor for anything.
-	-- For example, implicit taking of objects is not successful if the object happens
-	-- to be held by an NPC who is not compliant.
-	IS NOT takeable.
+    IS NOT inanimate.
+    IS NOT following.
+    IS NOT sitting.
+    IS NOT lying_down.
+    IS NOT named.
+  -- = the actor's name is not known to the player
+  IS wearing {null_clothing}.
+  -- = the actor's clothing is not specified.
+  -- "null_clothing" is a dummy default that can be ignored.
+  IS NOT compliant.
+  -- an actor only gives something to the hero if it is in a compliant mood.
+  -- In practice, this happens by default when the hero asks the actor for anything.
+  -- For example, implicit taking of objects is not successful if the object happens
+  -- to be held by an NPC who is not compliant.
+  IS NOT takeable.
 
-	IS NOT present_actor.
-
-	
-   	DEFINITE ARTICLE 
-		IF THIS IS NOT named
-			THEN "the"		
-			ELSE ""
-		END IF.
+  IS NOT present_actor.
 
 
-   	INDEFINITE ARTICLE 
-		IF THIS IS NOT named
-			THEN 								
-				IF THIS IS NOT plural
-					THEN "a"				
-					ELSE ""
-				END IF.		
-			ELSE ""
-		END IF.
-	
-	-- if you need "an", you must declare it separately at the actor instance
-
-	
-   	CONTAINER							
-		-- so that actors can receive and carry objects
-		HEADER
-			IF THIS = hero
-				THEN "You are carrying"
-				ELSE		
-					
-					IF THIS IS NOT named
-						THEN SAY THE THIS. 
-						ELSE SAY THIS.
-					END IF.
-										
-					IF THIS IS NOT plural
-						THEN "is carrying"
-						ELSE "are carrying"
-					END IF.
-			END IF.
-		ELSE
-			IF THIS = hero
-				THEN "You are empty-handed."
-				ELSE 
-					IF THIS IS NOT named
-						THEN SAY THE THIS. 
-						ELSE SAY THIS.
-					END IF.
-					
-					IF THIS IS NOT plural					
-						THEN "is not carrying anything."
-						ELSE "are not carrying anything."
-					END IF.
-					
-			END IF.
-
-		EXTRACT
-			CHECK THIS IS compliant
-				ELSE 
-					"That seems to belong to"
-					IF THIS IS NOT named
-						THEN SAY THE THIS. 
-						ELSE SAY THIS.
-					END IF.
-					"."
-	
-			
-
-  	INITIALIZE
-
-		MAKE hero compliant.		
-		-- so that the hero can give, drop, etc. carried objects.		
+    DEFINITE ARTICLE
+    IF THIS IS NOT named
+      THEN "the"
+      ELSE ""
+    END IF.
 
 
-		-- excluding the default dummy clothing object from all actors; ignore.  
-		
-		EXCLUDE null_clothing FROM wearing OF THIS.
+    INDEFINITE ARTICLE
+    IF THIS IS NOT named
+      THEN
+        IF THIS IS NOT plural
+          THEN "a"
+          ELSE ""
+        END IF.
+      ELSE ""
+    END IF.
+
+  -- if you need "an", you must declare it separately at the actor instance
 
 
-		-- all actors will obey this script from the start of the game:
-	
-		IF THIS <> hero
-			THEN USE SCRIPT following_hero FOR THIS.
-		END IF.
+    CONTAINER
+    -- so that actors can receive and carry objects
+    HEADER
+      IF THIS = hero
+        THEN "You are carrying"
+        ELSE
 
+          IF THIS IS NOT named
+            THEN SAY THE THIS.
+            ELSE SAY THIS.
+          END IF.
 
-				
-	SCRIPT following_hero						
-		-- this code will make any actor follow the hero
-		-- if the actor is given the attribute 'following'.
+          IF THIS IS NOT plural
+            THEN "is carrying"
+            ELSE "are carrying"
+          END IF.
+      END IF.
+    ELSE
+      IF THIS = hero
+        THEN "You are empty-handed."
+        ELSE
+          IF THIS IS NOT named
+            THEN SAY THE THIS.
+            ELSE SAY THIS.
+          END IF.
 
-		STEP WAIT UNTIL hero NOT HERE			
-				 
-			IF THIS IS following
-				THEN
-					LOCATE THIS AT hero.
-					"$p" SAY THE THIS. 
-						IF THIS IS NOT plural
-							THEN "follows you."
-							ELSE "follow you."
-						END IF.				
-			END IF.
-				
-			USE SCRIPT following_hero FOR THIS.
+          IF THIS IS NOT plural
+            THEN "is not carrying anything."
+            ELSE "are not carrying anything."
+          END IF.
+
+      END IF.
+
+    EXTRACT
+      CHECK THIS IS compliant
+        ELSE
+          "That seems to belong to"
+          IF THIS IS NOT named
+            THEN SAY THE THIS.
+            ELSE SAY THIS.
+          END IF.
+          "."
 
 
 
-	DESCRIPTION	
-		IF THIS IS scenery
-			THEN "$$"
-		ELSIF THIS IS NOT named
-			THEN 
-				IF THIS IS NOT plural
-					THEN "There is" SAY AN THIS. "here."		
-					ELSE "There are" SAY THIS. "here."	
-				END IF.	
-			ELSE SAY THIS. 
-				IF THIS IS NOT plural
-					THEN "is here."
-					ELSE "are here."
-				END IF.
-		END IF.	
-	
+    INITIALIZE
 
-	VERB examine
-		DOES AFTER
-			IF THIS <> hero
-				THEN
-					LIST THIS.
-			END IF.
-	END VERB.
-	
+    MAKE hero compliant.
+    -- so that the hero can give, drop, etc. carried objects.
+
+
+    -- excluding the default dummy clothing object from all actors; ignore.
+
+    EXCLUDE null_clothing FROM wearing OF THIS.
+
+
+    -- all actors will obey this script from the start of the game:
+
+    IF THIS <> hero
+      THEN USE SCRIPT following_hero FOR THIS.
+    END IF.
+
+
+
+  SCRIPT following_hero
+    -- this code will make any actor follow the hero
+    -- if the actor is given the attribute 'following'.
+
+    STEP WAIT UNTIL hero NOT HERE
+
+      IF THIS IS following
+        THEN
+          LOCATE THIS AT hero.
+          "$p" SAY THE THIS.
+            IF THIS IS NOT plural
+              THEN "follows you."
+              ELSE "follow you."
+            END IF.
+      END IF.
+
+      USE SCRIPT following_hero FOR THIS.
+
+
+
+  DESCRIPTION
+    IF THIS IS scenery
+      THEN "$$"
+    ELSIF THIS IS NOT named
+      THEN
+        IF THIS IS NOT plural
+          THEN "There is" SAY AN THIS. "here."
+          ELSE "There are" SAY THIS. "here."
+        END IF.
+      ELSE SAY THIS.
+        IF THIS IS NOT plural
+          THEN "is here."
+          ELSE "are here."
+        END IF.
+    END IF.
+
+
+  VERB examine
+    DOES AFTER
+      IF THIS <> hero
+        THEN
+          LIST THIS.
+      END IF.
+  END VERB.
+
 
 END ADD TO.
 
@@ -2131,49 +2131,49 @@ THE null_clothing ISA CLOTHING
 END THE.
 
 
-	
+
 
 
 -- ================================================================
 
 
------ PERSON			-- CAN talk
+----- PERSON      -- CAN talk
 
 
 -- ================================================================
 
 
 EVERY person ISA ACTOR
-    	CAN talk.
+      CAN talk.
 
-	CONTAINER
-		HEADER
-			SAY THE THIS.
-			IF THIS IS NOT plural
-				THEN "is carrying"
-				ELSE "are carrying"
-			END IF.
-		ELSE
-			
-			IF THIS IS NOT named
-				THEN SAY THE THIS. 
-				ELSE SAY THIS.
-			END IF.
-					
-			IF THIS IS NOT plural					
-				THEN "is empty-handed."
-				ELSE "are empty-handed."
-			END IF.
+  CONTAINER
+    HEADER
+      SAY THE THIS.
+      IF THIS IS NOT plural
+        THEN "is carrying"
+        ELSE "are carrying"
+      END IF.
+    ELSE
 
-		EXTRACT
-			CHECK THIS IS compliant
-				ELSE "That seems to belong to" 
-					IF THIS IS NOT named
-						THEN SAY THE THIS. 
-						ELSE SAY THIS.
-					END IF.
-					"."
-					
+      IF THIS IS NOT named
+        THEN SAY THE THIS.
+        ELSE SAY THIS.
+      END IF.
+
+      IF THIS IS NOT plural
+        THEN "is empty-handed."
+        ELSE "are empty-handed."
+      END IF.
+
+    EXTRACT
+      CHECK THIS IS compliant
+        ELSE "That seems to belong to"
+          IF THIS IS NOT named
+            THEN SAY THE THIS.
+            ELSE SAY THIS.
+          END IF.
+          "."
+
 END EVERY.
 
 
@@ -2183,7 +2183,7 @@ END EVERY.
 -- ================================================================
 
 
------ FEMALE and MALE		
+----- FEMALE and MALE
 
 
 -- ================================================================
@@ -2194,12 +2194,12 @@ END EVERY.
 
 
 EVERY female ISA PERSON
-	PRONOUN her
+  PRONOUN her
 END EVERY.
 
 
 EVERY male ISA PERSON
-	PRONOUN him
+  PRONOUN him
 END EVERY.
 
 

--- a/lib_definitions.i
+++ b/lib_definitions.i
@@ -2,19 +2,19 @@
 -- Definitions (file name: 'lib_definitions.i')
 
 -- Included in this file:
-	-- general attributes
-	-- some article declarations
-	-- common synonyms
-	-- the definition_block class 
-		-- attributes for the start section
-		-- messages for the hero
-		-- messages for dark locations	
-		-- response for restricted actions	
-		-- illegal parameter messages, used in SYNTAX definitions of verbs
-		-- verb check messages 
-		-- implicit taking message
-	-- attributes and events for restricted actions 
-	-- the banner instance (for the start section)
+  -- general attributes
+  -- some article declarations
+  -- common synonyms
+  -- the definition_block class
+    -- attributes for the start section
+    -- messages for the hero
+    -- messages for dark locations
+    -- response for restricted actions
+    -- illegal parameter messages, used in SYNTAX definitions of verbs
+    -- verb check messages
+    -- implicit taking message
+  -- attributes and events for restricted actions
+  -- the banner instance (for the start section)
 
 
 
@@ -22,67 +22,67 @@
 -- General attributes
 -- ==================
 
--- We define general attributes for every thing ( = object or actor): 
+-- We define general attributes for every thing ( = object or actor):
 
 
 ADD TO EVERY THING
 
-	IS examinable.
-		-- the library declares SOUNDs as not examinable. 
-	   inanimate.
-		-- actors are NOT inanimate.
-	   movable.  
-		-- to allow pushing, pulling, lifting, etc.
-	   open.
-		-- = not closed. 
-	   reachable. 		
-		-- See also 'distant' below
-	   takeable.
-		-- you'll have to separately define which objects are NOT takeable.
-		-- By default, the floor, walls, ceiling, ground and sky objects
-		-- are not takeable. The same goes for all doors, windows, sounds, liquids
-		-- that are not in containers, and actors.
+  IS examinable.
+    -- the library declares SOUNDs as not examinable.
+     inanimate.
+    -- actors are NOT inanimate.
+     movable.
+    -- to allow pushing, pulling, lifting, etc.
+     open.
+    -- = not closed.
+     reachable.
+    -- See also 'distant' below
+     takeable.
+    -- you'll have to separately define which objects are NOT takeable.
+    -- By default, the floor, walls, ceiling, ground and sky objects
+    -- are not takeable. The same goes for all doors, windows, sounds, liquids
+    -- that are not in containers, and actors.
 
-	HAS allowed {null_object}.
-		-- container objects only take what is allowed for them to take;
-		-- this applies to verbs empty_in, pour_in, put_in and throw_in.
-		-- "null_object" is a default dummy that can be ignored.
+  HAS allowed {null_object}.
+    -- container objects only take what is allowed for them to take;
+    -- this applies to verbs empty_in, pour_in, put_in and throw_in.
+    -- "null_object" is a default dummy that can be ignored.
 
-	HAS ex "".            -- an alternative way of giving responses to >x [thing],
-					-- instead of 'VERB examine DOES ONLY..."
-					-- See the library manual for more info.
+  HAS ex "".            -- an alternative way of giving responses to >x [thing],
+          -- instead of 'VERB examine DOES ONLY..."
+          -- See the library manual for more info.
 
-	HAS matching_key null_key.
-		-- All lockable doors need a matching key to lock/unlock them.
-		-- "null_key" is a default dummy that can be ignored. This attribute
-		-- is here added to every thing instead of just doors, to enable
-		-- matching keys to be programmed for other locked objects, too, like for
-		-- example treasure chests etc.
+  HAS matching_key null_key.
+    -- All lockable doors need a matching key to lock/unlock them.
+    -- "null_key" is a default dummy that can be ignored. This attribute
+    -- is here added to every thing instead of just doors, to enable
+    -- matching keys to be programmed for other locked objects, too, like for
+    -- example treasure chests etc.
 
-	HAS text "".	
+  HAS text "".
 
-	NOT broken.
-	NOT distant.		
-		-- Usage: you can for example talk to a "not reachable" actor but not to a "distant" one.
-		-- You can also throw things in, to or at a not reachable target but not to a distant one.
-		-- Default response for not reachable things: "The [thing] is out of your reach."
-		-- Default response for distant things: "The [thing] is too far away."
-	NOT drinkable. 
-	NOT edible.
-	NOT fireable.		
-		-- can (not) be used as a firearm
-	NOT lockable.
-	NOT locked.
-	NOT 'on'.
-	NOT openable.
-	NOT readable.   
-	NOT scenery.		
-		-- scenery has special responses for 'examine' and 'take', behaves like a normal object otherwise.
-	NOT wearable.
-	NOT writeable.
+  NOT broken.
+  NOT distant.
+    -- Usage: you can for example talk to a "not reachable" actor but not to a "distant" one.
+    -- You can also throw things in, to or at a not reachable target but not to a distant one.
+    -- Default response for not reachable things: "The [thing] is out of your reach."
+    -- Default response for distant things: "The [thing] is too far away."
+  NOT drinkable.
+  NOT edible.
+  NOT fireable.
+    -- can (not) be used as a firearm
+  NOT lockable.
+  NOT locked.
+  NOT 'on'.
+  NOT openable.
+  NOT readable.
+  NOT scenery.
+    -- scenery has special responses for 'examine' and 'take', behaves like a normal object otherwise.
+  NOT wearable.
+  NOT writeable.
 
-	CAN NOT talk.		
-	
+  CAN NOT talk.
+
 
 
 
@@ -90,10 +90,10 @@ ADD TO EVERY THING
 
 INDEFINITE ARTICLE
 
-	IF THIS IS NOT plural
-		THEN "a"
-		ELSE "some"
-	END IF.
+  IF THIS IS NOT plural
+    THEN "a"
+    ELSE "some"
+  END IF.
 
 END ADD TO.
 
@@ -102,17 +102,17 @@ END ADD TO.
 -- If you need "an", you should declare it separately at the instance, for example:
 
 -- THE owl ISA ACTOR
---  	AT woods
---  	INDEFINITE ARTICLE "an"
+--    AT woods
+--    INDEFINITE ARTICLE "an"
 -- END THE.
 
 
--- (We add the 'plural' attribute to the 'entity' class, because the plural 
+-- (We add the 'plural' attribute to the 'entity' class, because the plural
 -- applies not only to things but also to for example parameters in syntax statements; ignore.)
 
 
 ADD TO EVERY ENTITY
-	IS NOT plural.
+  IS NOT plural.
 END ADD TO.
 
 
@@ -133,18 +133,18 @@ END THE.
 
 
 ADD TO EVERY THING
-	HAS weight 0.
+  HAS weight 0.
 END ADD TO THING.
 
 
-ADD TO EVERY ACTOR 
-	HAS weight 50. 
-END ADD TO ACTOR. 
+ADD TO EVERY ACTOR
+  HAS weight 50.
+END ADD TO ACTOR.
 
 
 ADD TO EVERY OBJECT
-	HAS weight 5.
-END ADD TO OBJECT. 
+  HAS weight 5.
+END ADD TO OBJECT.
 
 
 -- These attributes are mostly used to check if something is movable.
@@ -154,7 +154,7 @@ END ADD TO OBJECT.
 -- An attribute for keeping track of nested locations; used internally in the library (ignore).
 
 ADD TO EVERY LOCATION
-	HAS nested {nowhere}.
+  HAS nested {nowhere}.
 END ADD TO.
 
 
@@ -165,11 +165,11 @@ END ADD TO.
 
 
 -- Next, we declare synonyms for some common words so that it will be possible
--- for the player to type commands such as both "put ball in box" and 
+-- for the player to type commands such as both "put ball in box" and
 -- "put ball into box", etc:
 
 
-SYNONYMS 
+SYNONYMS
 
 into, inside = 'in'.
 onto = on.
@@ -196,655 +196,655 @@ me, myself, yourself, self = hero.
 EVERY definition_block ISA LOCATION
 
 
-	-- attributes for the start section (banner):
-	-- ==========================================
+  -- attributes for the start section (banner):
+  -- ==========================================
 
-	HAS title "My New Game".		
-    	HAS subtitle "".			     	
-    	HAS author "An ALAN Author".   	
-    	HAS year 2017.				
-    	HAS version "1".					
-    	
-	-- These will be shown at the start of the game if you add
-		-- DESCRIBE banner.
-	-- after START AT [location].
+  HAS title "My New Game".
+      HAS subtitle "".
+      HAS author "An ALAN Author".
+      HAS year 2017.
+      HAS version "1".
 
+  -- These will be shown at the start of the game if you add
+    -- DESCRIBE banner.
+  -- after START AT [location].
 
 
-	-- messages for the hero:
-	-- ======================
 
-	-- The hero is not defined as an instance in the library; the game author
-	-- has all the freedom to define the hero as they see fit. However,
-	-- there are some messages for the hero defined in the library. These can be
-	-- easily overridden. Two of these messages are right here, the rest are
-	-- for example in verb checks.
+  -- messages for the hero:
+  -- ======================
 
-	HAS hero_worn_header "You are wearing".
-	HAS hero_worn_else "You are not wearing anything.".	
+  -- The hero is not defined as an instance in the library; the game author
+  -- has all the freedom to define the hero as they see fit. However,
+  -- there are some messages for the hero defined in the library. These can be
+  -- easily overridden. Two of these messages are right here, the rest are
+  -- for example in verb checks.
 
+  HAS hero_worn_header "You are wearing".
+  HAS hero_worn_else "You are not wearing anything.".
 
-	-- description messages for dark locations:
-	-- ========================================
 
-	HAS dark_loc_desc "It is pitch black. You can't see anything at all.".
-		-- This message is shown when the player tries to LOOK or do actions requiring light
-		-- in a dark location.
+  -- description messages for dark locations:
+  -- ========================================
 
-	HAS light_goes_off "It is now pitch black.".
-		-- This message is shown when a light goes off and the location becomes dark.
+  HAS dark_loc_desc "It is pitch black. You can't see anything at all.".
+    -- This message is shown when the player tries to LOOK or do actions requiring light
+    -- in a dark location.
 
+  HAS light_goes_off "It is now pitch black.".
+    -- This message is shown when a light goes off and the location becomes dark.
 
-	-- response for restricted actions:
-	-- ================================
 
-	HAS restricted_response "You can't do that.".
-		-- This message is shown whenever the player used a verb that has been restricted
-		 -- by the "CAN NOT [verb]" attributes further down this file.
+  -- response for restricted actions:
+  -- ================================
 
-	HAS restricted_level 0.   -- 0 = no verbs are restricted
+  HAS restricted_response "You can't do that.".
+    -- This message is shown whenever the player used a verb that has been restricted
+     -- by the "CAN NOT [verb]" attributes further down this file.
 
+  HAS restricted_level 0.   -- 0 = no verbs are restricted
 
 
 
 
-	-- all illegal parameter messages, typically found in the ELSE parts of SYNTAX structures and
-	-- the first two below being by far the most common.
-	-- ==========================================================================================
 
+  -- all illegal parameter messages, typically found in the ELSE parts of SYNTAX structures and
+  -- the first two below being by far the most common.
+  -- ==========================================================================================
 
-	-- the general message for when a parameter is not suitable with the verb:
-	--------------------------------------------------------------------------
 
- 	HAS illegal_parameter_sg "That's not something you can $v.".				-- (numerous)
-	HAS illegal_parameter_pl "Those are not something you can $v.".
+  -- the general message for when a parameter is not suitable with the verb:
+  --------------------------------------------------------------------------
 
+  HAS illegal_parameter_sg "That's not something you can $v.".        -- (numerous)
+  HAS illegal_parameter_pl "Those are not something you can $v.".
 
-	-- variations of the above message when a preposition is required after the verb:
-	---------------------------------------------------------------------------------
 
-	HAS illegal_parameter_about_sg "That's not something you can $v about.".		-- ask_about, tell_about, think_about
-	HAS illegal_parameter_about_pl "Those are not something you can $v about.".
-	HAS illegal_parameter_at "You can't $v anything at $+2.".					-- fire_at, throw_at
-	HAS illegal_parameter_for_sg "That's not something you can $v for.".			-- ask_for
-	HAS illegal_parameter_for_pl "Those are not something you can $v for.".
-	HAS illegal_parameter2_from_sg "That's not something you can take things from.".	-- take_from
-	HAS illegal_parameter2_from_pl "Those are not something you can take things from.".
-	HAS illegal_parameter_in_sg "That's not something you can $v in.".			-- dive_in, jump_in, lie_in, swim_in
-	HAS illegal_parameter_in_pl "Those are not something you can $v in.".
-	HAS illegal_parameter_on_sg "That's not something you can $v on.".			-- climb_on, jump_on, knock, lie_on, sit_on,
-																  -- stand_on, switch_on, turn_on
-	HAS illegal_parameter_on_pl "Those are not something you can $v on.".
-	HAS illegal_parameter_off_sg "That's not something you can $v off.".			-- get_off, switch_off, turn_off
-	HAS illegal_parameter_off_pl "Those are not something you can $v off.".
-	HAS illegal_parameter_to_sg "That's not something you can $v to.".			-- listen_to, talk_to
-	HAS illegal_parameter_to_pl "Those are not something you can $v to.".
-	HAS illegal_parameter2_to_sg "That's not something you can $v things to.".		-- give, show, tell, tie_to, throw_to
-	HAS illegal_parameter2_to_pl "Those are not something you can $v things to.".	
-	HAS illegal_parameter_with_sg "That's not something you can $v with.".		-- kill_with, shoot_with, play_with
-	HAS illegal_parameter_with_pl "Those are not something you can $v with.".	
-	HAS illegal_parameter2_with_sg "That's not something you can $v things with.".	-- attack_with, break_with, burn_with, close_with, 
-																 -- + cut_with, fill_with, lock_with, open_with, pry_with,
-																 -- + push_with, unlock_with
-	HAS illegal_parameter2_with_pl "Those are not something you can $v things with.".
-		
+  -- variations of the above message when a preposition is required after the verb:
+  ---------------------------------------------------------------------------------
 
-	-- other illegal parameter messages:
-	------------------------------------ 
+  HAS illegal_parameter_about_sg "That's not something you can $v about.".    -- ask_about, tell_about, think_about
+  HAS illegal_parameter_about_pl "Those are not something you can $v about.".
+  HAS illegal_parameter_at "You can't $v anything at $+2.".         -- fire_at, throw_at
+  HAS illegal_parameter_for_sg "That's not something you can $v for.".      -- ask_for
+  HAS illegal_parameter_for_pl "Those are not something you can $v for.".
+  HAS illegal_parameter2_from_sg "That's not something you can take things from.".  -- take_from
+  HAS illegal_parameter2_from_pl "Those are not something you can take things from.".
+  HAS illegal_parameter_in_sg "That's not something you can $v in.".      -- dive_in, jump_in, lie_in, swim_in
+  HAS illegal_parameter_in_pl "Those are not something you can $v in.".
+  HAS illegal_parameter_on_sg "That's not something you can $v on.".      -- climb_on, jump_on, knock, lie_on, sit_on,
+                                  -- stand_on, switch_on, turn_on
+  HAS illegal_parameter_on_pl "Those are not something you can $v on.".
+  HAS illegal_parameter_off_sg "That's not something you can $v off.".      -- get_off, switch_off, turn_off
+  HAS illegal_parameter_off_pl "Those are not something you can $v off.".
+  HAS illegal_parameter_to_sg "That's not something you can $v to.".      -- listen_to, talk_to
+  HAS illegal_parameter_to_pl "Those are not something you can $v to.".
+  HAS illegal_parameter2_to_sg "That's not something you can $v things to.".    -- give, show, tell, tie_to, throw_to
+  HAS illegal_parameter2_to_pl "Those are not something you can $v things to.".
+  HAS illegal_parameter_with_sg "That's not something you can $v with.".    -- kill_with, shoot_with, play_with
+  HAS illegal_parameter_with_pl "Those are not something you can $v with.".
+  HAS illegal_parameter2_with_sg "That's not something you can $v things with.".  -- attack_with, break_with, burn_with, close_with,
+                                 -- + cut_with, fill_with, lock_with, open_with, pry_with,
+                                 -- + push_with, unlock_with
+  HAS illegal_parameter2_with_pl "Those are not something you can $v things with.".
 
 
-	HAS illegal_parameter_act "That doesn't make sense.".							-- empty_in, pour_in, put_in, throw_in
-	
-	HAS illegal_parameter_consult_sg "That's not something you can find information		-- consult_about
-								about.".
-	HAS illegal_parameter_consult_pl "Those are not something you can find 			
-								information about.".
-
-	HAS illegal_parameter_examine_sg "That's not something you can examine.".			-- examine
-	HAS illegal_parameter_examine_pl "Those are not something you can examine.".
-
-	HAS illegal_parameter_go "You can't go there.".								-- go_to
-
-	HAS illegal_parameter_look_out_sg "That's not something you can look out of.".		-- look_out_of  
-	HAS illegal_parameter_look_out_pl "Those are not something you can look out of.".
-	HAS illegal_parameter_look_through "You can't look through $+1.".				-- look_through  
-
-	HAS illegal_parameter_obj "You can only $v objects.".							-- give, put, put_in, put_on, put_against,
-																	   -- + put_behind, put_near, put_under, 
-																	   -- + throw_at, throw_in, throw_to, tie_to,
-																	   -- + use, use_with
-
-	HAS illegal_parameter_string "Please state inside double quotes ("""") what you want to $v.".	-- answer, say, say_to, write
-	
-	HAS illegal_parameter_talk_sg "That's not something you can talk to.".			-- ask, ask_for, say_to, tell
-	HAS illegal_parameter_talk_pl "Those are not something you can talk to.".
-
-	HAS illegal_parameter_there "It's not possible to look there.".					-- look_behind, look_in, look_under 
-	
-	HAS illegal_parameter2_there "It's not possible to $v anything there.".    		-- empty_in, empty_on, pour_in, pour_on, put_in,  
-															    		 -- + put_on, put_against, put_behind, put_near, 
-																	 -- + put_under, throw_in, throw_to, tie_to, write
-
-	HAS illegal_parameter_what_sg "That's not something I know about.".				-- what_is, where_is
-	HAS illegal_parameter_what_pl "Those are not something I know about.".			-- what_is, where_is
-	HAS illegal_parameter_who_sg "That's not somebody I know about.".				-- who_is
-	HAS illegal_parameter_who_pl "Those are not somebody I know about.".				-- who_is
-		
-	
-	-- verb check messages, found before DOES sections of verbs and used mainly in 'lib_verbs.i':	
-	-- ==========================================================================================
-
-
-	-- a) attribute checks
-	----------------------
-
-		
-	-- the general check message for when an instance cannot be used with the verb :
-	--------------------------------------------------------------------------------	
-		
-	HAS check_obj_suitable_sg "That's not something you can $v.".				-- (numerous)				
-	HAS check_obj_suitable_pl "Those are not something you can $v.".
-
-
-	-- variations of the above message, needed for example when a preposition is required after the verb:
-	-----------------------------------------------------------------------------------------------------
-
-	HAS check_obj_suitable_at "You can't $v anything at $+2.".					-- fire_at, throw_at, throw_to
-	HAS check_obj2_suitable_for_sg "That's not something you can $v for.".		-- ask_for
-	HAS check_obj2_suitable_for_pl "Those are not something you can $v for.".
-	HAS check_obj_suitable_off_sg "That's not something you can $v off.".			-- turn_off, switch_off
-	HAS check_obj_suitable_off_pl "Those are not something you can $v off.".
-	HAS check_obj_suitable_on_sg "That's not something you can $v on.".			-- knock, switch_on, turn_on
-	HAS check_obj_suitable_on_pl "Those are not something you can $v on."	.	
-	HAS check_obj_suitable_with_sg "That's not something you can $v with.".		-- play_with
-	HAS check_obj_suitable_with_pl "Those are not something you can $v with.".		
-	HAS check_obj2_suitable_with_sg "That's not something you can $v things with.".	  -- break_with, burn_with, close_with, cut_with, fill_with, 
-	HAS check_obj2_suitable_with_pl "Those are not something you can $v things with.".	 -- + lock_with, open_with, pry_with, push_with,
-																	 -- + touch_with, unlock_with
-
-	HAS check_obj_suitable_examine_sg "That's not something you can examine.".			-- examine
-	HAS check_obj_suitable_examine_pl "Those are not something you can examine.".		-- examine
-
-	HAS check_obj_suitable_look_out_sg "That's not something you can look out of.".		-- look_out_of
-	HAS check_obj_suitable_look_out_pl "Those are not something you can look out of.".			
-	HAS check_obj_suitable_look_through "You can't look through $+1.".				-- look_through
-
-
-	-- checks for open, closed and locked objects:
-	----------------------------------------------
-
-	HAS check_obj_not_open_sg "$+1 is already open.".					-- open, open_with
-	HAS check_obj_not_open_pl "$+1 are already open.".
-	HAS check_obj_open1_sg "$+1 is already closed.".					-- close, close_with
-	HAS check_obj_open1_pl "$+1 are already closed.".
-	HAS check_obj_open2_sg "You can't, since $+1 is closed.".				-- empty (in/on), look_in, pour (in/on)
-	HAS check_obj_open2_pl "You can't, since $+1 are closed.".
-	HAS check_obj2_open_sg "You can't, since $+2 is closed.".				-- empty_in, pour_in, put_in, throw_in
-	HAS check_obj2_open_pl "You can't, since $+2 are closed.".
-	HAS check_obj_locked_sg "$+1 is already unlocked.".					-- unlock, unlock_with
-	HAS check_obj_locked_pl "$+1 are already unlocked.".
-	HAS check_obj_not_locked_sg "$+1 is already locked.". 				-- lock, lock_with
-	HAS check_obj_not_locked_pl "$+1 are already locked.".
-	
-
-
-	-- checks for "not reachable" and "distant" objects:
-	----------------------------------------------------
-
-	HAS check_obj_reachable_sg "$+1 is out of your reach.".				-- (numerous)
-	HAS check_obj_reachable_pl "$+1 are out of your reach.".
-	HAS check_obj2_reachable_sg "$+2 is out of your reach.".				-- empty_in, fill_with, pour_in, put_in, take_from, tie_to		
-	HAS check_obj2_reachable_pl "$+2 are out of your reach.".
-	HAS check_obj_reachable_ask "$+1 can't reach $+2.".					-- ask_for
-	HAS check_obj_not_distant_sg "$+1 is too far away.".					-- (numerous)
-	HAS check_obj_not_distant_pl "$+1 are too far away.".
-	HAS check_obj2_not_distant_sg "$+2 is too far away.".					-- empty_in, fill_with, pour_in, put_in, show, take_from,  																 -- + throw_at, throw_in, throw_to
-	HAS check_obj2_not_distant_pl "$+2 are too far away.".
-	
-
-	-- checks for the hero sitting or lying_down:
-	---------------------------------------------
-
-	HAS check_hero_not_sitting1 "It is difficult to $v while sitting down.".   		-- (with many intransitive verbs)
-	HAS check_hero_not_sitting2 "It is difficult to $v anything while sitting down.".	-- (with many transitive verbs)
-	HAS check_hero_not_sitting3 "It is difficult to $v anywhere while sitting down.".	-- (with many verbs of motion)
-	HAS check_hero_not_sitting4 "You're sitting down already.".					-- sit, sit_on
-	HAS check_hero_not_lying_down1 "It is difficult to $v while lying down.".			-- (with many intranstive verbs)
-	HAS check_hero_not_lying_down2 "It is difficult to $v anything while lying down.".	-- (with many transitive verbs)
-	HAS check_hero_not_lying_down3 "It is difficult to $v anywhere while lying down.".	-- (with many verbs of motion)
-	HAS check_hero_not_lying_down4 "You're lying down already.".					-- lie_down, lie_in
-
-
-	-- other attribute checks:
-	--------------------------
-
-	HAS check_act_can_talk_sg "That's not something you can talk to.".				-- ask, ask_for, say_to, tell
-	HAS check_act_can_talk_pl "Those are not something you can talk to.". 
-
-	HAS check_obj_allowed_in_sg "$+1 doesn't belong in $+2.". 						-- empty_in, pour_in, put_in, throw_in
-	HAS check_obj_allowed_in_pl "$+1 don't belong in $+2.".	
-	
-	HAS check_obj_broken_sg "That doesn't need fixing.".  						-- fix					
-	HAS check_obj_broken_pl "Those don't need fixing.".
-
-	HAS check_obj_inanimate1 "$+1 wouldn't probably appreciate that.".				-- push, push_with, scratch, search
-	HAS check_obj_inanimate2 "You are not sure whether $+1 would appreciate that.".		-- rub, touch, touch_with
-	
-	HAS check_obj_movable "It's not possible to $v $+1.".							-- lift, pull, push, push_with, shake, take, take_from
-			
-	HAS check_obj_not_scenery_sg "$+1 is not important.".							-- examine, take, take_from
-	HAS check_obj_not_scenery_pl "$+1 are not important.".
-
-	HAS check_obj2_not_scenery_sg "$+2 is not important.".							-- ask_for, take_from
-	HAS check_obj2_not_scenery_pl "$+2 are not important.".
-
-	HAS check_obj_suitable_there "It's not possible to $v there.".					-- look_behind, look_in, look_under
-	HAS check_obj2_suitable_there "It's not possible to $v anything there.".			-- throw_in, tie_to
-
-	HAS check_obj_takeable "You don't have $+1.".							-- (numerous; this check is in verbs using implicit taking)
-	HAS check_obj2_takeable1 "You don't have $+2.".								-- fill_with
-	HAS check_obj2_takeable2 "You can't have $+2.".								-- ask_for
-	
-	HAS check_obj_weight_sg "$+1 is too heavy to $v.".							-- lift, take, take_from
-	HAS check_obj_weight_pl "$+1 are too heavy to $v.".
-
-	HAS check_obj_writeable "Nothing can be written there.".						-- write
-
-
-	-- b) location and containment checks for actors and objects
-	------------------------------------------------------------
-
-
-	-- containment checks for actors other than the hero (checks for the hero are listed separately below):
-	-------------------------------------------------------------------------------------------------------
-	
-	HAS check_act_near_hero "You don't quite know where $+1 went.  					-- follow
-		You should state a direction where you want to go.".
-
-	HAS check_obj_in_act_sg "$+2 doesn't have $+1.".							-- take_from
-	HAS check_obj_in_act_pl "$+2 don't have $+1.".
-	HAS check_obj_not_in_act_sg "$+2 already has $+1.".							-- give
-	HAS check_obj_not_in_act_pl "$+2 already have $+1.". 
-
-
-	-- location and containment checks for the hero:
-	------------------------------------------------
-
-	HAS check_count_weapon_in_hero "You are not carrying any firearms.".				-- shoot
-
-	HAS check_obj_not_at_hero_sg "$+1 is right here.".  							-- find, follow, go_to, where_is
-	HAS check_obj_not_at_hero_pl "$+1 are right here.".
-	HAS check_obj_in_hero "You don't have the $+1.".							-- drop, fire, fire_at, put, show
-	HAS check_obj2_in_hero "You don't have the $+2.".							-- (numerous)
-	HAS check_obj_not_in_hero1 "It doesn't make sense to $v something you're holding.".  	-- attack, attack_with, kick, lift, shoot, shoot_with
-	HAS check_obj_not_in_hero2 "You already have $+1.".							-- take, take_from
-	HAS check_obj2_not_in_hero1 "You are carrying $+2.".   						-- throw_at, throw_in, throw_to
-	HAS check_obj2_not_in_hero2 "That would be futile.".							-- put_against, put_behind, put_near, put_under
-	HAS check_obj2_not_in_hero3 "You already have $+2.".							-- ask_for
-
-
-	-- checking whether an object is in a container or not:
-	-------------------------------------------------------
-
-	HAS check_cont_not_in_obj "That doesn't make sense.".							-- empty_in, pour_in, put_in
-	HAS check_obj_in_cont_sg "$+1 is not in $+2.".								-- take_from
-	HAS check_obj_in_cont_pl "$+1 are not in $+2.".
-	HAS check_obj_not_in_cont_sg "$+1 is in $+2 already.".						-- put_in, throw_in
-	HAS check_obj_not_in_cont_pl "$+1 are in $+2 already.".
-	HAS check_obj_not_in_cont2 "$+1 is already full of $+2.".						-- fill_with
-
-
-	-- checking whether an object is on a surface or not:
-	-----------------------------------------------------
-	
-	HAS check_obj_on_surface_sg "$+1 is not on $+2.".							-- take_from
-	HAS check_obj_on_surface_pl "$+1 are not on $+2.".
-	HAS check_obj_not_on_surface_sg "$+1 is already on $+2.".						-- put_on
-	HAS check_obj_not_on_surface_pl "$+1 are already on $+2.".
-	
-
-	-- checking whether an object is worn or not:
-	---------------------------------------------	
-
-	HAS check_obj_in_worn "You are not wearing $+1.".    							-- remove, take_off ('classes.i')
-	HAS check_obj_not_in_worn1 "You are already wearing $+1.".   					-- put_on, wear ('classes.i')
-    	HAS check_obj_not_in_worn2 "It doesn't make sense to $v something you're wearing.".	-- attack, attack_with, kick, shoot, shoot_with
-	HAS check_obj_not_in_worn3 "You'll have to take off $+1 first.".				-- drop
-    	
-
-	-- c) checking location states
-	------------------------------	
-
-    	HAS check_current_loc_lit "It is too dark to see.".						-- (numerous)
-
-
-	-- d) checks guarding against actions directed at the hero him-/herself
-	-----------------------------------------------------------------------
-
-	HAS check_obj_not_hero1 "It doesn't make sense to $v yourself.".			-- ask, ask_for, attack, attack_with, catch, follow
-																   -- kick, listen, pull, push, push_with, take, 
-																   -- take_from,tell 
-	HAS check_obj_not_hero2 "There is no need to be that desperate.".  			-- fire_at, kill, kill_with, shoot, shoot_with
-	HAS check_obj_not_hero3 "That wouldn't accomplish anything.".				-- scratch, touch
-	HAS check_obj_not_hero4 "You're right here.".							-- find, go_to
-	HAS check_obj_not_hero5 "You don't need to be freed.".					-- free
-	HAS check_obj_not_hero6 "There is no time for that now.".								-- kiss, play_with, rub
-	HAS check_obj_not_hero7 "Turning your head, you notice nothing unusual behind yourself.".		-- look_behind 
-	HAS check_obj_not_hero8 "You notice nothing unusual under yourself.".						-- look_under
-	HAS check_obj2_not_hero1 "That doesn't make sense.".						-- say_to, show, take_from, touch_with, throw_at/in/to
-	HAS check_obj2_not_hero2 "That would be futile.".						-- put_against, put_behind, put_near, put_under
-	HAS check_obj2_not_hero3 "You can't $v things to yourself.".				-- give, tie_to
-
-
-	-- e) checks guarding against actions where an object is used with itself
-	-------------------------------------------------------------------------
-
-	HAS check_obj_not_obj2_at "It doesn't make sense to $v something at itself.".		-- fire_at, throw_at
-	HAS check_obj_not_obj2_from "It doesn't make sense to $v something from itself.".	-- take_from
-	HAS check_obj_not_obj2_in "It doesn't make sense to $v something into itself.".		-- empty_in, pour_in, put_in, throw_in
-	HAS check_obj_not_obj2_on "It doesn't make sense to $v something onto itself.".		-- empty_on, pour_on, put_on
-	HAS check_obj_not_obj2_to "It doesn't make sense to $v something to itself.".		-- give, show, throw_to, tie_to
-	HAS check_obj_not_obj2_with "It doesn't make sense to $v something with itself.".  	-- attack_with, break_with, burn_with, close_with, 																		   -- + cut_with, fill_with, lock_with, 
-																	   -- + open_with, push_with, pry_with, shoot_with,  
-																	   -- + touch_withm unlock_with, use_with
-	
-	HAS check_obj_not_obj2_put "That doesn't make sense."	.					-- put_against, put_behind, put_near, put_under
-
-	
-    	-- f) additional checks for classes:
-	------------------------------------
-
-	HAS check_clothing_sex "On second thoughts you decide $+1 won't really suit you.".			-- clothing: wear
-	HAS check_cont_not_supporter "You can't put $+1 inside $+2.".							-- supporter: put_in
-	HAS check_device_on_sg "$+1 is already off.". 										-- device: turn_off, switch_off
-	HAS check_device_on_pl "$+1 are already off.".
-	HAS check_device_not_on_sg "$+1 is already on.". 									-- device: turn_on, switch_on
-	HAS check_device_not_on_pl "$+1 are already on.".
-	HAS check_door_matching_key "You can't use $+2 to $v $+1.".							-- door: lock_with, unlock_with	
-	HAS check_lightsource_lit_sg "But $+1 is not lit.".									-- lightsource: extinguish, turn_off
-	HAS check_lightsource_lit_pl "But $+1 are not lit.".
-	HAS check_lightsource_not_lit_sg "$+1 is already lit.".								-- lightsource: light, turn_on
-	HAS check_lightsource_not_lit_pl "$+1 are already lit.".
-	HAS check_lightsource_switchable_sg "That's not something you can switch on and off."	.		-- lightsource: switch 
-	HAS check_lightsource_switchable_pl "Those are not something you can switch on and off.".
-	HAS check_liquid_vessel_not_cont "You can't carry $+1 around in your bare hands.".			-- liquid: take_from
-	HAS check_obj_not_broken "Nothing happens.".										-- device, lightsource: light, switch, turn_on
-
-
-	-- messages for implicit taking:
-	-- =============================
-
-    	HAS implicit_taking_message "(taking $+1 first)$n".	
-
-	-- The following verbs are preceded by implicit taking:
-			-- bite, drink, eat, empty, empty_in, empty_on, give, pour, pour_in, pour_on,  
-			-- put_in, put_on, throw, throw_at, throw_in, throw_to, tie_to.
-	-- In ditransitive verbs, only the first parameter (the direct object) is taken implicitly.
-			-- For example, >push door with pole  won't work if the hero is not carrying the pole.
+  -- other illegal parameter messages:
+  ------------------------------------
+
+
+  HAS illegal_parameter_act "That doesn't make sense.".             -- empty_in, pour_in, put_in, throw_in
+
+  HAS illegal_parameter_consult_sg "That's not something you can find information   -- consult_about
+                about.".
+  HAS illegal_parameter_consult_pl "Those are not something you can find
+                information about.".
+
+  HAS illegal_parameter_examine_sg "That's not something you can examine.".     -- examine
+  HAS illegal_parameter_examine_pl "Those are not something you can examine.".
+
+  HAS illegal_parameter_go "You can't go there.".               -- go_to
+
+  HAS illegal_parameter_look_out_sg "That's not something you can look out of.".    -- look_out_of
+  HAS illegal_parameter_look_out_pl "Those are not something you can look out of.".
+  HAS illegal_parameter_look_through "You can't look through $+1.".       -- look_through
+
+  HAS illegal_parameter_obj "You can only $v objects.".             -- give, put, put_in, put_on, put_against,
+                                     -- + put_behind, put_near, put_under,
+                                     -- + throw_at, throw_in, throw_to, tie_to,
+                                     -- + use, use_with
+
+  HAS illegal_parameter_string "Please state inside double quotes ("""") what you want to $v.". -- answer, say, say_to, write
+
+  HAS illegal_parameter_talk_sg "That's not something you can talk to.".      -- ask, ask_for, say_to, tell
+  HAS illegal_parameter_talk_pl "Those are not something you can talk to.".
+
+  HAS illegal_parameter_there "It's not possible to look there.".         -- look_behind, look_in, look_under
+
+  HAS illegal_parameter2_there "It's not possible to $v anything there.".       -- empty_in, empty_on, pour_in, pour_on, put_in,
+                                       -- + put_on, put_against, put_behind, put_near,
+                                   -- + put_under, throw_in, throw_to, tie_to, write
+
+  HAS illegal_parameter_what_sg "That's not something I know about.".       -- what_is, where_is
+  HAS illegal_parameter_what_pl "Those are not something I know about.".      -- what_is, where_is
+  HAS illegal_parameter_who_sg "That's not somebody I know about.".       -- who_is
+  HAS illegal_parameter_who_pl "Those are not somebody I know about.".        -- who_is
+
+
+  -- verb check messages, found before DOES sections of verbs and used mainly in 'lib_verbs.i':
+  -- ==========================================================================================
+
+
+  -- a) attribute checks
+  ----------------------
+
+
+  -- the general check message for when an instance cannot be used with the verb :
+  --------------------------------------------------------------------------------
+
+  HAS check_obj_suitable_sg "That's not something you can $v.".       -- (numerous)
+  HAS check_obj_suitable_pl "Those are not something you can $v.".
+
+
+  -- variations of the above message, needed for example when a preposition is required after the verb:
+  -----------------------------------------------------------------------------------------------------
+
+  HAS check_obj_suitable_at "You can't $v anything at $+2.".          -- fire_at, throw_at, throw_to
+  HAS check_obj2_suitable_for_sg "That's not something you can $v for.".    -- ask_for
+  HAS check_obj2_suitable_for_pl "Those are not something you can $v for.".
+  HAS check_obj_suitable_off_sg "That's not something you can $v off.".     -- turn_off, switch_off
+  HAS check_obj_suitable_off_pl "Those are not something you can $v off.".
+  HAS check_obj_suitable_on_sg "That's not something you can $v on.".     -- knock, switch_on, turn_on
+  HAS check_obj_suitable_on_pl "Those are not something you can $v on." .
+  HAS check_obj_suitable_with_sg "That's not something you can $v with.".   -- play_with
+  HAS check_obj_suitable_with_pl "Those are not something you can $v with.".
+  HAS check_obj2_suitable_with_sg "That's not something you can $v things with.".   -- break_with, burn_with, close_with, cut_with, fill_with,
+  HAS check_obj2_suitable_with_pl "Those are not something you can $v things with.".   -- + lock_with, open_with, pry_with, push_with,
+                                   -- + touch_with, unlock_with
+
+  HAS check_obj_suitable_examine_sg "That's not something you can examine.".      -- examine
+  HAS check_obj_suitable_examine_pl "Those are not something you can examine.".   -- examine
+
+  HAS check_obj_suitable_look_out_sg "That's not something you can look out of.".   -- look_out_of
+  HAS check_obj_suitable_look_out_pl "Those are not something you can look out of.".
+  HAS check_obj_suitable_look_through "You can't look through $+1.".        -- look_through
+
+
+  -- checks for open, closed and locked objects:
+  ----------------------------------------------
+
+  HAS check_obj_not_open_sg "$+1 is already open.".         -- open, open_with
+  HAS check_obj_not_open_pl "$+1 are already open.".
+  HAS check_obj_open1_sg "$+1 is already closed.".          -- close, close_with
+  HAS check_obj_open1_pl "$+1 are already closed.".
+  HAS check_obj_open2_sg "You can't, since $+1 is closed.".       -- empty (in/on), look_in, pour (in/on)
+  HAS check_obj_open2_pl "You can't, since $+1 are closed.".
+  HAS check_obj2_open_sg "You can't, since $+2 is closed.".       -- empty_in, pour_in, put_in, throw_in
+  HAS check_obj2_open_pl "You can't, since $+2 are closed.".
+  HAS check_obj_locked_sg "$+1 is already unlocked.".         -- unlock, unlock_with
+  HAS check_obj_locked_pl "$+1 are already unlocked.".
+  HAS check_obj_not_locked_sg "$+1 is already locked.".         -- lock, lock_with
+  HAS check_obj_not_locked_pl "$+1 are already locked.".
+
+
+
+  -- checks for "not reachable" and "distant" objects:
+  ----------------------------------------------------
+
+  HAS check_obj_reachable_sg "$+1 is out of your reach.".       -- (numerous)
+  HAS check_obj_reachable_pl "$+1 are out of your reach.".
+  HAS check_obj2_reachable_sg "$+2 is out of your reach.".        -- empty_in, fill_with, pour_in, put_in, take_from, tie_to
+  HAS check_obj2_reachable_pl "$+2 are out of your reach.".
+  HAS check_obj_reachable_ask "$+1 can't reach $+2.".         -- ask_for
+  HAS check_obj_not_distant_sg "$+1 is too far away.".          -- (numerous)
+  HAS check_obj_not_distant_pl "$+1 are too far away.".
+  HAS check_obj2_not_distant_sg "$+2 is too far away.".         -- empty_in, fill_with, pour_in, put_in, show, take_from,                                  -- + throw_at, throw_in, throw_to
+  HAS check_obj2_not_distant_pl "$+2 are too far away.".
+
+
+  -- checks for the hero sitting or lying_down:
+  ---------------------------------------------
+
+  HAS check_hero_not_sitting1 "It is difficult to $v while sitting down.".      -- (with many intransitive verbs)
+  HAS check_hero_not_sitting2 "It is difficult to $v anything while sitting down.". -- (with many transitive verbs)
+  HAS check_hero_not_sitting3 "It is difficult to $v anywhere while sitting down.". -- (with many verbs of motion)
+  HAS check_hero_not_sitting4 "You're sitting down already.".         -- sit, sit_on
+  HAS check_hero_not_lying_down1 "It is difficult to $v while lying down.".     -- (with many intranstive verbs)
+  HAS check_hero_not_lying_down2 "It is difficult to $v anything while lying down.".  -- (with many transitive verbs)
+  HAS check_hero_not_lying_down3 "It is difficult to $v anywhere while lying down.".  -- (with many verbs of motion)
+  HAS check_hero_not_lying_down4 "You're lying down already.".          -- lie_down, lie_in
+
+
+  -- other attribute checks:
+  --------------------------
+
+  HAS check_act_can_talk_sg "That's not something you can talk to.".        -- ask, ask_for, say_to, tell
+  HAS check_act_can_talk_pl "Those are not something you can talk to.".
+
+  HAS check_obj_allowed_in_sg "$+1 doesn't belong in $+2.".             -- empty_in, pour_in, put_in, throw_in
+  HAS check_obj_allowed_in_pl "$+1 don't belong in $+2.".
+
+  HAS check_obj_broken_sg "That doesn't need fixing.".              -- fix
+  HAS check_obj_broken_pl "Those don't need fixing.".
+
+  HAS check_obj_inanimate1 "$+1 wouldn't probably appreciate that.".        -- push, push_with, scratch, search
+  HAS check_obj_inanimate2 "You are not sure whether $+1 would appreciate that.".   -- rub, touch, touch_with
+
+  HAS check_obj_movable "It's not possible to $v $+1.".             -- lift, pull, push, push_with, shake, take, take_from
+
+  HAS check_obj_not_scenery_sg "$+1 is not important.".             -- examine, take, take_from
+  HAS check_obj_not_scenery_pl "$+1 are not important.".
+
+  HAS check_obj2_not_scenery_sg "$+2 is not important.".              -- ask_for, take_from
+  HAS check_obj2_not_scenery_pl "$+2 are not important.".
+
+  HAS check_obj_suitable_there "It's not possible to $v there.".          -- look_behind, look_in, look_under
+  HAS check_obj2_suitable_there "It's not possible to $v anything there.".      -- throw_in, tie_to
+
+  HAS check_obj_takeable "You don't have $+1.".             -- (numerous; this check is in verbs using implicit taking)
+  HAS check_obj2_takeable1 "You don't have $+2.".               -- fill_with
+  HAS check_obj2_takeable2 "You can't have $+2.".               -- ask_for
+
+  HAS check_obj_weight_sg "$+1 is too heavy to $v.".              -- lift, take, take_from
+  HAS check_obj_weight_pl "$+1 are too heavy to $v.".
+
+  HAS check_obj_writeable "Nothing can be written there.".            -- write
+
+
+  -- b) location and containment checks for actors and objects
+  ------------------------------------------------------------
+
+
+  -- containment checks for actors other than the hero (checks for the hero are listed separately below):
+  -------------------------------------------------------------------------------------------------------
+
+  HAS check_act_near_hero "You don't quite know where $+1 went.           -- follow
+    You should state a direction where you want to go.".
+
+  HAS check_obj_in_act_sg "$+2 doesn't have $+1.".              -- take_from
+  HAS check_obj_in_act_pl "$+2 don't have $+1.".
+  HAS check_obj_not_in_act_sg "$+2 already has $+1.".             -- give
+  HAS check_obj_not_in_act_pl "$+2 already have $+1.".
+
+
+  -- location and containment checks for the hero:
+  ------------------------------------------------
+
+  HAS check_count_weapon_in_hero "You are not carrying any firearms.".        -- shoot
+
+  HAS check_obj_not_at_hero_sg "$+1 is right here.".                -- find, follow, go_to, where_is
+  HAS check_obj_not_at_hero_pl "$+1 are right here.".
+  HAS check_obj_in_hero "You don't have the $+1.".              -- drop, fire, fire_at, put, show
+  HAS check_obj2_in_hero "You don't have the $+2.".             -- (numerous)
+  HAS check_obj_not_in_hero1 "It doesn't make sense to $v something you're holding.".   -- attack, attack_with, kick, lift, shoot, shoot_with
+  HAS check_obj_not_in_hero2 "You already have $+1.".             -- take, take_from
+  HAS check_obj2_not_in_hero1 "You are carrying $+2.".              -- throw_at, throw_in, throw_to
+  HAS check_obj2_not_in_hero2 "That would be futile.".              -- put_against, put_behind, put_near, put_under
+  HAS check_obj2_not_in_hero3 "You already have $+2.".              -- ask_for
+
+
+  -- checking whether an object is in a container or not:
+  -------------------------------------------------------
+
+  HAS check_cont_not_in_obj "That doesn't make sense.".             -- empty_in, pour_in, put_in
+  HAS check_obj_in_cont_sg "$+1 is not in $+2.".                -- take_from
+  HAS check_obj_in_cont_pl "$+1 are not in $+2.".
+  HAS check_obj_not_in_cont_sg "$+1 is in $+2 already.".            -- put_in, throw_in
+  HAS check_obj_not_in_cont_pl "$+1 are in $+2 already.".
+  HAS check_obj_not_in_cont2 "$+1 is already full of $+2.".           -- fill_with
+
+
+  -- checking whether an object is on a surface or not:
+  -----------------------------------------------------
+
+  HAS check_obj_on_surface_sg "$+1 is not on $+2.".             -- take_from
+  HAS check_obj_on_surface_pl "$+1 are not on $+2.".
+  HAS check_obj_not_on_surface_sg "$+1 is already on $+2.".           -- put_on
+  HAS check_obj_not_on_surface_pl "$+1 are already on $+2.".
+
+
+  -- checking whether an object is worn or not:
+  ---------------------------------------------
+
+  HAS check_obj_in_worn "You are not wearing $+1.".                 -- remove, take_off ('classes.i')
+  HAS check_obj_not_in_worn1 "You are already wearing $+1.".            -- put_on, wear ('classes.i')
+      HAS check_obj_not_in_worn2 "It doesn't make sense to $v something you're wearing.". -- attack, attack_with, kick, shoot, shoot_with
+  HAS check_obj_not_in_worn3 "You'll have to take off $+1 first.".        -- drop
+
+
+  -- c) checking location states
+  ------------------------------
+
+      HAS check_current_loc_lit "It is too dark to see.".           -- (numerous)
+
+
+  -- d) checks guarding against actions directed at the hero him-/herself
+  -----------------------------------------------------------------------
+
+  HAS check_obj_not_hero1 "It doesn't make sense to $v yourself.".      -- ask, ask_for, attack, attack_with, catch, follow
+                                   -- kick, listen, pull, push, push_with, take,
+                                   -- take_from,tell
+  HAS check_obj_not_hero2 "There is no need to be that desperate.".       -- fire_at, kill, kill_with, shoot, shoot_with
+  HAS check_obj_not_hero3 "That wouldn't accomplish anything.".       -- scratch, touch
+  HAS check_obj_not_hero4 "You're right here.".             -- find, go_to
+  HAS check_obj_not_hero5 "You don't need to be freed.".          -- free
+  HAS check_obj_not_hero6 "There is no time for that now.".               -- kiss, play_with, rub
+  HAS check_obj_not_hero7 "Turning your head, you notice nothing unusual behind yourself.".   -- look_behind
+  HAS check_obj_not_hero8 "You notice nothing unusual under yourself.".           -- look_under
+  HAS check_obj2_not_hero1 "That doesn't make sense.".            -- say_to, show, take_from, touch_with, throw_at/in/to
+  HAS check_obj2_not_hero2 "That would be futile.".           -- put_against, put_behind, put_near, put_under
+  HAS check_obj2_not_hero3 "You can't $v things to yourself.".        -- give, tie_to
+
+
+  -- e) checks guarding against actions where an object is used with itself
+  -------------------------------------------------------------------------
+
+  HAS check_obj_not_obj2_at "It doesn't make sense to $v something at itself.".   -- fire_at, throw_at
+  HAS check_obj_not_obj2_from "It doesn't make sense to $v something from itself.". -- take_from
+  HAS check_obj_not_obj2_in "It doesn't make sense to $v something into itself.".   -- empty_in, pour_in, put_in, throw_in
+  HAS check_obj_not_obj2_on "It doesn't make sense to $v something onto itself.".   -- empty_on, pour_on, put_on
+  HAS check_obj_not_obj2_to "It doesn't make sense to $v something to itself.".   -- give, show, throw_to, tie_to
+  HAS check_obj_not_obj2_with "It doesn't make sense to $v something with itself.".   -- attack_with, break_with, burn_with, close_with,                                       -- + cut_with, fill_with, lock_with,
+                                     -- + open_with, push_with, pry_with, shoot_with,
+                                     -- + touch_withm unlock_with, use_with
+
+  HAS check_obj_not_obj2_put "That doesn't make sense." .         -- put_against, put_behind, put_near, put_under
+
+
+      -- f) additional checks for classes:
+  ------------------------------------
+
+  HAS check_clothing_sex "On second thoughts you decide $+1 won't really suit you.".      -- clothing: wear
+  HAS check_cont_not_supporter "You can't put $+1 inside $+2.".             -- supporter: put_in
+  HAS check_device_on_sg "$+1 is already off.".                     -- device: turn_off, switch_off
+  HAS check_device_on_pl "$+1 are already off.".
+  HAS check_device_not_on_sg "$+1 is already on.".                  -- device: turn_on, switch_on
+  HAS check_device_not_on_pl "$+1 are already on.".
+  HAS check_door_matching_key "You can't use $+2 to $v $+1.".             -- door: lock_with, unlock_with
+  HAS check_lightsource_lit_sg "But $+1 is not lit.".                 -- lightsource: extinguish, turn_off
+  HAS check_lightsource_lit_pl "But $+1 are not lit.".
+  HAS check_lightsource_not_lit_sg "$+1 is already lit.".               -- lightsource: light, turn_on
+  HAS check_lightsource_not_lit_pl "$+1 are already lit.".
+  HAS check_lightsource_switchable_sg "That's not something you can switch on and off." .   -- lightsource: switch
+  HAS check_lightsource_switchable_pl "Those are not something you can switch on and off.".
+  HAS check_liquid_vessel_not_cont "You can't carry $+1 around in your bare hands.".      -- liquid: take_from
+  HAS check_obj_not_broken "Nothing happens.".                    -- device, lightsource: light, switch, turn_on
+
+
+  -- messages for implicit taking:
+  -- =============================
+
+      HAS implicit_taking_message "(taking $+1 first)$n".
+
+  -- The following verbs are preceded by implicit taking:
+      -- bite, drink, eat, empty, empty_in, empty_on, give, pour, pour_in, pour_on,
+      -- put_in, put_on, throw, throw_at, throw_in, throw_to, tie_to.
+  -- In ditransitive verbs, only the first parameter (the direct object) is taken implicitly.
+      -- For example, >push door with pole  won't work if the hero is not carrying the pole.
 
 
 
 
    -- ==========================================================================================
 
-	-- These three attributes, as well as the 'schedule' statement following them,
-	-- are needed for the 'notify' command ('lib_verbs.i'); ignore.
+  -- These three attributes, as well as the 'schedule' statement following them,
+  -- are needed for the 'notify' command ('lib_verbs.i'); ignore.
 
-	HAS oldscore 0. 		
-			-- Records previous score so 'checkscore' event
- 			-- can compare with the current score 
-	IS notify_turned_on. 		
-			-- Set by 'notify' verb, records whether 
-			-- player wants to see score messages or not. 
-	IS NOT seen_notify. 	
-			-- Records whether player has seen the notify verb 
-			-- instructions yet. 
+  HAS oldscore 0.
+      -- Records previous score so 'checkscore' event
+      -- can compare with the current score
+  IS notify_turned_on.
+      -- Set by 'notify' verb, records whether
+      -- player wants to see score messages or not.
+  IS NOT seen_notify.
+      -- Records whether player has seen the notify verb
+      -- instructions yet.
 
-	INITIALIZE
-		SCHEDULE check_score AFTER 0.		
-		SCHEDULE check_restriction AFTER 0.
+  INITIALIZE
+    SCHEDULE check_score AFTER 0.
+    SCHEDULE check_restriction AFTER 0.
 
    -- ==========================================================================================
 
 
 -- The my_game instance defined as a meta-location (ignore):
 
-				FOR EACH l ISA LOCATION
-					DO
-						EXCLUDE nowhere FROM nested OF l. 
-						IF COUNT ISA LOCATION, AT l > 0
-							THEN 
-								FOR EACH x ISA LOCATION, AT l
-									DO
-										INCLUDE x IN nested OF l.
-								END FOR.
-						END IF.
-				END FOR.
-							
-				FOR EACH l ISA LOCATION
-					DO
-			  			IF l <> my_game AND l <> nowhere
-							THEN LOCATE l AT my_game.
-						END IF.
-				END FOR.
-		
-				FOR EACH r1 ISA ROOM
-					DO 
-						LOCATE r1 AT indoor.		
-				END FOR.
+        FOR EACH l ISA LOCATION
+          DO
+            EXCLUDE nowhere FROM nested OF l.
+            IF COUNT ISA LOCATION, AT l > 0
+              THEN
+                FOR EACH x ISA LOCATION, AT l
+                  DO
+                    INCLUDE x IN nested OF l.
+                END FOR.
+            END IF.
+        END FOR.
 
-				FOR EACH s1 ISA SITE
-					DO 
-						LOCATE s1 AT outdoor.
-				END FOR.
+        FOR EACH l ISA LOCATION
+          DO
+              IF l <> my_game AND l <> nowhere
+              THEN LOCATE l AT my_game.
+            END IF.
+        END FOR.
 
-				FOR EACH l ISA LOCATION 
-					DO
-  					IF nested OF l <> {} AND l <> my_game AND l <> nowhere
-						THEN
-    			   				FOR EACH x ISA LOCATION, IN nested OF l 
-								DO
-									IF l <> my_game AND x <> my_game
-      									THEN LOCATE x AT l.
-									END IF.	
-    							END FOR.
-  			 		END IF.
-				END FOR.
-	
-						
+        FOR EACH r1 ISA ROOM
+          DO
+            LOCATE r1 AT indoor.
+        END FOR.
 
--- We ensure that the 'visited' and 'described' attributes of the starting location 
+        FOR EACH s1 ISA SITE
+          DO
+            LOCATE s1 AT outdoor.
+        END FOR.
+
+        FOR EACH l ISA LOCATION
+          DO
+            IF nested OF l <> {} AND l <> my_game AND l <> nowhere
+            THEN
+                    FOR EACH x ISA LOCATION, IN nested OF l
+                DO
+                  IF l <> my_game AND x <> my_game
+                        THEN LOCATE x AT l.
+                  END IF.
+                  END FOR.
+            END IF.
+        END FOR.
+
+
+
+-- We ensure that the 'visited' and 'described' attributes of the starting location
 -- are correct at the start of the game:
 
-		SET visited OF location OF hero TO 1.
- 		SET described OF location OF hero TO 1.
-		
-		
+    SET visited OF location OF hero TO 1.
+    SET described OF location OF hero TO 1.
+
+
 
 
 -- Finally, for restricted actions, we implement the following attributes, corresponding to the library verbs.
-	-- If you change any of these to CAN NOT..., for examle "CAN NOT attack.", that verb, together with its
-	-- synonyms, is disabled in-game. The restricted_response of the my_game instance (by default "You can't
-	--- do that.") will be shown instead. The restriced_response is defined further up this file.
+  -- If you change any of these to CAN NOT..., for examle "CAN NOT attack.", that verb, together with its
+  -- synonyms, is disabled in-game. The restricted_response of the my_game instance (by default "You can't
+  --- do that.") will be shown instead. The restriced_response is defined further up this file.
 
 
 
-	CAN about.       
-	CAN 'again'.
-	CAN answer.      -- (+ reply)                                       
-	CAN ask.         -- (+ enquire, inquire, interrogate)               
-	CAN ask_for.                                                     
-	CAN attack.      -- (+ beat, fight, hit, punch)                     
-	CAN attack_with.                                                 
-	CAN bite.        -- (+ chew)		                                  
-	CAN break.       -- (+ destroy)                                     
-	CAN break_with.                                                  
-	CAN 'brief'.                                                       
-	CAN burn.                                                        
-	CAN burn_with.                                                   
-	CAN buy.         -- (+ purchase)                                    			
-	CAN catch.                                                                                
-	CAN clean.       -- (+ polish, wipe)                                                        
-	CAN climb.                                                                                 
-	CAN climb_on.                                                    						
-	CAN climb_through.                                                                
-	CAN close.       -- (+ shut)                                                                
-	CAN close_with.                                                             
-	CAN consult.                                                     			
-	CAN credits.     -- (+ acknowledgments, author, copyright)                                      					
-	CAN cut.                                                                                   
-	CAN cut_with.                                                                 
-	CAN dance.                                                       
-	CAN dig.                                                                                  
-	CAN dive.                                                        
-	CAN dive_in.                                                     
-	CAN drink.                                                       
-	CAN drive.                                                       
-	CAN drop.        -- (+ discard, dump, reject)                                               
-	CAN eat.                                                         		
-	CAN 'empty'.                                                       
-	CAN empty_in.                                                    
-	CAN empty_on.                                                    
-	CAN enter.                                                       
-	CAN examine.     -- (+ check, inspect, observe, x)                  
-	CAN 'exit'.                                                        
-	CAN extinguish.  -- (+ put out, quench)                              
-	CAN fill.                                                        			
-	CAN fill_with.                                                   			
-	CAN find.        -- (+ locate)                                                              
-	CAN fire.                                                        
-	CAN fire_at.										  
-	CAN fix.		  -- (+ mend, repair)						  					 
-	CAN follow.                                                      		
-	CAN free.        -- (+ release)                                     
-	CAN get_up.                                                      					
-	CAN get_off.                                                     
-	CAN give.                                                        
-	CAN go_to.                                                       			
-	CAN hint.        -- (+ hints)                                       
-	CAN i.   		 -- (+ inv, inventory)                                      
-	CAN jump.                                                        
-	CAN jump_in.                                                     			
-	CAN jump_on.                                                     			
-	CAN kick.                                                        
-	CAN kill.        -- (+ murder)                                      			
-	CAN kill_with.                                                   			
-	CAN kiss.        -- (+ hug, embrace)  
-	CAN knock.                              
-	CAN lie_down.                                                    
-	CAN lie_in.                                                           
-	CAN lie_on.                                                      
-	CAN lift.                                                        
-	CAN light.       -- (+ lit)                                         
-	CAN listen0.                                                     
-	CAN listen.                                                      
-	CAN lock.                                                        
-	CAN lock_with.                                                   
-	CAN 'look'.        -- (+ gaze, peek)                                  						
-	CAN look_at.                                                     
-	CAN look_behind.                                                 			
-	CAN look_in.                                                     			
-	CAN look_out_of.                                                 				
-	CAN look_through.                                                		
-	CAN look_under.                                                  			
-	CAN look_up.                                                     
-	CAN 'no'.                                                          						
-	CAN 'notify'. 
-	CAN notify_on.
-	CAN notify_off.                                            
-	CAN open.                                                                                  
-	CAN open_with.                                                               	
-	CAN 'play'.                                                                                  
-	CAN play_with.                                                   
-	CAN pour.                          
-	CAN pour_in.                                     
-	CAN pour_on.                               
-	CAN pray.                                                        
-	CAN pry.                                                         
-	CAN pry_with.                                                    
-	CAN pull.                                                        
-	CAN push.                                                        
-	CAN push_with.                                                   	
-	CAN put.         -- (+ lay, place)                                  
-	CAN put_against.									  
-	CAN put_behind.                                                 			
-	CAN put_down.                                                    
-	CAN put_in.      -- (+ insert)                                      
-	CAN put_near.                                                                  
-	CAN put_on.                                                                  
-	CAN put_under.  
-	CAN 'quit'.                                                             
-	CAN read.                                                        
-	CAN remove.										  				
-	CAN 'restart'.                                                     					
-	CAN 'restore'.                                                     		
-	CAN rub.                                                                             
-	CAN 'save'.                                                        
-	CAN 'say'.                                                          	
-	CAN say_to.                                                      
-	CAN 'score'.                                                        
-	CAN scratch.                                                                          
-	CAN 'script'.    
-	CAN script_on.
-	CAN script_off.                                                  
-	CAN search.                                                                              
-	CAN sell.                                                        
-	CAN shake.                                                                              
-	CAN shoot. -- (at)                                                  
-	CAN shoot_with.                                                  			
-	CAN shout.       -- (+ scream, yell)                                                               
-	CAN 'show'.      -- (+ reveal)                                                
-	CAN sing.                                                        						
-	CAN sip.                                                        
-	CAN sit. -- (down)                                                  
-	CAN sit_on.                                                      
-	CAN sleep.       -- (+ rest)                                        
-	CAN smell0.                                                      
-	CAN smell.                                                       
-	CAN squeeze.                                                                          
-	CAN stand. -- (up)                                                  
-	CAN stand_on.                                                    
-	CAN swim.                                                        
-	CAN swim_in.   
-	CAN switch.                                                  
-	CAN switch_on.	  			  
-	CAN switch_off.  			  
-	CAN take.        -- (+ carry, get, grab, hold, obtain)              
-	CAN take_from.   -- (+ remove from)                                 
-	CAN talk.                                                        						
-	CAN talk_to.     -- (+ speak)                                       
-	CAN taste.       -- (+ lick)                                        
-	CAN tear.        -- (+ rip)                                         
-	CAN tell.        -- (+ enlighten, inform)                           	
-	CAN think.                                                       
-	CAN think_about.                                                 
-	CAN throw.                                                       
-	CAN throw_at.                                                    	
-	CAN throw_in.                                                    
-	CAN throw_to.                                                     
-	CAN tie.                                                                                    
-	CAN tie_to.                                                                    
-	CAN touch.       -- (+ feel)
-	CAN touch_with.                                                                			
-	CAN turn.        -- (+ rotate)                                                                
-	CAN turn_on.                                                                    
-	CAN turn_off.                                                    
-	CAN undress.										  
-	CAN unlock.                                                      
-	CAN unlock_with.                                                 	
-	CAN 'use'.                                                         
-	CAN use_with.                                                    
-	CAN 'verbose'.                                                     
-	CAN 'wait'.        -- (+ z)                                           
-	CAN wear.											  
-	CAN what_am_i.                                                   	
-	CAN what_is.                                                     	
-	CAN where_am_i.                                                  
-	CAN where_is.                                                    
-	CAN who_am_i.                                                    
-	CAN who_is.
-	CAN write.
-	CAN yes.
+  CAN about.
+  CAN 'again'.
+  CAN answer.      -- (+ reply)
+  CAN ask.         -- (+ enquire, inquire, interrogate)
+  CAN ask_for.
+  CAN attack.      -- (+ beat, fight, hit, punch)
+  CAN attack_with.
+  CAN bite.        -- (+ chew)
+  CAN break.       -- (+ destroy)
+  CAN break_with.
+  CAN 'brief'.
+  CAN burn.
+  CAN burn_with.
+  CAN buy.         -- (+ purchase)
+  CAN catch.
+  CAN clean.       -- (+ polish, wipe)
+  CAN climb.
+  CAN climb_on.
+  CAN climb_through.
+  CAN close.       -- (+ shut)
+  CAN close_with.
+  CAN consult.
+  CAN credits.     -- (+ acknowledgments, author, copyright)
+  CAN cut.
+  CAN cut_with.
+  CAN dance.
+  CAN dig.
+  CAN dive.
+  CAN dive_in.
+  CAN drink.
+  CAN drive.
+  CAN drop.        -- (+ discard, dump, reject)
+  CAN eat.
+  CAN 'empty'.
+  CAN empty_in.
+  CAN empty_on.
+  CAN enter.
+  CAN examine.     -- (+ check, inspect, observe, x)
+  CAN 'exit'.
+  CAN extinguish.  -- (+ put out, quench)
+  CAN fill.
+  CAN fill_with.
+  CAN find.        -- (+ locate)
+  CAN fire.
+  CAN fire_at.
+  CAN fix.      -- (+ mend, repair)
+  CAN follow.
+  CAN free.        -- (+ release)
+  CAN get_up.
+  CAN get_off.
+  CAN give.
+  CAN go_to.
+  CAN hint.        -- (+ hints)
+  CAN i.       -- (+ inv, inventory)
+  CAN jump.
+  CAN jump_in.
+  CAN jump_on.
+  CAN kick.
+  CAN kill.        -- (+ murder)
+  CAN kill_with.
+  CAN kiss.        -- (+ hug, embrace)
+  CAN knock.
+  CAN lie_down.
+  CAN lie_in.
+  CAN lie_on.
+  CAN lift.
+  CAN light.       -- (+ lit)
+  CAN listen0.
+  CAN listen.
+  CAN lock.
+  CAN lock_with.
+  CAN 'look'.        -- (+ gaze, peek)
+  CAN look_at.
+  CAN look_behind.
+  CAN look_in.
+  CAN look_out_of.
+  CAN look_through.
+  CAN look_under.
+  CAN look_up.
+  CAN 'no'.
+  CAN 'notify'.
+  CAN notify_on.
+  CAN notify_off.
+  CAN open.
+  CAN open_with.
+  CAN 'play'.
+  CAN play_with.
+  CAN pour.
+  CAN pour_in.
+  CAN pour_on.
+  CAN pray.
+  CAN pry.
+  CAN pry_with.
+  CAN pull.
+  CAN push.
+  CAN push_with.
+  CAN put.         -- (+ lay, place)
+  CAN put_against.
+  CAN put_behind.
+  CAN put_down.
+  CAN put_in.      -- (+ insert)
+  CAN put_near.
+  CAN put_on.
+  CAN put_under.
+  CAN 'quit'.
+  CAN read.
+  CAN remove.
+  CAN 'restart'.
+  CAN 'restore'.
+  CAN rub.
+  CAN 'save'.
+  CAN 'say'.
+  CAN say_to.
+  CAN 'score'.
+  CAN scratch.
+  CAN 'script'.
+  CAN script_on.
+  CAN script_off.
+  CAN search.
+  CAN sell.
+  CAN shake.
+  CAN shoot. -- (at)
+  CAN shoot_with.
+  CAN shout.       -- (+ scream, yell)
+  CAN 'show'.      -- (+ reveal)
+  CAN sing.
+  CAN sip.
+  CAN sit. -- (down)
+  CAN sit_on.
+  CAN sleep.       -- (+ rest)
+  CAN smell0.
+  CAN smell.
+  CAN squeeze.
+  CAN stand. -- (up)
+  CAN stand_on.
+  CAN swim.
+  CAN swim_in.
+  CAN switch.
+  CAN switch_on.
+  CAN switch_off.
+  CAN take.        -- (+ carry, get, grab, hold, obtain)
+  CAN take_from.   -- (+ remove from)
+  CAN talk.
+  CAN talk_to.     -- (+ speak)
+  CAN taste.       -- (+ lick)
+  CAN tear.        -- (+ rip)
+  CAN tell.        -- (+ enlighten, inform)
+  CAN think.
+  CAN think_about.
+  CAN throw.
+  CAN throw_at.
+  CAN throw_in.
+  CAN throw_to.
+  CAN tie.
+  CAN tie_to.
+  CAN touch.       -- (+ feel)
+  CAN touch_with.
+  CAN turn.        -- (+ rotate)
+  CAN turn_on.
+  CAN turn_off.
+  CAN undress.
+  CAN unlock.
+  CAN unlock_with.
+  CAN 'use'.
+  CAN use_with.
+  CAN 'verbose'.
+  CAN 'wait'.        -- (+ z)
+  CAN wear.
+  CAN what_am_i.
+  CAN what_is.
+  CAN where_am_i.
+  CAN where_is.
+  CAN who_am_i.
+  CAN who_is.
+  CAN write.
+  CAN yes.
 
 
 END EVERY.
@@ -854,751 +854,751 @@ END EVERY.
 
 EVENT check_restriction
 
-IF restricted_level OF my_game = 0		-- all verbs work normally
-	THEN    
+IF restricted_level OF my_game = 0    -- all verbs work normally
+  THEN
 
-	MAKE my_game about.       
-	MAKE my_game 'again'.
-	MAKE my_game answer.      -- (+ reply)                                       
-	MAKE my_game ask.         -- (+ enquire, inquire, interrogate)               
-	MAKE my_game ask_for.                                                     
-	MAKE my_game attack.      -- (+ beat, fight, hit, punch)                     
-	MAKE my_game attack_with.                                                 
-	MAKE my_game bite.        -- (+ chew)		                                  
-	MAKE my_game break.       -- (+ destroy)                                     
-	MAKE my_game break_with.                                                  
-	MAKE my_game 'brief'.                                                       
-	MAKE my_game burn.                                                        
-	MAKE my_game burn_with.                                                   
-	MAKE my_game buy.         -- (+ purchase)                                    			
-	MAKE my_game catch.                                                                                
-	MAKE my_game clean.       -- (+ polish, wipe)                                                        
-	MAKE my_game climb.                                                                                 
-	MAKE my_game climb_on.                                                    						
-	MAKE my_game climb_through.                                                                
-	MAKE my_game close.       -- (+ shut)                                                                
-	MAKE my_game close_with.                                                             
-	MAKE my_game consult.                                                     			
-	MAKE my_game credits.     -- (+ acknowledgments, author, copyright)                                      					
-	MAKE my_game cut.                                                                                   
-	MAKE my_game cut_with.                                                                 
-	MAKE my_game dance.                                                       
-	MAKE my_game dig.                                                                                  
-	MAKE my_game dive.                                                        
-	MAKE my_game dive_in.                                                     
-	MAKE my_game drink.                                                       
-	MAKE my_game drive.                                                       
-	MAKE my_game drop.        -- (+ discard, dump, reject)                                               
-	MAKE my_game eat.                                                         		
-	MAKE my_game 'empty'.                                                       
-	MAKE my_game empty_in.                                                    
-	MAKE my_game empty_on.                                                    
-	MAKE my_game enter.                                                       
-	MAKE my_game examine.     -- (+ check, inspect, observe, x)                  
-	MAKE my_game 'exit'.                                                        
-	MAKE my_game extinguish.  -- (+ put out, quench)                              
-	MAKE my_game fill.                                                        			
-	MAKE my_game fill_with.                                                   			
-	MAKE my_game find.        -- (+ locate)                                                              
-	MAKE my_game fire.                                                        
-	MAKE my_game fire_at.										  
-	MAKE my_game fix.		  -- (+ mend, repair)						  					 
-	MAKE my_game follow.                                                      		
-	MAKE my_game free.        -- (+ release)                                     
-	MAKE my_game get_up.                                                      					
-	MAKE my_game get_off.                                                     
-	MAKE my_game give.                                                        
-	MAKE my_game go_to.                                                       			
-	MAKE my_game hint.        -- (+ hints)                                       
-	MAKE my_game i.   		 -- (+ inv, inventory)                                      
-	MAKE my_game jump.                                                        
-	MAKE my_game jump_in.                                                     			
-	MAKE my_game jump_on.                                                     			
-	MAKE my_game kick.                                                        
-	MAKE my_game kill.        -- (+ murder)                                      			
-	MAKE my_game kill_with.                                                   			
-	MAKE my_game kiss.        -- (+ hug, embrace)  
-	MAKE my_game knock.                              
-	MAKE my_game lie_down.                                                    
-	MAKE my_game lie_in.                                                           
-	MAKE my_game lie_on.                                                      
-	MAKE my_game lift.                                                        
-	MAKE my_game light.       -- (+ lit)                                         
-	MAKE my_game listen0.                                                     
-	MAKE my_game listen.                                                      
-	MAKE my_game lock.                                                        
-	MAKE my_game lock_with.                                                   
-	MAKE my_game 'look'.        -- (+ gaze, peek)                                  						
-	MAKE my_game look_at.                                                     
-	MAKE my_game look_behind.                                                 			
-	MAKE my_game look_in.                                                     			
-	MAKE my_game look_out_of.                                                 				
-	MAKE my_game look_through.                                                		
-	MAKE my_game look_under.                                                  			
-	MAKE my_game look_up.                                                     
-	MAKE my_game 'no'.                                                          						
-	MAKE my_game 'notify'. 
-	MAKE my_game notify_on.
-	MAKE my_game notify_off.                                            
-	MAKE my_game open.                                                                                  
-	MAKE my_game open_with.                                                               	
-	MAKE my_game 'play'.                                                                                  
-	MAKE my_game play_with.                                                   
-	MAKE my_game pour.                          
-	MAKE my_game pour_in.                                     
-	MAKE my_game pour_on.                               
-	MAKE my_game pray.                                                        
-	MAKE my_game pry.                                                         
-	MAKE my_game pry_with.                                                    
-	MAKE my_game pull.                                                        
-	MAKE my_game push.                                                        
-	MAKE my_game push_with.                                                   	
-	MAKE my_game put.         -- (+ lay, place)                                  
-	MAKE my_game put_against.									  
-	MAKE my_game put_behind.                                                 			
-	MAKE my_game put_down.                                                    
-	MAKE my_game put_in.      -- (+ insert)                                      
-	MAKE my_game put_near.                                                                  
-	MAKE my_game put_on.                                                                  
-	MAKE my_game put_under.  
-	MAKE my_game 'quit'.                                                             
-	MAKE my_game read.                                                        
-	MAKE my_game remove.										  				
-	MAKE my_game 'restart'.                                                     					
-	MAKE my_game 'restore'.                                                     		
-	MAKE my_game rub.                                                                             
-	MAKE my_game 'save'.                                                        
-	MAKE my_game 'say'.                                                          	
-	MAKE my_game say_to.                                                      
-	MAKE my_game 'score'.                                                        
-	MAKE my_game scratch.                                                                          
-	MAKE my_game 'script'.    
-	MAKE my_game script_on.
-	MAKE my_game script_off.                                                  
-	MAKE my_game search.                                                                              
-	MAKE my_game sell.                                                        
-	MAKE my_game shake.                                                                              
-	MAKE my_game shoot. -- (at)                                                  
-	MAKE my_game shoot_with.                                                  			
-	MAKE my_game shout.       -- (+ scream, yell)                                                               
-	MAKE my_game 'show'.      -- (+ reveal)                                                
-	MAKE my_game sing.                                                        						
-	MAKE my_game sip.                                                        
-	MAKE my_game sit. -- (down)                                                  
-	MAKE my_game sit_on.                                                      
-	MAKE my_game sleep.       -- (+ rest)                                        
-	MAKE my_game smell0.                                                      
-	MAKE my_game smell.                                                       
-	MAKE my_game squeeze.                                                                          
-	MAKE my_game stand. -- (up)                                                  
-	MAKE my_game stand_on.                                                    
-	MAKE my_game swim.                                                        
-	MAKE my_game swim_in.   
-	MAKE my_game switch.                                                  
-	MAKE my_game switch_on.	  			  
-	MAKE my_game switch_off.  			  
-	MAKE my_game take.        -- (+ carry, get, grab, hold, obtain)              
-	MAKE my_game take_from.   -- (+ remove from)                                 
-	MAKE my_game talk.                                                        						
-	MAKE my_game talk_to.     -- (+ speak)                                       
-	MAKE my_game taste.       -- (+ lick)                                        
-	MAKE my_game tear.        -- (+ rip)                                         
-	MAKE my_game tell.        -- (+ enlighten, inform)                           	
-	MAKE my_game think.                                                       
-	MAKE my_game think_about.                                                 
-	MAKE my_game throw.                                                       
-	MAKE my_game throw_at.                                                    	
-	MAKE my_game throw_in.                                                    
-	MAKE my_game throw_to.                                                     
-	MAKE my_game tie.                                                                                    
-	MAKE my_game tie_to.                                                                    
-	MAKE my_game touch.       -- (+ feel)
-	MAKE my_game touch_with.                                                                			
-	MAKE my_game turn.        -- (+ rotate)                                                                
-	MAKE my_game turn_on.                                                                    
-	MAKE my_game turn_off.                                                    
-	MAKE my_game undress.										  
-	MAKE my_game unlock.                                                      
-	MAKE my_game unlock_with.                                                 	
-	MAKE my_game 'use'.                                                         
-	MAKE my_game use_with.                                                    
-	MAKE my_game 'verbose'.                                                     
-	MAKE my_game 'wait'.        -- (+ z)                                           
-	MAKE my_game wear.											  
-	MAKE my_game what_am_i.                                                   	
-	MAKE my_game what_is.                                                     	
-	MAKE my_game where_am_i.                                                  
-	MAKE my_game where_is.                                                    
-	MAKE my_game who_am_i.                                                    
-	MAKE my_game who_is.
-	MAKE my_game write.
-	MAKE my_game yes.
+  MAKE my_game about.
+  MAKE my_game 'again'.
+  MAKE my_game answer.      -- (+ reply)
+  MAKE my_game ask.         -- (+ enquire, inquire, interrogate)
+  MAKE my_game ask_for.
+  MAKE my_game attack.      -- (+ beat, fight, hit, punch)
+  MAKE my_game attack_with.
+  MAKE my_game bite.        -- (+ chew)
+  MAKE my_game break.       -- (+ destroy)
+  MAKE my_game break_with.
+  MAKE my_game 'brief'.
+  MAKE my_game burn.
+  MAKE my_game burn_with.
+  MAKE my_game buy.         -- (+ purchase)
+  MAKE my_game catch.
+  MAKE my_game clean.       -- (+ polish, wipe)
+  MAKE my_game climb.
+  MAKE my_game climb_on.
+  MAKE my_game climb_through.
+  MAKE my_game close.       -- (+ shut)
+  MAKE my_game close_with.
+  MAKE my_game consult.
+  MAKE my_game credits.     -- (+ acknowledgments, author, copyright)
+  MAKE my_game cut.
+  MAKE my_game cut_with.
+  MAKE my_game dance.
+  MAKE my_game dig.
+  MAKE my_game dive.
+  MAKE my_game dive_in.
+  MAKE my_game drink.
+  MAKE my_game drive.
+  MAKE my_game drop.        -- (+ discard, dump, reject)
+  MAKE my_game eat.
+  MAKE my_game 'empty'.
+  MAKE my_game empty_in.
+  MAKE my_game empty_on.
+  MAKE my_game enter.
+  MAKE my_game examine.     -- (+ check, inspect, observe, x)
+  MAKE my_game 'exit'.
+  MAKE my_game extinguish.  -- (+ put out, quench)
+  MAKE my_game fill.
+  MAKE my_game fill_with.
+  MAKE my_game find.        -- (+ locate)
+  MAKE my_game fire.
+  MAKE my_game fire_at.
+  MAKE my_game fix.     -- (+ mend, repair)
+  MAKE my_game follow.
+  MAKE my_game free.        -- (+ release)
+  MAKE my_game get_up.
+  MAKE my_game get_off.
+  MAKE my_game give.
+  MAKE my_game go_to.
+  MAKE my_game hint.        -- (+ hints)
+  MAKE my_game i.        -- (+ inv, inventory)
+  MAKE my_game jump.
+  MAKE my_game jump_in.
+  MAKE my_game jump_on.
+  MAKE my_game kick.
+  MAKE my_game kill.        -- (+ murder)
+  MAKE my_game kill_with.
+  MAKE my_game kiss.        -- (+ hug, embrace)
+  MAKE my_game knock.
+  MAKE my_game lie_down.
+  MAKE my_game lie_in.
+  MAKE my_game lie_on.
+  MAKE my_game lift.
+  MAKE my_game light.       -- (+ lit)
+  MAKE my_game listen0.
+  MAKE my_game listen.
+  MAKE my_game lock.
+  MAKE my_game lock_with.
+  MAKE my_game 'look'.        -- (+ gaze, peek)
+  MAKE my_game look_at.
+  MAKE my_game look_behind.
+  MAKE my_game look_in.
+  MAKE my_game look_out_of.
+  MAKE my_game look_through.
+  MAKE my_game look_under.
+  MAKE my_game look_up.
+  MAKE my_game 'no'.
+  MAKE my_game 'notify'.
+  MAKE my_game notify_on.
+  MAKE my_game notify_off.
+  MAKE my_game open.
+  MAKE my_game open_with.
+  MAKE my_game 'play'.
+  MAKE my_game play_with.
+  MAKE my_game pour.
+  MAKE my_game pour_in.
+  MAKE my_game pour_on.
+  MAKE my_game pray.
+  MAKE my_game pry.
+  MAKE my_game pry_with.
+  MAKE my_game pull.
+  MAKE my_game push.
+  MAKE my_game push_with.
+  MAKE my_game put.         -- (+ lay, place)
+  MAKE my_game put_against.
+  MAKE my_game put_behind.
+  MAKE my_game put_down.
+  MAKE my_game put_in.      -- (+ insert)
+  MAKE my_game put_near.
+  MAKE my_game put_on.
+  MAKE my_game put_under.
+  MAKE my_game 'quit'.
+  MAKE my_game read.
+  MAKE my_game remove.
+  MAKE my_game 'restart'.
+  MAKE my_game 'restore'.
+  MAKE my_game rub.
+  MAKE my_game 'save'.
+  MAKE my_game 'say'.
+  MAKE my_game say_to.
+  MAKE my_game 'score'.
+  MAKE my_game scratch.
+  MAKE my_game 'script'.
+  MAKE my_game script_on.
+  MAKE my_game script_off.
+  MAKE my_game search.
+  MAKE my_game sell.
+  MAKE my_game shake.
+  MAKE my_game shoot. -- (at)
+  MAKE my_game shoot_with.
+  MAKE my_game shout.       -- (+ scream, yell)
+  MAKE my_game 'show'.      -- (+ reveal)
+  MAKE my_game sing.
+  MAKE my_game sip.
+  MAKE my_game sit. -- (down)
+  MAKE my_game sit_on.
+  MAKE my_game sleep.       -- (+ rest)
+  MAKE my_game smell0.
+  MAKE my_game smell.
+  MAKE my_game squeeze.
+  MAKE my_game stand. -- (up)
+  MAKE my_game stand_on.
+  MAKE my_game swim.
+  MAKE my_game swim_in.
+  MAKE my_game switch.
+  MAKE my_game switch_on.
+  MAKE my_game switch_off.
+  MAKE my_game take.        -- (+ carry, get, grab, hold, obtain)
+  MAKE my_game take_from.   -- (+ remove from)
+  MAKE my_game talk.
+  MAKE my_game talk_to.     -- (+ speak)
+  MAKE my_game taste.       -- (+ lick)
+  MAKE my_game tear.        -- (+ rip)
+  MAKE my_game tell.        -- (+ enlighten, inform)
+  MAKE my_game think.
+  MAKE my_game think_about.
+  MAKE my_game throw.
+  MAKE my_game throw_at.
+  MAKE my_game throw_in.
+  MAKE my_game throw_to.
+  MAKE my_game tie.
+  MAKE my_game tie_to.
+  MAKE my_game touch.       -- (+ feel)
+  MAKE my_game touch_with.
+  MAKE my_game turn.        -- (+ rotate)
+  MAKE my_game turn_on.
+  MAKE my_game turn_off.
+  MAKE my_game undress.
+  MAKE my_game unlock.
+  MAKE my_game unlock_with.
+  MAKE my_game 'use'.
+  MAKE my_game use_with.
+  MAKE my_game 'verbose'.
+  MAKE my_game 'wait'.        -- (+ z)
+  MAKE my_game wear.
+  MAKE my_game what_am_i.
+  MAKE my_game what_is.
+  MAKE my_game where_am_i.
+  MAKE my_game where_is.
+  MAKE my_game who_am_i.
+  MAKE my_game who_is.
+  MAKE my_game write.
+  MAKE my_game yes.
 
 
 ELSIF restricted_level OF my_game = 1  -- communication verbs are restricted
-	THEN 
+  THEN
 
-	MAKE my_game NOT answer.
-	MAKE my_game NOT ask.
-	MAKE my_game NOT ask_for.
-	MAKE my_game NOT 'say'.                                                          	
-	MAKE my_game NOT say_to.
-	MAKE my_game NOT shout. 
-	MAKE my_game NOT sing.
-	MAKE my_game NOT tell.
+  MAKE my_game NOT answer.
+  MAKE my_game NOT ask.
+  MAKE my_game NOT ask_for.
+  MAKE my_game NOT 'say'.
+  MAKE my_game NOT say_to.
+  MAKE my_game NOT shout.
+  MAKE my_game NOT sing.
+  MAKE my_game NOT tell.
 
 
 
 
 
 ELSIF restricted_level OF my_game = 2   -- all action verbs, including communication verbs,
-								-- are restricted. Verbs like 'examine', 'look', , 'inventory, 'think'
-								-- 'wait' and sensory verbs as well as all out-of-game verbs work
-	THEN
-						   
-	MAKE my_game about.       
-	MAKE my_game 'again'.
-	MAKE my_game NOT answer.      -- (+ reply)                                       
-	MAKE my_game NOT ask.         -- (+ enquire, inquire, interrogate)               
-	MAKE my_game NOT ask_for.                                                     
-	MAKE my_game NOT attack.      -- (+ beat, fight, hit, punch)                     
-	MAKE my_game NOT attack_with.                                                 
-	MAKE my_game NOT bite.        -- (+ chew)		                                  
-	MAKE my_game NOT break.       -- (+ destroy)                                     
-	MAKE my_game NOT break_with.                                                  
-	MAKE my_game 'brief'.                                                       
-	MAKE my_game NOT burn.                                                        
-	MAKE my_game NOT burn_with.                                                   
-	MAKE my_game NOT buy.         -- (+ purchase)                                    			
-	MAKE my_game NOT catch.                                                                                
-	MAKE my_game NOT clean.       -- (+ polish, wipe)                                                        
-	MAKE my_game NOT climb.                                                                                 
-	MAKE my_game NOT climb_on.                                                    						
-	MAKE my_game NOT climb_through.                                                                
-	MAKE my_game NOT close.       -- (+ shut)                                                                
-	MAKE my_game NOT close_with.                                                             
-	MAKE my_game NOT consult.                                                     			
-	MAKE my_game credits.     -- (+ acknowledgments, author, copyright)                                      					
-	MAKE my_game NOT cut.                                                                                   
-	MAKE my_game NOT cut_with.                                                                 
-	MAKE my_game NOT dance.                                                       
-	MAKE my_game NOT dig.                                                                                  
-	MAKE my_game NOT dive.                                                        
-	MAKE my_game NOT dive_in.                                                     
-	MAKE my_game NOT drink.                                                       
-	MAKE my_game NOT drive.                                                       
-	MAKE my_game NOT drop.        -- (+ discard, dump, reject)                                               
-	MAKE my_game NOT eat.                                                         		
-	MAKE my_game NOT 'empty'.                                                       
-	MAKE my_game NOT empty_in.                                                    
-	MAKE my_game NOT empty_on.                                                    
-	MAKE my_game NOT enter.                                                       
-	MAKE my_game examine.     -- (+ check, inspect, observe, x)                  
-	MAKE my_game NOT 'exit'.                                                        
-	MAKE my_game NOT extinguish.  -- (+ put out, quench)                              
-	MAKE my_game NOT fill.                                                        			
-	MAKE my_game NOT fill_with.                                                   			
-	MAKE my_game NOT find.        -- (+ locate)                                                              
-	MAKE my_game NOT fire.                                                        
-	MAKE my_game NOT fire_at.										  
-	MAKE my_game NOT fix.		  -- (+ mend, repair)						  					 
-	MAKE my_game NOT follow.                                                      		
-	MAKE my_game NOT free.        -- (+ release)                                     
-	MAKE my_game NOT get_up.                                                      					
-	MAKE my_game NOT get_off.                                                     
-	MAKE my_game NOT give.                                                        
-	MAKE my_game NOT go_to.                                                       			
-	MAKE my_game hint.        -- (+ hints)                                       
-	MAKE my_game i.   		 -- (+ inv, inventory)                                      
-	MAKE my_game NOT jump.                                                        
-	MAKE my_game NOT jump_in.                                                     			
-	MAKE my_game NOT jump_on.                                                     			
-	MAKE my_game NOT kick.                                                        
-	MAKE my_game NOT kill.        -- (+ murder)                                      			
-	MAKE my_game NOT kill_with.                                                   			
-	MAKE my_game NOT kiss.        -- (+ hug, embrace)  
-	MAKE my_game NOT knock.                              
-	MAKE my_game NOT lie_down.                                                    
-	MAKE my_game NOT lie_in.                                                           
-	MAKE my_game NOT lie_on.                                                      
-	MAKE my_game NOT lift.                                                        
-	MAKE my_game NOT light.       -- (+ lit)                                         
-	MAKE my_game listen0.                                                     
-	MAKE my_game listen.                                                      
-	MAKE my_game NOT lock.                                                        
-	MAKE my_game NOT lock_with.                                                   
-	MAKE my_game 'look'.        -- (+ gaze, peek)                                  						
-	MAKE my_game look_at.                                                     
-	MAKE my_game look_behind.                                                 			
-	MAKE my_game look_in.                                                     			
-	MAKE my_game look_out_of.                                                 				
-	MAKE my_game look_through.                                                		
-	MAKE my_game look_under.                                                  			
-	MAKE my_game look_up.                                                     
-	MAKE my_game 'no'.                                                          						
-	MAKE my_game 'notify'. 
-	MAKE my_game notify_on.
-	MAKE my_game notify_off.                                            
-	MAKE my_game NOT open.                                                                                  
-	MAKE my_game NOT open_with.                                                               	
-	MAKE my_game NOT 'play'.                                                                                  
-	MAKE my_game NOT play_with.                                                   
-	MAKE my_game NOT pour.                          
-	MAKE my_game NOT pour_in.                                     
-	MAKE my_game NOT pour_on.                               
-	MAKE my_game pray.                                                        
-	MAKE my_game NOT pry.                                                         
-	MAKE my_game NOT pry_with.                                                    
-	MAKE my_game NOT pull.                                                        
-	MAKE my_game NOT push.                                                        
-	MAKE my_game NOT push_with.                                                   	
-	MAKE my_game NOT put.         -- (+ lay, place)                                  
-	MAKE my_game NOT put_against.									  
-	MAKE my_game NOT put_behind.                                                 			
-	MAKE my_game NOT put_down.                                                    
-	MAKE my_game NOT put_in.      -- (+ insert)                                      
-	MAKE my_game NOT put_near.                                                                  
-	MAKE my_game NOT put_on.                                                                  
-	MAKE my_game NOT put_under.  
-	MAKE my_game 'quit'.                                                             
-	MAKE my_game NOT read.                                                        
-	MAKE my_game NOT remove.										  				
-	MAKE my_game 'restart'.                                                     					
-	MAKE my_game 'restore'.                                                     		
-	MAKE my_game NOT rub.                                                                             
-	MAKE my_game 'save'.                                                        
-	MAKE my_game NOT 'say'.                                                          	
-	MAKE my_game NOT say_to.                                                      
-	MAKE my_game 'score'.                                                        
-	MAKE my_game NOT scratch.                                                                          
-	MAKE my_game 'script'.    
-	MAKE my_game script_on.
-	MAKE my_game script_off.                                                  
-	MAKE my_game NOT search.                                                                              
-	MAKE my_game NOT sell.                                                        
-	MAKE my_game NOT shake.                                                                              
-	MAKE my_game NOT shoot. -- (at)                                                  
-	MAKE my_game NOT shoot_with.                                                  			
-	MAKE my_game NOT shout.       -- (+ scream, yell)                                                               
-	MAKE my_game NOT 'show'.      -- (+ reveal)                                                
-	MAKE my_game NOT sing.                                                        						
-	MAKE my_game NOT sip.                                                        
-	MAKE my_game NOT sit. -- (down)                                                  
-	MAKE my_game NOT sit_on.                                                      
-	MAKE my_game NOT sleep.       -- (+ rest)                                        
-	MAKE my_game smell0.                                                      
-	MAKE my_game smell.                                                       
-	MAKE my_game NOT squeeze.                                                                          
-	MAKE my_game NOT stand. -- (up)                                                  
-	MAKE my_game NOT stand_on.                                                    
-	MAKE my_game NOT swim.                                                        
-	MAKE my_game NOT swim_in.   
-	MAKE my_game NOT switch.                                                  
-	MAKE my_game NOT switch_on.	  			  
-	MAKE my_game NOT switch_off.  			  
-	MAKE my_game NOT take.        -- (+ carry, get, grab, hold, obtain)              
-	MAKE my_game NOT take_from.   -- (+ remove from)                                 
-	MAKE my_game NOT talk.                                                        						
-	MAKE my_game NOT talk_to.     -- (+ speak)                                       
-	MAKE my_game NOT taste.       -- (+ lick)                                        
-	MAKE my_game NOT tear.        -- (+ rip)                                         
-	MAKE my_game NOT tell.        -- (+ enlighten, inform)                           	
-	MAKE my_game think.                                                       
-	MAKE my_game think_about.                                                 
-	MAKE my_game NOT throw.                                                       
-	MAKE my_game NOT throw_at.                                                    	
-	MAKE my_game NOT throw_in.                                                    
-	MAKE my_game NOT throw_to.                                                     
-	MAKE my_game NOT tie.                                                                                    
-	MAKE my_game NOT tie_to.                                                                    
-	MAKE my_game NOT touch.       -- (+ feel)
-	MAKE my_game NOT touch_with.                                                                			
-	MAKE my_game NOT turn.        -- (+ rotate)                                                                
-	MAKE my_game NOT turn_on.                                                                    
-	MAKE my_game NOT turn_off.                                                    
-	MAKE my_game NOT undress.										  
-	MAKE my_game NOT unlock.                                                      
-	MAKE my_game NOT unlock_with.                                                 	
-	MAKE my_game NOT 'use'.                                                         
-	MAKE my_game NOT use_with.                                                    
-	MAKE my_game 'verbose'.                                                     
-	MAKE my_game 'wait'.        -- (+ z)                                           
-	MAKE my_game NOT wear.											  
-	MAKE my_game what_am_i.                                                   	
-	MAKE my_game what_is.                                                     	
-	MAKE my_game where_am_i.                                                  
-	MAKE my_game where_is.                                                    
-	MAKE my_game who_am_i.                                                    
-	MAKE my_game who_is.
-	MAKE my_game NOT write.
-	MAKE my_game yes.
+                -- are restricted. Verbs like 'examine', 'look', , 'inventory, 'think'
+                -- 'wait' and sensory verbs as well as all out-of-game verbs work
+  THEN
+
+  MAKE my_game about.
+  MAKE my_game 'again'.
+  MAKE my_game NOT answer.      -- (+ reply)
+  MAKE my_game NOT ask.         -- (+ enquire, inquire, interrogate)
+  MAKE my_game NOT ask_for.
+  MAKE my_game NOT attack.      -- (+ beat, fight, hit, punch)
+  MAKE my_game NOT attack_with.
+  MAKE my_game NOT bite.        -- (+ chew)
+  MAKE my_game NOT break.       -- (+ destroy)
+  MAKE my_game NOT break_with.
+  MAKE my_game 'brief'.
+  MAKE my_game NOT burn.
+  MAKE my_game NOT burn_with.
+  MAKE my_game NOT buy.         -- (+ purchase)
+  MAKE my_game NOT catch.
+  MAKE my_game NOT clean.       -- (+ polish, wipe)
+  MAKE my_game NOT climb.
+  MAKE my_game NOT climb_on.
+  MAKE my_game NOT climb_through.
+  MAKE my_game NOT close.       -- (+ shut)
+  MAKE my_game NOT close_with.
+  MAKE my_game NOT consult.
+  MAKE my_game credits.     -- (+ acknowledgments, author, copyright)
+  MAKE my_game NOT cut.
+  MAKE my_game NOT cut_with.
+  MAKE my_game NOT dance.
+  MAKE my_game NOT dig.
+  MAKE my_game NOT dive.
+  MAKE my_game NOT dive_in.
+  MAKE my_game NOT drink.
+  MAKE my_game NOT drive.
+  MAKE my_game NOT drop.        -- (+ discard, dump, reject)
+  MAKE my_game NOT eat.
+  MAKE my_game NOT 'empty'.
+  MAKE my_game NOT empty_in.
+  MAKE my_game NOT empty_on.
+  MAKE my_game NOT enter.
+  MAKE my_game examine.     -- (+ check, inspect, observe, x)
+  MAKE my_game NOT 'exit'.
+  MAKE my_game NOT extinguish.  -- (+ put out, quench)
+  MAKE my_game NOT fill.
+  MAKE my_game NOT fill_with.
+  MAKE my_game NOT find.        -- (+ locate)
+  MAKE my_game NOT fire.
+  MAKE my_game NOT fire_at.
+  MAKE my_game NOT fix.     -- (+ mend, repair)
+  MAKE my_game NOT follow.
+  MAKE my_game NOT free.        -- (+ release)
+  MAKE my_game NOT get_up.
+  MAKE my_game NOT get_off.
+  MAKE my_game NOT give.
+  MAKE my_game NOT go_to.
+  MAKE my_game hint.        -- (+ hints)
+  MAKE my_game i.        -- (+ inv, inventory)
+  MAKE my_game NOT jump.
+  MAKE my_game NOT jump_in.
+  MAKE my_game NOT jump_on.
+  MAKE my_game NOT kick.
+  MAKE my_game NOT kill.        -- (+ murder)
+  MAKE my_game NOT kill_with.
+  MAKE my_game NOT kiss.        -- (+ hug, embrace)
+  MAKE my_game NOT knock.
+  MAKE my_game NOT lie_down.
+  MAKE my_game NOT lie_in.
+  MAKE my_game NOT lie_on.
+  MAKE my_game NOT lift.
+  MAKE my_game NOT light.       -- (+ lit)
+  MAKE my_game listen0.
+  MAKE my_game listen.
+  MAKE my_game NOT lock.
+  MAKE my_game NOT lock_with.
+  MAKE my_game 'look'.        -- (+ gaze, peek)
+  MAKE my_game look_at.
+  MAKE my_game look_behind.
+  MAKE my_game look_in.
+  MAKE my_game look_out_of.
+  MAKE my_game look_through.
+  MAKE my_game look_under.
+  MAKE my_game look_up.
+  MAKE my_game 'no'.
+  MAKE my_game 'notify'.
+  MAKE my_game notify_on.
+  MAKE my_game notify_off.
+  MAKE my_game NOT open.
+  MAKE my_game NOT open_with.
+  MAKE my_game NOT 'play'.
+  MAKE my_game NOT play_with.
+  MAKE my_game NOT pour.
+  MAKE my_game NOT pour_in.
+  MAKE my_game NOT pour_on.
+  MAKE my_game pray.
+  MAKE my_game NOT pry.
+  MAKE my_game NOT pry_with.
+  MAKE my_game NOT pull.
+  MAKE my_game NOT push.
+  MAKE my_game NOT push_with.
+  MAKE my_game NOT put.         -- (+ lay, place)
+  MAKE my_game NOT put_against.
+  MAKE my_game NOT put_behind.
+  MAKE my_game NOT put_down.
+  MAKE my_game NOT put_in.      -- (+ insert)
+  MAKE my_game NOT put_near.
+  MAKE my_game NOT put_on.
+  MAKE my_game NOT put_under.
+  MAKE my_game 'quit'.
+  MAKE my_game NOT read.
+  MAKE my_game NOT remove.
+  MAKE my_game 'restart'.
+  MAKE my_game 'restore'.
+  MAKE my_game NOT rub.
+  MAKE my_game 'save'.
+  MAKE my_game NOT 'say'.
+  MAKE my_game NOT say_to.
+  MAKE my_game 'score'.
+  MAKE my_game NOT scratch.
+  MAKE my_game 'script'.
+  MAKE my_game script_on.
+  MAKE my_game script_off.
+  MAKE my_game NOT search.
+  MAKE my_game NOT sell.
+  MAKE my_game NOT shake.
+  MAKE my_game NOT shoot. -- (at)
+  MAKE my_game NOT shoot_with.
+  MAKE my_game NOT shout.       -- (+ scream, yell)
+  MAKE my_game NOT 'show'.      -- (+ reveal)
+  MAKE my_game NOT sing.
+  MAKE my_game NOT sip.
+  MAKE my_game NOT sit. -- (down)
+  MAKE my_game NOT sit_on.
+  MAKE my_game NOT sleep.       -- (+ rest)
+  MAKE my_game smell0.
+  MAKE my_game smell.
+  MAKE my_game NOT squeeze.
+  MAKE my_game NOT stand. -- (up)
+  MAKE my_game NOT stand_on.
+  MAKE my_game NOT swim.
+  MAKE my_game NOT swim_in.
+  MAKE my_game NOT switch.
+  MAKE my_game NOT switch_on.
+  MAKE my_game NOT switch_off.
+  MAKE my_game NOT take.        -- (+ carry, get, grab, hold, obtain)
+  MAKE my_game NOT take_from.   -- (+ remove from)
+  MAKE my_game NOT talk.
+  MAKE my_game NOT talk_to.     -- (+ speak)
+  MAKE my_game NOT taste.       -- (+ lick)
+  MAKE my_game NOT tear.        -- (+ rip)
+  MAKE my_game NOT tell.        -- (+ enlighten, inform)
+  MAKE my_game think.
+  MAKE my_game think_about.
+  MAKE my_game NOT throw.
+  MAKE my_game NOT throw_at.
+  MAKE my_game NOT throw_in.
+  MAKE my_game NOT throw_to.
+  MAKE my_game NOT tie.
+  MAKE my_game NOT tie_to.
+  MAKE my_game NOT touch.       -- (+ feel)
+  MAKE my_game NOT touch_with.
+  MAKE my_game NOT turn.        -- (+ rotate)
+  MAKE my_game NOT turn_on.
+  MAKE my_game NOT turn_off.
+  MAKE my_game NOT undress.
+  MAKE my_game NOT unlock.
+  MAKE my_game NOT unlock_with.
+  MAKE my_game NOT 'use'.
+  MAKE my_game NOT use_with.
+  MAKE my_game 'verbose'.
+  MAKE my_game 'wait'.        -- (+ z)
+  MAKE my_game NOT wear.
+  MAKE my_game what_am_i.
+  MAKE my_game what_is.
+  MAKE my_game where_am_i.
+  MAKE my_game where_is.
+  MAKE my_game who_am_i.
+  MAKE my_game who_is.
+  MAKE my_game NOT write.
+  MAKE my_game yes.
 
 
 
 
-ELSIF restricted_level OF my_game = 3 	-- all in-game verbs are restricted, even
- 	THEN							-- 'examine', 'look' etc. Only out-of-game verbs like
-								-- 'save', 'quit' etc work.
+ELSIF restricted_level OF my_game = 3   -- all in-game verbs are restricted, even
+  THEN              -- 'examine', 'look' etc. Only out-of-game verbs like
+                -- 'save', 'quit' etc work.
 
 
-	MAKE my_game about.       
-	MAKE my_game 'again'.
-	MAKE my_game NOT answer.      -- (+ reply)                                       
-	MAKE my_game NOT ask.         -- (+ enquire, inquire, interrogate)               
-	MAKE my_game NOT ask_for.                                                     
-	MAKE my_game NOT attack.      -- (+ beat, fight, hit, punch)                     
-	MAKE my_game NOT attack_with.                                                 
-	MAKE my_game NOT bite.        -- (+ chew)		                                  
-	MAKE my_game NOT break.       -- (+ destroy)                                     
-	MAKE my_game NOT break_with.                                                  
-	MAKE my_game 'brief'.                                                       
-	MAKE my_game NOT burn.                                                        
-	MAKE my_game NOT burn_with.                                                   
-	MAKE my_game NOT buy.         -- (+ purchase)                                    			
-	MAKE my_game NOT catch.                                                                                
-	MAKE my_game NOT clean.       -- (+ polish, wipe)                                                        
-	MAKE my_game NOT climb.                                                                                 
-	MAKE my_game NOT climb_on.                                                    						
-	MAKE my_game NOT climb_through.                                                                
-	MAKE my_game NOT close.       -- (+ shut)                                                                
-	MAKE my_game NOT close_with.                                                             
-	MAKE my_game NOT consult.                                                     			
-	MAKE my_game credits.     -- (+ acknowledgments, author, copyright)                                      					
-	MAKE my_game NOT cut.                                                                                   
-	MAKE my_game NOT cut_with.                                                                 
-	MAKE my_game NOT dance.                                                       
-	MAKE my_game NOT dig.                                                                                  
-	MAKE my_game NOT dive.                                                        
-	MAKE my_game NOT dive_in.                                                     
-	MAKE my_game NOT drink.                                                       
-	MAKE my_game NOT drive.                                                       
-	MAKE my_game NOT drop.        -- (+ discard, dump, reject)                                               
-	MAKE my_game NOT eat.                                                         		
-	MAKE my_game NOT 'empty'.                                                       
-	MAKE my_game NOT empty_in.                                                    
-	MAKE my_game NOT empty_on.                                                    
-	MAKE my_game NOT enter.                                                       
-	MAKE my_game NOT examine.     -- (+ check, inspect, observe, x)                  
-	MAKE my_game NOT 'exit'.                                                        
-	MAKE my_game NOT extinguish.  -- (+ put out, quench)                              
-	MAKE my_game NOT fill.                                                        			
-	MAKE my_game NOT fill_with.                                                   			
-	MAKE my_game NOT find.        -- (+ locate)                                                              
-	MAKE my_game NOT fire.                                                        
-	MAKE my_game NOT fire_at.										  
-	MAKE my_game NOT fix.		  -- (+ mend, repair)						  					 
-	MAKE my_game NOT follow.                                                      		
-	MAKE my_game NOT free.        -- (+ release)                                     
-	MAKE my_game NOT get_up.                                                      					
-	MAKE my_game NOT get_off.                                                     
-	MAKE my_game NOT give.                                                        
-	MAKE my_game NOT go_to.                                                       			
-	MAKE my_game hint.        -- (+ hints)                                       
-	MAKE my_game NOT i.   		 -- (+ inv, inventory)                                      
-	MAKE my_game NOT jump.                                                        
-	MAKE my_game NOT jump_in.                                                     			
-	MAKE my_game NOT jump_on.                                                     			
-	MAKE my_game NOT kick.                                                        
-	MAKE my_game NOT kill.        -- (+ murder)                                      			
-	MAKE my_game NOT kill_with.                                                   			
-	MAKE my_game NOT kiss.        -- (+ hug, embrace)  
-	MAKE my_game NOT knock.                              
-	MAKE my_game NOT lie_down.                                                    
-	MAKE my_game NOT lie_in.                                                           
-	MAKE my_game NOT lie_on.                                                      
-	MAKE my_game NOT lift.                                                        
-	MAKE my_game NOT light.       -- (+ lit)                                         
-	MAKE my_game NOT listen0.                                                     
-	MAKE my_game NOT listen.                                                      
-	MAKE my_game NOT lock.                                                        
-	MAKE my_game NOT lock_with.                                                   
-	MAKE my_game NOT 'look'.        -- (+ gaze, peek)                                  						
-	MAKE my_game NOT look_at.                                                     
-	MAKE my_game NOT look_behind.                                                 			
-	MAKE my_game NOT look_in.                                                     			
-	MAKE my_game NOT look_out_of.                                                 				
-	MAKE my_game NOT look_through.                                                		
-	MAKE my_game NOT look_under.                                                  			
-	MAKE my_game NOT look_up.                                                     
-	MAKE my_game 'no'.                                                          						
-	MAKE my_game 'notify'. 
-	MAKE my_game notify_on.
-	MAKE my_game notify_off.                                            
-	MAKE my_game NOT open.                                                                                  
-	MAKE my_game NOT open_with.                                                               	
-	MAKE my_game NOT 'play'.                                                                                  
-	MAKE my_game NOT play_with.                                                   
-	MAKE my_game NOT pour.                          
-	MAKE my_game NOT pour_in.                                     
-	MAKE my_game NOT pour_on.                               
-	MAKE my_game NOT pray.                                                        
-	MAKE my_game NOT pry.                                                         
-	MAKE my_game NOT pry_with.                                                    
-	MAKE my_game NOT pull.                                                        
-	MAKE my_game NOT push.                                                        
-	MAKE my_game NOT push_with.                                                   	
-	MAKE my_game NOT put.         -- (+ lay, place)                                  
-	MAKE my_game NOT put_against.									  
-	MAKE my_game NOT put_behind.                                                 			
-	MAKE my_game NOT put_down.                                                    
-	MAKE my_game NOT put_in.      -- (+ insert)                                      
-	MAKE my_game NOT put_near.                                                                  
-	MAKE my_game NOT put_on.                                                                  
-	MAKE my_game NOT put_under.  
-	MAKE my_game 'quit'.                                                             
-	MAKE my_game NOT read.                                                        
-	MAKE my_game NOT remove.										  				
-	MAKE my_game 'restart'.                                                     					
-	MAKE my_game 'restore'.                                                     		
-	MAKE my_game NOT rub.                                                                             
-	MAKE my_game 'save'.                                                        
-	MAKE my_game NOT 'say'.                                                          	
-	MAKE my_game NOT say_to.                                                      
-	MAKE my_game 'score'.                                                        
-	MAKE my_game NOT scratch.                                                                          
-	MAKE my_game 'script'.    
-	MAKE my_game script_on.
-	MAKE my_game script_off.                                                  
-	MAKE my_game NOT search.                                                                              
-	MAKE my_game NOT sell.                                                        
-	MAKE my_game NOT shake.                                                                              
-	MAKE my_game NOT shoot. -- (at)                                                  
-	MAKE my_game NOT shoot_with.                                                  			
-	MAKE my_game NOT shout.       -- (+ scream, yell)                                                               
-	MAKE my_game NOT 'show'.      -- (+ reveal)                                                
-	MAKE my_game NOT sing.                                                        						
-	MAKE my_game NOT sip.                                                        
-	MAKE my_game NOT sit. -- (down)                                                  
-	MAKE my_game NOT sit_on.                                                      
-	MAKE my_game NOT sleep.       -- (+ rest)                                        
-	MAKE my_game NOT smell0.                                                      
-	MAKE my_game NOT smell.                                                       
-	MAKE my_game NOT squeeze.                                                                          
-	MAKE my_game NOT stand. -- (up)                                                  
-	MAKE my_game NOT stand_on.                                                    
-	MAKE my_game NOT swim.                                                        
-	MAKE my_game NOT swim_in.   
-	MAKE my_game NOT switch.                                                  
-	MAKE my_game NOT switch_on.	  			  
-	MAKE my_game NOT switch_off.  			  
-	MAKE my_game NOT take.        -- (+ carry, get, grab, hold, obtain)              
-	MAKE my_game NOT take_from.   -- (+ remove from)                                 
-	MAKE my_game NOT talk.                                                        						
-	MAKE my_game NOT talk_to.     -- (+ speak)                                       
-	MAKE my_game NOT taste.       -- (+ lick)                                        
-	MAKE my_game NOT tear.        -- (+ rip)                                         
-	MAKE my_game NOT tell.        -- (+ enlighten, inform)                           	
-	MAKE my_game NOT think.                                                       
-	MAKE my_game NOT think_about.                                                 
-	MAKE my_game NOT throw.                                                       
-	MAKE my_game NOT throw_at.                                                    	
-	MAKE my_game NOT throw_in.                                                    
-	MAKE my_game NOT throw_to.                                                     
-	MAKE my_game NOT tie.                                                                                    
-	MAKE my_game NOT tie_to.                                                                    
-	MAKE my_game NOT touch.       -- (+ feel)
-	MAKE my_game NOT touch_with.                                                                			
-	MAKE my_game NOT turn.        -- (+ rotate)                                                                
-	MAKE my_game NOT turn_on.                                                                    
-	MAKE my_game NOT turn_off.                                                    
-	MAKE my_game NOT undress.										  
-	MAKE my_game NOT unlock.                                                      
-	MAKE my_game NOT unlock_with.                                                 	
-	MAKE my_game NOT 'use'.                                                         
-	MAKE my_game NOT use_with.                                                    
-	MAKE my_game 'verbose'.                                                     
-	MAKE my_game NOT 'wait'.        -- (+ z)                                           
-	MAKE my_game NOT wear.											  
-	MAKE my_game NOT what_am_i.                                                   	
-	MAKE my_game NOT what_is.                                                     	
-	MAKE my_game NOT where_am_i.                                                  
-	MAKE my_game NOT where_is.                                                    
-	MAKE my_game NOT who_am_i.                                                    
-	MAKE my_game NOT who_is.
-	MAKE my_game NOT write.
-	MAKE my_game yes.
-	
+  MAKE my_game about.
+  MAKE my_game 'again'.
+  MAKE my_game NOT answer.      -- (+ reply)
+  MAKE my_game NOT ask.         -- (+ enquire, inquire, interrogate)
+  MAKE my_game NOT ask_for.
+  MAKE my_game NOT attack.      -- (+ beat, fight, hit, punch)
+  MAKE my_game NOT attack_with.
+  MAKE my_game NOT bite.        -- (+ chew)
+  MAKE my_game NOT break.       -- (+ destroy)
+  MAKE my_game NOT break_with.
+  MAKE my_game 'brief'.
+  MAKE my_game NOT burn.
+  MAKE my_game NOT burn_with.
+  MAKE my_game NOT buy.         -- (+ purchase)
+  MAKE my_game NOT catch.
+  MAKE my_game NOT clean.       -- (+ polish, wipe)
+  MAKE my_game NOT climb.
+  MAKE my_game NOT climb_on.
+  MAKE my_game NOT climb_through.
+  MAKE my_game NOT close.       -- (+ shut)
+  MAKE my_game NOT close_with.
+  MAKE my_game NOT consult.
+  MAKE my_game credits.     -- (+ acknowledgments, author, copyright)
+  MAKE my_game NOT cut.
+  MAKE my_game NOT cut_with.
+  MAKE my_game NOT dance.
+  MAKE my_game NOT dig.
+  MAKE my_game NOT dive.
+  MAKE my_game NOT dive_in.
+  MAKE my_game NOT drink.
+  MAKE my_game NOT drive.
+  MAKE my_game NOT drop.        -- (+ discard, dump, reject)
+  MAKE my_game NOT eat.
+  MAKE my_game NOT 'empty'.
+  MAKE my_game NOT empty_in.
+  MAKE my_game NOT empty_on.
+  MAKE my_game NOT enter.
+  MAKE my_game NOT examine.     -- (+ check, inspect, observe, x)
+  MAKE my_game NOT 'exit'.
+  MAKE my_game NOT extinguish.  -- (+ put out, quench)
+  MAKE my_game NOT fill.
+  MAKE my_game NOT fill_with.
+  MAKE my_game NOT find.        -- (+ locate)
+  MAKE my_game NOT fire.
+  MAKE my_game NOT fire_at.
+  MAKE my_game NOT fix.     -- (+ mend, repair)
+  MAKE my_game NOT follow.
+  MAKE my_game NOT free.        -- (+ release)
+  MAKE my_game NOT get_up.
+  MAKE my_game NOT get_off.
+  MAKE my_game NOT give.
+  MAKE my_game NOT go_to.
+  MAKE my_game hint.        -- (+ hints)
+  MAKE my_game NOT i.        -- (+ inv, inventory)
+  MAKE my_game NOT jump.
+  MAKE my_game NOT jump_in.
+  MAKE my_game NOT jump_on.
+  MAKE my_game NOT kick.
+  MAKE my_game NOT kill.        -- (+ murder)
+  MAKE my_game NOT kill_with.
+  MAKE my_game NOT kiss.        -- (+ hug, embrace)
+  MAKE my_game NOT knock.
+  MAKE my_game NOT lie_down.
+  MAKE my_game NOT lie_in.
+  MAKE my_game NOT lie_on.
+  MAKE my_game NOT lift.
+  MAKE my_game NOT light.       -- (+ lit)
+  MAKE my_game NOT listen0.
+  MAKE my_game NOT listen.
+  MAKE my_game NOT lock.
+  MAKE my_game NOT lock_with.
+  MAKE my_game NOT 'look'.        -- (+ gaze, peek)
+  MAKE my_game NOT look_at.
+  MAKE my_game NOT look_behind.
+  MAKE my_game NOT look_in.
+  MAKE my_game NOT look_out_of.
+  MAKE my_game NOT look_through.
+  MAKE my_game NOT look_under.
+  MAKE my_game NOT look_up.
+  MAKE my_game 'no'.
+  MAKE my_game 'notify'.
+  MAKE my_game notify_on.
+  MAKE my_game notify_off.
+  MAKE my_game NOT open.
+  MAKE my_game NOT open_with.
+  MAKE my_game NOT 'play'.
+  MAKE my_game NOT play_with.
+  MAKE my_game NOT pour.
+  MAKE my_game NOT pour_in.
+  MAKE my_game NOT pour_on.
+  MAKE my_game NOT pray.
+  MAKE my_game NOT pry.
+  MAKE my_game NOT pry_with.
+  MAKE my_game NOT pull.
+  MAKE my_game NOT push.
+  MAKE my_game NOT push_with.
+  MAKE my_game NOT put.         -- (+ lay, place)
+  MAKE my_game NOT put_against.
+  MAKE my_game NOT put_behind.
+  MAKE my_game NOT put_down.
+  MAKE my_game NOT put_in.      -- (+ insert)
+  MAKE my_game NOT put_near.
+  MAKE my_game NOT put_on.
+  MAKE my_game NOT put_under.
+  MAKE my_game 'quit'.
+  MAKE my_game NOT read.
+  MAKE my_game NOT remove.
+  MAKE my_game 'restart'.
+  MAKE my_game 'restore'.
+  MAKE my_game NOT rub.
+  MAKE my_game 'save'.
+  MAKE my_game NOT 'say'.
+  MAKE my_game NOT say_to.
+  MAKE my_game 'score'.
+  MAKE my_game NOT scratch.
+  MAKE my_game 'script'.
+  MAKE my_game script_on.
+  MAKE my_game script_off.
+  MAKE my_game NOT search.
+  MAKE my_game NOT sell.
+  MAKE my_game NOT shake.
+  MAKE my_game NOT shoot. -- (at)
+  MAKE my_game NOT shoot_with.
+  MAKE my_game NOT shout.       -- (+ scream, yell)
+  MAKE my_game NOT 'show'.      -- (+ reveal)
+  MAKE my_game NOT sing.
+  MAKE my_game NOT sip.
+  MAKE my_game NOT sit. -- (down)
+  MAKE my_game NOT sit_on.
+  MAKE my_game NOT sleep.       -- (+ rest)
+  MAKE my_game NOT smell0.
+  MAKE my_game NOT smell.
+  MAKE my_game NOT squeeze.
+  MAKE my_game NOT stand. -- (up)
+  MAKE my_game NOT stand_on.
+  MAKE my_game NOT swim.
+  MAKE my_game NOT swim_in.
+  MAKE my_game NOT switch.
+  MAKE my_game NOT switch_on.
+  MAKE my_game NOT switch_off.
+  MAKE my_game NOT take.        -- (+ carry, get, grab, hold, obtain)
+  MAKE my_game NOT take_from.   -- (+ remove from)
+  MAKE my_game NOT talk.
+  MAKE my_game NOT talk_to.     -- (+ speak)
+  MAKE my_game NOT taste.       -- (+ lick)
+  MAKE my_game NOT tear.        -- (+ rip)
+  MAKE my_game NOT tell.        -- (+ enlighten, inform)
+  MAKE my_game NOT think.
+  MAKE my_game NOT think_about.
+  MAKE my_game NOT throw.
+  MAKE my_game NOT throw_at.
+  MAKE my_game NOT throw_in.
+  MAKE my_game NOT throw_to.
+  MAKE my_game NOT tie.
+  MAKE my_game NOT tie_to.
+  MAKE my_game NOT touch.       -- (+ feel)
+  MAKE my_game NOT touch_with.
+  MAKE my_game NOT turn.        -- (+ rotate)
+  MAKE my_game NOT turn_on.
+  MAKE my_game NOT turn_off.
+  MAKE my_game NOT undress.
+  MAKE my_game NOT unlock.
+  MAKE my_game NOT unlock_with.
+  MAKE my_game NOT 'use'.
+  MAKE my_game NOT use_with.
+  MAKE my_game 'verbose'.
+  MAKE my_game NOT 'wait'.        -- (+ z)
+  MAKE my_game NOT wear.
+  MAKE my_game NOT what_am_i.
+  MAKE my_game NOT what_is.
+  MAKE my_game NOT where_am_i.
+  MAKE my_game NOT where_is.
+  MAKE my_game NOT who_am_i.
+  MAKE my_game NOT who_is.
+  MAKE my_game NOT write.
+  MAKE my_game yes.
 
-ELSIF restricted_level OF my_game = 4		-- the strictest level of restriction; 
-								-- no verbs work, not even out-of-game verbs 
-	THEN							-- like 'save' and 'quit'.
 
-	MAKE my_game NOT about.       
-	MAKE my_game NOT 'again'.
-	MAKE my_game NOT answer.      -- (+ reply)                                       
-	MAKE my_game NOT ask.         -- (+ enquire, inquire, interrogate)               
-	MAKE my_game NOT ask_for.                                                     
-	MAKE my_game NOT attack.      -- (+ beat, fight, hit, punch)                     
-	MAKE my_game NOT attack_with.                                                 
-	MAKE my_game NOT bite.        -- (+ chew)		                                  
-	MAKE my_game NOT break.       -- (+ destroy)                                     
-	MAKE my_game NOT break_with.                                                  
-	MAKE my_game NOT 'brief'.                                                       
-	MAKE my_game NOT burn.                                                        
-	MAKE my_game NOT burn_with.                                                   
-	MAKE my_game NOT buy.         -- (+ purchase)                                    			
-	MAKE my_game NOT catch.                                                                                
-	MAKE my_game NOT clean.       -- (+ polish, wipe)                                                        
-	MAKE my_game NOT climb.                                                                                 
-	MAKE my_game NOT climb_on.                                                    						
-	MAKE my_game NOT climb_through.                                                                
-	MAKE my_game NOT close.       -- (+ shut)                                                                
-	MAKE my_game NOT close_with.                                                             
-	MAKE my_game NOT consult.                                                     			
-	MAKE my_game NOT credits.     -- (+ acknowledgments, author, copyright)                                      					
-	MAKE my_game NOT cut.                                                                                   
-	MAKE my_game NOT cut_with.                                                                 
-	MAKE my_game NOT dance.                                                       
-	MAKE my_game NOT dig.                                                                                  
-	MAKE my_game NOT dive.                                                        
-	MAKE my_game NOT dive_in.                                                     
-	MAKE my_game NOT drink.                                                       
-	MAKE my_game NOT drive.                                                       
-	MAKE my_game NOT drop.        -- (+ discard, dump, reject)                                               
-	MAKE my_game NOT eat.                                                         		
-	MAKE my_game NOT 'empty'.                                                       
-	MAKE my_game NOT empty_in.                                                    
-	MAKE my_game NOT empty_on.                                                    
-	MAKE my_game NOT enter.                                                       
-	MAKE my_game NOT examine.     -- (+ check, inspect, observe, x)                  
-	MAKE my_game NOT 'exit'.                                                        
-	MAKE my_game NOT extinguish.  -- (+ put out, quench)                              
-	MAKE my_game NOT fill.                                                        			
-	MAKE my_game NOT fill_with.                                                   			
-	MAKE my_game NOT find.        -- (+ locate)                                                              
-	MAKE my_game NOT fire.                                                        
-	MAKE my_game NOT fire_at.										  
-	MAKE my_game NOT fix.		  -- (+ mend, repair)						  					 
-	MAKE my_game NOT follow.                                                      		
-	MAKE my_game NOT free.        -- (+ release)                                     
-	MAKE my_game NOT get_up.                                                      					
-	MAKE my_game NOT get_off.                                                     
-	MAKE my_game NOT give.                                                        
-	MAKE my_game NOT go_to.                                                       			
-	MAKE my_game NOT hint.        -- (+ hints)                                       
-	MAKE my_game NOT i.   		 -- (+ inv, inventory)                                      
-	MAKE my_game NOT jump.                                                        
-	MAKE my_game NOT jump_in.                                                     			
-	MAKE my_game NOT jump_on.                                                     			
-	MAKE my_game NOT kick.                                                        
-	MAKE my_game NOT kill.        -- (+ murder)                                      			
-	MAKE my_game NOT kill_with.                                                   			
-	MAKE my_game NOT kiss.        -- (+ hug, embrace)  
-	MAKE my_game NOT knock.                              
-	MAKE my_game NOT lie_down.                                                    
-	MAKE my_game NOT lie_in.                                                           
-	MAKE my_game NOT lie_on.                                                      
-	MAKE my_game NOT lift.                                                        
-	MAKE my_game NOT light.       -- (+ lit)                                         
-	MAKE my_game NOT listen0.                                                     
-	MAKE my_game NOT listen.                                                      
-	MAKE my_game NOT lock.                                                        
-	MAKE my_game NOT lock_with.                                                   
-	MAKE my_game NOT 'look'.        -- (+ gaze, peek)                                  						
-	MAKE my_game NOT look_at.                                                     
-	MAKE my_game NOT look_behind.                                                 			
-	MAKE my_game NOT look_in.                                                     			
-	MAKE my_game NOT look_out_of.                                                 				
-	MAKE my_game NOT look_through.                                                		
-	MAKE my_game NOT look_under.                                                  			
-	MAKE my_game NOT look_up.                                                     
-	MAKE my_game NOT 'no'.                                                          						
-	MAKE my_game NOT 'notify'. 
-	MAKE my_game NOT notify_on.
-	MAKE my_game NOT notify_off.                                            
-	MAKE my_game NOT open.                                                                                  
-	MAKE my_game NOT open_with.                                                               	
-	MAKE my_game NOT 'play'.                                                                                  
-	MAKE my_game NOT play_with.                                                   
-	MAKE my_game NOT pour.                          
-	MAKE my_game NOT pour_in.                                     
-	MAKE my_game NOT pour_on.                               
-	MAKE my_game NOT pray.                                                        
-	MAKE my_game NOT pry.                                                         
-	MAKE my_game NOT pry_with.                                                    
-	MAKE my_game NOT pull.                                                        
-	MAKE my_game NOT push.                                                        
-	MAKE my_game NOT push_with.                                                   	
-	MAKE my_game NOT put.         -- (+ lay, place)                                  
-	MAKE my_game NOT put_against.									  
-	MAKE my_game NOT put_behind.                                                 			
-	MAKE my_game NOT put_down.                                                    
-	MAKE my_game NOT put_in.      -- (+ insert)                                      
-	MAKE my_game NOT put_near.                                                                  
-	MAKE my_game NOT put_on.                                                                  
-	MAKE my_game NOT put_under.  
-	MAKE my_game NOT 'quit'.                                                             
-	MAKE my_game NOT read.                                                        
-	MAKE my_game NOT remove.										  				
-	MAKE my_game NOT 'restart'.                                                     					
-	MAKE my_game NOT 'restore'.                                                     		
-	MAKE my_game NOT rub.                                                                             
-	MAKE my_game NOT 'save'.                                                        
-	MAKE my_game NOT 'say'.                                                          	
-	MAKE my_game NOT say_to.                                                      
-	MAKE my_game NOT 'score'.                                                        
-	MAKE my_game NOT scratch.                                                                          
-	MAKE my_game NOT 'script'.    
-	MAKE my_game NOT script_on.
-	MAKE my_game NOT script_off.                                                  
-	MAKE my_game NOT search.                                                                              
-	MAKE my_game NOT sell.                                                        
-	MAKE my_game NOT shake.                                                                              
-	MAKE my_game NOT shoot. -- (at)                                                  
-	MAKE my_game NOT shoot_with.                                                  			
-	MAKE my_game NOT shout.       -- (+ scream, yell)                                                               
-	MAKE my_game NOT 'show'.      -- (+ reveal)                                                
-	MAKE my_game NOT sing.                                                        						
-	MAKE my_game NOT sip.                                                        
-	MAKE my_game NOT sit. -- (down)                                                  
-	MAKE my_game NOT sit_on.                                                      
-	MAKE my_game NOT sleep.       -- (+ rest)                                        
-	MAKE my_game NOT smell0.                                                      
-	MAKE my_game NOT smell.                                                       
-	MAKE my_game NOT squeeze.                                                                          
-	MAKE my_game NOT stand. -- (up)                                                  
-	MAKE my_game NOT stand_on.                                                    
-	MAKE my_game NOT swim.                                                        
-	MAKE my_game NOT swim_in.   
-	MAKE my_game NOT switch.                                                  
-	MAKE my_game NOT switch_on.	  			  
-	MAKE my_game NOT switch_off.  			  
-	MAKE my_game NOT take.        -- (+ carry, get, grab, hold, obtain)              
-	MAKE my_game NOT take_from.   -- (+ remove from)                                 
-	MAKE my_game NOT talk.                                                        						
-	MAKE my_game NOT talk_to.     -- (+ speak)                                       
-	MAKE my_game NOT taste.       -- (+ lick)                                        
-	MAKE my_game NOT tear.        -- (+ rip)                                         
-	MAKE my_game NOT tell.        -- (+ enlighten, inform)                           	
-	MAKE my_game NOT think.                                                       
-	MAKE my_game NOT think_about.                                                 
-	MAKE my_game NOT throw.                                                       
-	MAKE my_game NOT throw_at.                                                    	
-	MAKE my_game NOT throw_in.                                                    
-	MAKE my_game NOT throw_to.                                                     
-	MAKE my_game NOT tie.                                                                                    
-	MAKE my_game NOT tie_to.                                                                    
-	MAKE my_game NOT touch.       -- (+ feel)
-	MAKE my_game NOT touch_with.                                                                			
-	MAKE my_game NOT turn.        -- (+ rotate)                                                                
-	MAKE my_game NOT turn_on.                                                                    
-	MAKE my_game NOT turn_off.                                                    
-	MAKE my_game NOT undress.										  
-	MAKE my_game NOT unlock.                                                      
-	MAKE my_game NOT unlock_with.                                                 	
-	MAKE my_game NOT 'use'.                                                         
-	MAKE my_game NOT use_with.                                                    
-	MAKE my_game NOT 'verbose'.                                                     
-	MAKE my_game NOT 'wait'.        -- (+ z)                                           
-	MAKE my_game NOT wear.											  
-	MAKE my_game NOT what_am_i.                                                   	
-	MAKE my_game NOT what_is.                                                     	
-	MAKE my_game NOT where_am_i.                                                  
-	MAKE my_game NOT where_is.                                                    
-	MAKE my_game NOT who_am_i.                                                    
-	MAKE my_game NOT who_is.
-	MAKE my_game NOT write.
-	MAKE my_game NOT yes.
+ELSIF restricted_level OF my_game = 4   -- the strictest level of restriction;
+                -- no verbs work, not even out-of-game verbs
+  THEN              -- like 'save' and 'quit'.
+
+  MAKE my_game NOT about.
+  MAKE my_game NOT 'again'.
+  MAKE my_game NOT answer.      -- (+ reply)
+  MAKE my_game NOT ask.         -- (+ enquire, inquire, interrogate)
+  MAKE my_game NOT ask_for.
+  MAKE my_game NOT attack.      -- (+ beat, fight, hit, punch)
+  MAKE my_game NOT attack_with.
+  MAKE my_game NOT bite.        -- (+ chew)
+  MAKE my_game NOT break.       -- (+ destroy)
+  MAKE my_game NOT break_with.
+  MAKE my_game NOT 'brief'.
+  MAKE my_game NOT burn.
+  MAKE my_game NOT burn_with.
+  MAKE my_game NOT buy.         -- (+ purchase)
+  MAKE my_game NOT catch.
+  MAKE my_game NOT clean.       -- (+ polish, wipe)
+  MAKE my_game NOT climb.
+  MAKE my_game NOT climb_on.
+  MAKE my_game NOT climb_through.
+  MAKE my_game NOT close.       -- (+ shut)
+  MAKE my_game NOT close_with.
+  MAKE my_game NOT consult.
+  MAKE my_game NOT credits.     -- (+ acknowledgments, author, copyright)
+  MAKE my_game NOT cut.
+  MAKE my_game NOT cut_with.
+  MAKE my_game NOT dance.
+  MAKE my_game NOT dig.
+  MAKE my_game NOT dive.
+  MAKE my_game NOT dive_in.
+  MAKE my_game NOT drink.
+  MAKE my_game NOT drive.
+  MAKE my_game NOT drop.        -- (+ discard, dump, reject)
+  MAKE my_game NOT eat.
+  MAKE my_game NOT 'empty'.
+  MAKE my_game NOT empty_in.
+  MAKE my_game NOT empty_on.
+  MAKE my_game NOT enter.
+  MAKE my_game NOT examine.     -- (+ check, inspect, observe, x)
+  MAKE my_game NOT 'exit'.
+  MAKE my_game NOT extinguish.  -- (+ put out, quench)
+  MAKE my_game NOT fill.
+  MAKE my_game NOT fill_with.
+  MAKE my_game NOT find.        -- (+ locate)
+  MAKE my_game NOT fire.
+  MAKE my_game NOT fire_at.
+  MAKE my_game NOT fix.     -- (+ mend, repair)
+  MAKE my_game NOT follow.
+  MAKE my_game NOT free.        -- (+ release)
+  MAKE my_game NOT get_up.
+  MAKE my_game NOT get_off.
+  MAKE my_game NOT give.
+  MAKE my_game NOT go_to.
+  MAKE my_game NOT hint.        -- (+ hints)
+  MAKE my_game NOT i.        -- (+ inv, inventory)
+  MAKE my_game NOT jump.
+  MAKE my_game NOT jump_in.
+  MAKE my_game NOT jump_on.
+  MAKE my_game NOT kick.
+  MAKE my_game NOT kill.        -- (+ murder)
+  MAKE my_game NOT kill_with.
+  MAKE my_game NOT kiss.        -- (+ hug, embrace)
+  MAKE my_game NOT knock.
+  MAKE my_game NOT lie_down.
+  MAKE my_game NOT lie_in.
+  MAKE my_game NOT lie_on.
+  MAKE my_game NOT lift.
+  MAKE my_game NOT light.       -- (+ lit)
+  MAKE my_game NOT listen0.
+  MAKE my_game NOT listen.
+  MAKE my_game NOT lock.
+  MAKE my_game NOT lock_with.
+  MAKE my_game NOT 'look'.        -- (+ gaze, peek)
+  MAKE my_game NOT look_at.
+  MAKE my_game NOT look_behind.
+  MAKE my_game NOT look_in.
+  MAKE my_game NOT look_out_of.
+  MAKE my_game NOT look_through.
+  MAKE my_game NOT look_under.
+  MAKE my_game NOT look_up.
+  MAKE my_game NOT 'no'.
+  MAKE my_game NOT 'notify'.
+  MAKE my_game NOT notify_on.
+  MAKE my_game NOT notify_off.
+  MAKE my_game NOT open.
+  MAKE my_game NOT open_with.
+  MAKE my_game NOT 'play'.
+  MAKE my_game NOT play_with.
+  MAKE my_game NOT pour.
+  MAKE my_game NOT pour_in.
+  MAKE my_game NOT pour_on.
+  MAKE my_game NOT pray.
+  MAKE my_game NOT pry.
+  MAKE my_game NOT pry_with.
+  MAKE my_game NOT pull.
+  MAKE my_game NOT push.
+  MAKE my_game NOT push_with.
+  MAKE my_game NOT put.         -- (+ lay, place)
+  MAKE my_game NOT put_against.
+  MAKE my_game NOT put_behind.
+  MAKE my_game NOT put_down.
+  MAKE my_game NOT put_in.      -- (+ insert)
+  MAKE my_game NOT put_near.
+  MAKE my_game NOT put_on.
+  MAKE my_game NOT put_under.
+  MAKE my_game NOT 'quit'.
+  MAKE my_game NOT read.
+  MAKE my_game NOT remove.
+  MAKE my_game NOT 'restart'.
+  MAKE my_game NOT 'restore'.
+  MAKE my_game NOT rub.
+  MAKE my_game NOT 'save'.
+  MAKE my_game NOT 'say'.
+  MAKE my_game NOT say_to.
+  MAKE my_game NOT 'score'.
+  MAKE my_game NOT scratch.
+  MAKE my_game NOT 'script'.
+  MAKE my_game NOT script_on.
+  MAKE my_game NOT script_off.
+  MAKE my_game NOT search.
+  MAKE my_game NOT sell.
+  MAKE my_game NOT shake.
+  MAKE my_game NOT shoot. -- (at)
+  MAKE my_game NOT shoot_with.
+  MAKE my_game NOT shout.       -- (+ scream, yell)
+  MAKE my_game NOT 'show'.      -- (+ reveal)
+  MAKE my_game NOT sing.
+  MAKE my_game NOT sip.
+  MAKE my_game NOT sit. -- (down)
+  MAKE my_game NOT sit_on.
+  MAKE my_game NOT sleep.       -- (+ rest)
+  MAKE my_game NOT smell0.
+  MAKE my_game NOT smell.
+  MAKE my_game NOT squeeze.
+  MAKE my_game NOT stand. -- (up)
+  MAKE my_game NOT stand_on.
+  MAKE my_game NOT swim.
+  MAKE my_game NOT swim_in.
+  MAKE my_game NOT switch.
+  MAKE my_game NOT switch_on.
+  MAKE my_game NOT switch_off.
+  MAKE my_game NOT take.        -- (+ carry, get, grab, hold, obtain)
+  MAKE my_game NOT take_from.   -- (+ remove from)
+  MAKE my_game NOT talk.
+  MAKE my_game NOT talk_to.     -- (+ speak)
+  MAKE my_game NOT taste.       -- (+ lick)
+  MAKE my_game NOT tear.        -- (+ rip)
+  MAKE my_game NOT tell.        -- (+ enlighten, inform)
+  MAKE my_game NOT think.
+  MAKE my_game NOT think_about.
+  MAKE my_game NOT throw.
+  MAKE my_game NOT throw_at.
+  MAKE my_game NOT throw_in.
+  MAKE my_game NOT throw_to.
+  MAKE my_game NOT tie.
+  MAKE my_game NOT tie_to.
+  MAKE my_game NOT touch.       -- (+ feel)
+  MAKE my_game NOT touch_with.
+  MAKE my_game NOT turn.        -- (+ rotate)
+  MAKE my_game NOT turn_on.
+  MAKE my_game NOT turn_off.
+  MAKE my_game NOT undress.
+  MAKE my_game NOT unlock.
+  MAKE my_game NOT unlock_with.
+  MAKE my_game NOT 'use'.
+  MAKE my_game NOT use_with.
+  MAKE my_game NOT 'verbose'.
+  MAKE my_game NOT 'wait'.        -- (+ z)
+  MAKE my_game NOT wear.
+  MAKE my_game NOT what_am_i.
+  MAKE my_game NOT what_is.
+  MAKE my_game NOT where_am_i.
+  MAKE my_game NOT where_is.
+  MAKE my_game NOT who_am_i.
+  MAKE my_game NOT who_is.
+  MAKE my_game NOT write.
+  MAKE my_game NOT yes.
 
 END IF.
 
@@ -1619,24 +1619,24 @@ END EVENT.
 
 THE banner ISA DEFINITION_BLOCK
 
-  	DESCRIPTION
-   		
-		"$p" STYLE alert. SAY title OF my_game. STYLE normal. 
-   		
-		IF subtitle OF my_game <> ""
-			THEN "$n" SAY subtitle OF my_game.
-   		END IF.
-   		
-		"$n(C)" SAY year OF my_game. "by" SAY author OF my_game.
-   		
-		"$nProgrammed with the ALAN Interactive Fiction Language v3.0 beta5
-		$nStandard Library v2.1"
-   		
-		IF version OF my_game <> "0"
-			THEN "$nVersion" SAY version OF my_game. 
-   		END IF.	
-   		
-		"$nAll rights reserved."
+    DESCRIPTION
+
+    "$p" STYLE alert. SAY title OF my_game. STYLE normal.
+
+    IF subtitle OF my_game <> ""
+      THEN "$n" SAY subtitle OF my_game.
+      END IF.
+
+    "$n(C)" SAY year OF my_game. "by" SAY author OF my_game.
+
+    "$nProgrammed with the ALAN Interactive Fiction Language v3.0 beta5
+    $nStandard Library v2.1"
+
+    IF version OF my_game <> "0"
+      THEN "$nVersion" SAY version OF my_game.
+      END IF.
+
+    "$nAll rights reserved."
 
 END THE banner.
 

--- a/lib_locations.i
+++ b/lib_locations.i
@@ -2,13 +2,13 @@
 -- Locations (file name: 'lib_locations.i')
 
 
--- This library file defines the default directions (exits) and the location 'nowhere', 
+-- This library file defines the default directions (exits) and the location 'nowhere',
 -- a useful place to locate things when you want to remove them from play.
 -- This file also defines four specific location classes: rooms (= indoor locations),
--- sites (= outdoor locations) dark_locations and areas. 
+-- sites (= outdoor locations) dark_locations and areas.
 -- Finally, the attributes 'visited' and 'described' are defined.
 -- You may modify this file in any way that suits your purposes.
--- To use this file, you should have it in the same folder as your source code file, 
+-- To use this file, you should have it in the same folder as your source code file,
 -- and the line
 --
 -- IMPORT 'locations.i'.
@@ -28,44 +28,44 @@
 
 THE nowhere ISA LOCATION
 
-	EXIT  
-		north, 
-		south, 
-		east, 
-		west, 
-		northeast, 
-		southeast, 
-		northwest, 
-		southwest, 
-		up, 
-		down, 
-		'in', 
-		out 
-		
-		TO nowhere.
+  EXIT
+    north,
+    south,
+    east,
+    west,
+    northeast,
+    southeast,
+    northwest,
+    southwest,
+    up,
+    down,
+    'in',
+    out
 
-		
+    TO nowhere.
+
+
 END THE nowhere.
 
 
 SYNONYMS
-		n = north.
-		s = south.
-		e = east.
-		w = west.
-		ne = northeast.
-		se = southeast.
-		nw = northwest.
-		sw = southwest.
-		u = up.
-		d = down.
+    n = north.
+    s = south.
+    e = east.
+    w = west.
+    ne = northeast.
+    se = southeast.
+    nw = northwest.
+    sw = southwest.
+    u = up.
+    d = down.
 
 
 -- Note:
- 
 
--- 1) the directions defined above (and their synonyms) are not predefined in or 
--- hardwired to the interpreter in any way, so you can replace them altogether or add new 
+
+-- 1) the directions defined above (and their synonyms) are not predefined in or
+-- hardwired to the interpreter in any way, so you can replace them altogether or add new
 -- ones to be used alongside with them.
 
 
@@ -74,13 +74,13 @@ SYNONYMS
 -- LOCATE [object] AT nowhere.
 --
 -- for example
--- 
+--
 -- THE piece_of_paper ISA OBJECT
 -- ...
 --    VERB tear
--- 		DOES ONLY "You tear the piece of paper to shreds."
--- 		LOCATE piece_of_paper AT nowhere.
--- 	END VERB.
+--    DOES ONLY "You tear the piece of paper to shreds."
+--    LOCATE piece_of_paper AT nowhere.
+--  END VERB.
 --
 -- END THE piece_of_paper.
 
@@ -100,9 +100,9 @@ SYNONYMS
 -- Thus, you will be able to define for example
 --
 -- THE kitchen ISA ROOM
--- 
+--
 -- and it will automatically have a floor, walls and a ceiling,
--- 
+--
 -- or:
 --
 -- THE greenmeadow ISA SITE
@@ -116,30 +116,30 @@ SYNONYMS
 --
 -- etc, but the floor, walls and ceiling won't be automatically included there.
 -- The walls, floor, ceiling, ground and sky are not takeable or movable.
--- This library file also defines the sky to be distant and the ceiling to be out of reach, 
+-- This library file also defines the sky to be distant and the ceiling to be out of reach,
 -- so that they can't be touched, for example.
 
 -- (We make use of ALAN's nested locations feature in the following definitions: )
 
 
-THE outdoor ISA LOCATION 
+THE outdoor ISA LOCATION
 END THE outdoor.
 
 
-THE indoor ISA LOCATION 
+THE indoor ISA LOCATION
 END THE indoor.
 
 
 EVERY room ISA LOCATION AT indoor
-	HAS floor_desc "".		-- if these values are left unchanged,
-	HAS walls_desc "".		-- the descriptions of the walls, floor and 
-	HAS ceiling_desc "".	 	-- ceiling will be the default "You notice nothing unusual
-END EVERY.					-- about the [object]."
+  HAS floor_desc "".    -- if these values are left unchanged,
+  HAS walls_desc "".    -- the descriptions of the walls, floor and
+  HAS ceiling_desc "".    -- ceiling will be the default "You notice nothing unusual
+END EVERY.          -- about the [object]."
 
 
-EVERY site ISA LOCATION AT outdoor	
-	HAS ground_desc "".
-	HAS sky_desc "".
+EVERY site ISA LOCATION AT outdoor
+  HAS ground_desc "".
+  HAS sky_desc "".
 END EVERY.
 
 
@@ -152,107 +152,107 @@ END EVERY.
 
 
 THE floor ISA room_object
-	IS NOT takeable.
-	IS NOT movable.
-	CONTAINER 			
-		-- to allow 'empty/pour/put something on floor'
-	DESCRIPTION ""
+  IS NOT takeable.
+  IS NOT movable.
+  CONTAINER
+    -- to allow 'empty/pour/put something on floor'
+  DESCRIPTION ""
 
 
-	-- As we have declared the floor a container, we will disable some verbs
-	-- defined to work with containers:
+  -- As we have declared the floor a container, we will disable some verbs
+  -- defined to work with containers:
 
 
-	VERB empty_in, pour_in
-	   WHEN cont
-		DOES ONLY "That's not something you can $v things into."
-	END VERB.
+  VERB empty_in, pour_in
+     WHEN cont
+    DOES ONLY "That's not something you can $v things into."
+  END VERB.
 
 
-	VERB look_in
-		DOES ONLY "That's not possible."
-	END VERB.
+  VERB look_in
+    DOES ONLY "That's not possible."
+  END VERB.
 
 
-	VERB put_in
-	   WHEN cont
-		DOES ONLY "That's not something you can $v things into."
-	END VERB.
+  VERB put_in
+     WHEN cont
+    DOES ONLY "That's not something you can $v things into."
+  END VERB.
 
 
-	VERB take_from
-	   WHEN holder
-		DOES ONLY "If you want to pick up something, just TAKE it."
-	END VERB.
+  VERB take_from
+     WHEN holder
+    DOES ONLY "If you want to pick up something, just TAKE it."
+  END VERB.
 
 
-	VERB throw_in
-	   WHEN cont
-		DOES ONLY "That's not something you can $v things into."
-	END VERB.
-	
+  VERB throw_in
+     WHEN cont
+    DOES ONLY "That's not something you can $v things into."
+  END VERB.
+
 
 
 END THE.
 
 
 THE wall ISA room_object
-	NAME wall NAME walls
-	IS NOT takeable.
-	IS NOT movable.
-	DESCRIPTION ""
+  NAME wall NAME walls
+  IS NOT takeable.
+  IS NOT movable.
+  DESCRIPTION ""
 END THE.
 
 
 
 THE ceiling ISA room_object
-	IS NOT takeable.
-	IS NOT reachable.	
-	DESCRIPTION ""	
+  IS NOT takeable.
+  IS NOT reachable.
+  DESCRIPTION ""
 END THE.
 
 
 
 THE ground ISA site_object
-	IS NOT takeable.
-	IS NOT movable.
-	CONTAINER				
-		-- to allow 'empty/pour something on ground'
-	DESCRIPTION ""
+  IS NOT takeable.
+  IS NOT movable.
+  CONTAINER
+    -- to allow 'empty/pour something on ground'
+  DESCRIPTION ""
 
 
 
-	-- As we have declared the ground to be a container, we will disable some verbs
-	-- defined to work with containers:
+  -- As we have declared the ground to be a container, we will disable some verbs
+  -- defined to work with containers:
 
 
-	VERB empty_in, pour_in
-	   WHEN cont
-		DOES ONLY "That's not something you can $v things into."
-	END VERB.
+  VERB empty_in, pour_in
+     WHEN cont
+    DOES ONLY "That's not something you can $v things into."
+  END VERB.
 
 
-	VERB look_in
-		DOES ONLY "That's not possible."
-	END VERB.
+  VERB look_in
+    DOES ONLY "That's not possible."
+  END VERB.
 
 
-	VERB put_in
-	   WHEN cont
-		DOES ONLY "That's not something you can $v things into."
-	END VERB.
+  VERB put_in
+     WHEN cont
+    DOES ONLY "That's not something you can $v things into."
+  END VERB.
 
 
-	VERB take_from
-	   WHEN holder
-		DOES ONLY "If you want to pick up something, just TAKE it."
-	END VERB.
+  VERB take_from
+     WHEN holder
+    DOES ONLY "If you want to pick up something, just TAKE it."
+  END VERB.
 
 
-	VERB throw_in
-	   WHEN cont
-		DOES ONLY "That's not something you can $v things into."
-	END VERB.
+  VERB throw_in
+     WHEN cont
+    DOES ONLY "That's not something you can $v things into."
+  END VERB.
 
 
 END THE.
@@ -260,9 +260,9 @@ END THE.
 
 
 THE sky ISA site_object
-	IS NOT takeable.
-	IS distant.
-	DESCRIPTION ""
+  IS NOT takeable.
+  IS distant.
+  DESCRIPTION ""
 END THE.
 
 
@@ -271,36 +271,36 @@ END THE.
 
 ADD TO EVERY room_object
 
-	VERB put_against
-		WHEN bulk
-			CHECK THIS = wall
-				ELSE "That's not possible."	
-	END VERB.
-    
-	VERB put_behind, put_near, put_under
-		WHEN bulk
-			DOES ONLY "That's not possible."
-	END VERB.
+  VERB put_against
+    WHEN bulk
+      CHECK THIS = wall
+        ELSE "That's not possible."
+  END VERB.
 
-	VERB look_behind, look_through, look_under
-		DOES ONLY "That's not possible."
-	END VERB.
+  VERB put_behind, put_near, put_under
+    WHEN bulk
+      DOES ONLY "That's not possible."
+  END VERB.
 
-END ADD TO.	
+  VERB look_behind, look_through, look_under
+    DOES ONLY "That's not possible."
+  END VERB.
+
+END ADD TO.
 
 
 ADD TO EVERY site_object
-    
-	VERB put_against, put_behind, put_near, put_under
-		WHEN bulk
-			DOES ONLY "That's not possible."
-	END VERB.
 
-	VERB look_behind, look_through, look_under
-		DOES ONLY "That's not possible."
-	END VERB.
+  VERB put_against, put_behind, put_near, put_under
+    WHEN bulk
+      DOES ONLY "That's not possible."
+  END VERB.
 
-END ADD TO.	
+  VERB look_behind, look_through, look_under
+    DOES ONLY "That's not possible."
+  END VERB.
+
+END ADD TO.
 
 
 -- NOTE: it is often a good idea to modify the 'examine' verb for the above objects.
@@ -309,18 +309,18 @@ END ADD TO.
 -- THE my_game ISA DEFINITION_BLOCK
 -- ...
 -- VERB examine
---    CHECK obj <> wall 
---       ELSE 
+--    CHECK obj <> wall
+--       ELSE
 --          IF hero AT kitchen
 --              THEN "The walls are lined with shelves."
---          ELSIF hero AT livingroom  
---			THEN "The wallpaper has a nice flower pattern."
+--          ELSIF hero AT livingroom
+--      THEN "The wallpaper has a nice flower pattern."
 --          ELSIF...
---          END IF. 
+--          END IF.
 --    ...
 -- END VERB.
 --
--- END THE my_game.         
+-- END THE my_game.
 
 
 
@@ -335,59 +335,59 @@ END ADD TO.
 
 
 ADD TO EVERY LOCATION
-	IS lit. 
-END ADD TO. 
+  IS lit.
+END ADD TO.
 
 
 EVERY dark_location ISA LOCATION
-	IS NOT lit. 
+  IS NOT lit.
 
-	ENTERED
+  ENTERED
 
-		IF COUNT ISA LIGHTSOURCE, IS lit, HERE > 0	
-			THEN MAKE THIS lit.	
-				IF CURRENT ACTOR <> hero
-					THEN LOOK.
-				END IF.			
-		END IF.
+    IF COUNT ISA LIGHTSOURCE, IS lit, HERE > 0
+      THEN MAKE THIS lit.
+        IF CURRENT ACTOR <> hero
+          THEN LOOK.
+        END IF.
+    END IF.
 
-		IF COUNT ISA LIGHTSOURCE, IS lit, HERE = 0
-			THEN MAKE THIS NOT lit.
-		END IF.
-									
-		-- These ENTERED statements take care
-		-- of the dark location being correctly lit or not lit at entrance, 
-		-- the WHEN rules below take care of the change when the hero is 
-		-- already in the location.
-		
+    IF COUNT ISA LIGHTSOURCE, IS lit, HERE = 0
+      THEN MAKE THIS NOT lit.
+    END IF.
 
-	DESCRIPTION 
-		CHECK THIS IS lit
-			ELSE SAY dark_loc_desc OF my_game.
-
-END EVERY dark_location. 
+    -- These ENTERED statements take care
+    -- of the dark location being correctly lit or not lit at entrance,
+    -- the WHEN rules below take care of the change when the hero is
+    -- already in the location.
 
 
-WHEN location OF hero IS NOT lit 
-	AND COUNT ISA lightsource, IS lit, AT hero > 0  
-THEN MAKE location OF hero lit. 
-	SCHEDULE light_on AT hero AFTER 0.
+  DESCRIPTION
+    CHECK THIS IS lit
+      ELSE SAY dark_loc_desc OF my_game.
+
+END EVERY dark_location.
+
+
+WHEN location OF hero IS NOT lit
+  AND COUNT ISA lightsource, IS lit, AT hero > 0
+THEN MAKE location OF hero lit.
+  SCHEDULE light_on AT hero AFTER 0.
 
 
 EVENT light_on
-	LOOK.
+  LOOK.
 END EVENT.
 
 
-WHEN location OF hero ISA dark_location 
-	AND location OF hero IS lit
-	AND COUNT ISA lightsource, IS lit, AT hero = 0  
-THEN MAKE location OF hero NOT lit. 
-	SCHEDULE light_off AT hero AFTER 0.
+WHEN location OF hero ISA dark_location
+  AND location OF hero IS lit
+  AND COUNT ISA lightsource, IS lit, AT hero = 0
+THEN MAKE location OF hero NOT lit.
+  SCHEDULE light_off AT hero AFTER 0.
 
 
 EVENT light_off
-	SAY light_goes_off OF my_game.
+  SAY light_goes_off OF my_game.
 END EVENT.
 
 
@@ -396,23 +396,23 @@ END EVENT.
 
 EVENT check_darkness
     FOR EACH dl ISA dark_location, IS lit
-		DO
-			IF COUNT ISA LIGHTSOURCE, AT dl = 0
-				THEN MAKE dl NOT lit.
-			END IF.
+    DO
+      IF COUNT ISA LIGHTSOURCE, AT dl = 0
+        THEN MAKE dl NOT lit.
+      END IF.
     END FOR.
     SCHEDULE check_darkness AFTER 1.
 END EVENT.
 
 
--- This event is initialized in the start_section instance ('definitions.i'). 
+-- This event is initialized in the start_section instance ('definitions.i').
 
 
--- To define a dark location, use a formulation like the following: 
+-- To define a dark location, use a formulation like the following:
 
 
 -- THE basement ISA dark_location
--- 	EXIT up TO kitchen.
+--  EXIT up TO kitchen.
 -- ...
 -- END THE.
 
@@ -426,7 +426,7 @@ END EVENT.
 
 -- THE basement ISA dark_location
 --    DESCRIPTION "Cobwebs and old junk are the only things you see here."
--- 	EXIT up TO kitchen.
+--  EXIT up TO kitchen.
 -- END THE.
 
 
@@ -437,7 +437,7 @@ END EVENT.
 -- =====================================================================
 
 
------ 4. The attributes 'visited' and 'described' 
+----- 4. The attributes 'visited' and 'described'
 
 
 -- =====================================================================
@@ -447,26 +447,26 @@ END EVENT.
 -- value increases on every subsequent visit.
 -- This helps when you need to control if or how many times a location has been visited,
 -- and also if you want the location description to be different after the first visit.
- 
+
 -- A location has the value 'described 0' before the first location description,
 -- and the value increases every time the description is shown.
--- This distinction is handy when you want the first-time description of a location to be different 
+-- This distinction is handy when you want the first-time description of a location to be different
 -- from the subsequent ones (even if the hero is in the location still for the first time).
 
 
 ADD TO EVERY LOCATION
-	HAS visited 0.	
-	HAS described 0.
+  HAS visited 0.
+  HAS described 0.
 
-	ENTERED
-		 IF CURRENT ACTOR = hero
-			THEN 
-				INCREASE visited OF THIS.	
-				INCREASE described OF THIS.		
-				-- The "described" attribute increases also after LOOK (see 'verbs.i').
-		 END IF.
+  ENTERED
+     IF CURRENT ACTOR = hero
+      THEN
+        INCREASE visited OF THIS.
+        INCREASE described OF THIS.
+        -- The "described" attribute increases also after LOOK (see 'verbs.i').
+     END IF.
 
-END ADD TO.						
+END ADD TO.
 
 
 

--- a/lib_messages.i
+++ b/lib_messages.i
@@ -2,134 +2,134 @@
 -- Messages (file name: 'lib_messages.i')
 
 
--- All runtime messages are listed below.  
+-- All runtime messages are listed below.
 
 -- Many of these messages are not in their default ("built-in") form as described
 -- in the ALAN language manual, but have been slightly edited for this library.
 
 
-MESSAGE 
-	AFTER_BUT: "You must give at least one object after '$1'."
-	AGAIN: ""
-	BUT_ALL: "You can only use '$1' AFTER '$2'."
-	CAN_NOT_CONTAIN: "$+1 can not contain $+2."
-	CANT0: "You can't do that."    
-		 -- note that the fifth token in CANT0 is a zero, not an 'o'.
-	CARRIES: 
-		IF parameter1 IS NOT plural
-			THEN "$+1 is carrying"
-			ELSE "$+1 are carrying"
-		END IF.
-	CONTAINMENT_LOOP:
-		"Putting $+1 in" 
-			IF parameter1 IS NOT plural
-				THEN "itself"
-				ELSE "themselves"
-			END IF.
-		"is impossible."	   
-	CONTAINMENT_LOOP2: "Putting $+1 in $+2 is impossible since $+2 already" 
-					IF parameter2 IS NOT plural
-						THEN "is"
-						ELSE "are"
-					END IF. 
-				    "inside $+1."
-	'CONTAINS': 
-		IF parameter1 IS NOT plural
-			THEN "$+1 contains"
-			ELSE "$+1 contain"
-		END IF.
-	CONTAINS_COMMA: "$01" 
-		IF parameter1 ISA CLOTHING
-			THEN 
-				-- the following snippet adds "(being worn)" after all
-				-- pieces of clothing worn by an NPC, at 'x [actor]'
+MESSAGE
+  AFTER_BUT: "You must give at least one object after '$1'."
+  AGAIN: ""
+  BUT_ALL: "You can only use '$1' AFTER '$2'."
+  CAN_NOT_CONTAIN: "$+1 can not contain $+2."
+  CANT0: "You can't do that."
+     -- note that the fifth token in CANT0 is a zero, not an 'o'.
+  CARRIES:
+    IF parameter1 IS NOT plural
+      THEN "$+1 is carrying"
+      ELSE "$+1 are carrying"
+    END IF.
+  CONTAINMENT_LOOP:
+    "Putting $+1 in"
+      IF parameter1 IS NOT plural
+        THEN "itself"
+        ELSE "themselves"
+      END IF.
+    "is impossible."
+  CONTAINMENT_LOOP2: "Putting $+1 in $+2 is impossible since $+2 already"
+          IF parameter2 IS NOT plural
+            THEN "is"
+            ELSE "are"
+          END IF.
+            "inside $+1."
+  'CONTAINS':
+    IF parameter1 IS NOT plural
+      THEN "$+1 contains"
+      ELSE "$+1 contain"
+    END IF.
+  CONTAINS_COMMA: "$01"
+    IF parameter1 ISA CLOTHING
+      THEN
+        -- the following snippet adds "(being worn)" after all
+        -- pieces of clothing worn by an NPC, at 'x [actor]'
 
-				IF parameter1 IS donned 
-					THEN
-						IF parameter1 NOT IN worn
-							THEN "(being worn)" 
-						END IF.
-				END IF.
-		END IF.
-		"$$,"
-    	CONTAINS_AND: "$01"
-		IF parameter1 ISA CLOTHING
-			THEN 
-				-- the following snippet adds "(being worn)" after all
-				-- pieces of clothing worn by an NPC, after 'x [actor]'
+        IF parameter1 IS donned
+          THEN
+            IF parameter1 NOT IN worn
+              THEN "(being worn)"
+            END IF.
+        END IF.
+    END IF.
+    "$$,"
+      CONTAINS_AND: "$01"
+    IF parameter1 ISA CLOTHING
+      THEN
+        -- the following snippet adds "(being worn)" after all
+        -- pieces of clothing worn by an NPC, after 'x [actor]'
 
-				IF parameter1 IS donned 
-					THEN
-						IF parameter1 NOT IN worn
-							THEN "(being worn)" 
-						END IF.
-				END IF.
-		END IF.
+        IF parameter1 IS donned
+          THEN
+            IF parameter1 NOT IN worn
+              THEN "(being worn)"
+            END IF.
+        END IF.
+    END IF.
 
-		"and"
+    "and"
 
-	CONTAINS_END: "$01"
-		IF parameter1 ISA CLOTHING
-			THEN 
-				-- the following snippet adds "(being worn)" after all
-				-- pieces of clothing worn by an NPC, after 'x [actor]'
+  CONTAINS_END: "$01"
+    IF parameter1 ISA CLOTHING
+      THEN
+        -- the following snippet adds "(being worn)" after all
+        -- pieces of clothing worn by an NPC, after 'x [actor]'
 
-				IF parameter1 IS donned 
-					THEN
-						IF parameter1 NOT IN worn
-							THEN "(being worn)" 
-						END IF.
-				END IF.
-		END IF.
-		"." 
-	EMPTY_HANDED: 
-		IF parameter1 IS NOT plural
-			THEN "$+1 is empty-handed."
-			ELSE "$+1 are empty-handed."
-		END IF.
-			
-	HAVE_SCORED: "You have scored $1 points out of $2."
-    	IMPOSSIBLE_WITH: "That's impossible with $+1."
-	IS_EMPTY: 
-		IF parameter1 IS NOT plural
-			THEN "$+1 is empty."
-			ELSE "$+1 are empty."
-		END IF.
-	MORE: "<More>"
-	MULTIPLE: "You can't refer to multiple objects with '$v'."
-	NO_SUCH: "You can't see any $1 here."
-	NO_WAY: "You can't go that way."	
-	NOT_MUCH: "That doesn't leave much to $v!"
-	NOUN: "You must supply a noun."
-    	NOT_A_SAVEFILE: "That file does not seem to be an Alan game save file."
-    	QUIT_ACTION: "Do you want to RESTART, RESTORE, QUIT or UNDO? "
-		-- these four alternatives are hardwired to the interpreter and cannot be changed.
-	REALLY: "Are you sure (press ENTER to confirm)?"
-	RESTORE_FROM: "Enter file name to restore from"
-	SAVE_FAILED: "Sorry, save failed."
-	SAVE_MISSING: "Sorry, could not open the save file."	
-	SAVE_NAME: "Sorry, the save file did not contain a save for this adventure."
-   	SAVE_OVERWRITE: "That file already exists, overwrite (y)?"
-	SAVE_VERSION: "Sorry, the save file was created by a different version."
-	SAVE_WHERE: "Enter file name to save in"
-	SEE_START: 
-		IF parameter1 IS NOT plural
-			THEN "There is $01"
-			ELSE "There are $01"
-		END IF.
-	SEE_COMMA: ", $01"
-	SEE_AND: "and $01"
-	SEE_END: "here."
-	NO_UNDO: "No further undo available."
-	UNDONE: "'$1' undone."
-	UNKNOWN_WORD: "I don't know the word '$1'."
-	WHAT: "That was not understood."
-    	WHAT_WORD: "It is not clear what you mean by '$1'."
-	WHICH_PRONOUN_START: "It is not clear if you by '$1'"
-	WHICH_PRONOUN_FIRST: "mean $+1"
-	WHICH_START: "It is not clear if you mean $+1"
-	WHICH_COMMA: ", $+1"
-	WHICH_OR: "or $+1."
+        IF parameter1 IS donned
+          THEN
+            IF parameter1 NOT IN worn
+              THEN "(being worn)"
+            END IF.
+        END IF.
+    END IF.
+    "."
+  EMPTY_HANDED:
+    IF parameter1 IS NOT plural
+      THEN "$+1 is empty-handed."
+      ELSE "$+1 are empty-handed."
+    END IF.
+
+  HAVE_SCORED: "You have scored $1 points out of $2."
+      IMPOSSIBLE_WITH: "That's impossible with $+1."
+  IS_EMPTY:
+    IF parameter1 IS NOT plural
+      THEN "$+1 is empty."
+      ELSE "$+1 are empty."
+    END IF.
+  MORE: "<More>"
+  MULTIPLE: "You can't refer to multiple objects with '$v'."
+  NO_SUCH: "You can't see any $1 here."
+  NO_WAY: "You can't go that way."
+  NOT_MUCH: "That doesn't leave much to $v!"
+  NOUN: "You must supply a noun."
+      NOT_A_SAVEFILE: "That file does not seem to be an Alan game save file."
+      QUIT_ACTION: "Do you want to RESTART, RESTORE, QUIT or UNDO? "
+    -- these four alternatives are hardwired to the interpreter and cannot be changed.
+  REALLY: "Are you sure (press ENTER to confirm)?"
+  RESTORE_FROM: "Enter file name to restore from"
+  SAVE_FAILED: "Sorry, save failed."
+  SAVE_MISSING: "Sorry, could not open the save file."
+  SAVE_NAME: "Sorry, the save file did not contain a save for this adventure."
+    SAVE_OVERWRITE: "That file already exists, overwrite (y)?"
+  SAVE_VERSION: "Sorry, the save file was created by a different version."
+  SAVE_WHERE: "Enter file name to save in"
+  SEE_START:
+    IF parameter1 IS NOT plural
+      THEN "There is $01"
+      ELSE "There are $01"
+    END IF.
+  SEE_COMMA: ", $01"
+  SEE_AND: "and $01"
+  SEE_END: "here."
+  NO_UNDO: "No further undo available."
+  UNDONE: "'$1' undone."
+  UNKNOWN_WORD: "I don't know the word '$1'."
+  WHAT: "That was not understood."
+      WHAT_WORD: "It is not clear what you mean by '$1'."
+  WHICH_PRONOUN_START: "It is not clear if you by '$1'"
+  WHICH_PRONOUN_FIRST: "mean $+1"
+  WHICH_START: "It is not clear if you mean $+1"
+  WHICH_COMMA: ", $+1"
+  WHICH_OR: "or $+1."
 
 
 -- end of file.

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -5,12 +5,12 @@
 
 ----- This library file defines common verbs needed in gameplay. The verbs
 ----- are listed alphabetically. This file also includes common commands which are not
------ actually verbs, such as "inventory", "verbose" and "again". 
+----- actually verbs, such as "inventory", "verbose" and "again".
 ----- Verbs originally defined in this file are the following:
 
 
 ----- VERB        SYNONYMS                                        SYNTAX                              ARITY             OBJ
-		
+
 ----- about       (+ help, info)                                  about                               0
 ----- again       (+ g)                                           again                               0
 ----- answer      (+ reply)                                       answer (topic)                      1
@@ -18,24 +18,24 @@
 ----- ask_for                                                     ask (act) for (obj)                 2                 x
 ----- attack      (+ beat, fight, hit, punch)                     attack (target)                     1
 ----- attack_with                                                 attack (target) with (weapon)       2
------ bite        (+ chew)		                                  bite (obj)                          1                 x
------ break       (+ destroy)                                     break (obj)                         1			   x 
------ break_with                                                  break (obj) with (instr)            2                 x 
+----- bite        (+ chew)                                      bite (obj)                          1                 x
+----- break       (+ destroy)                                     break (obj)                         1        x
+----- break_with                                                  break (obj) with (instr)            2                 x
 ----- brief                                                       brief                               0
 ----- burn                                                        burn (obj)                          1                 x
------ burn_with                                                   burn (obj) with (instr)             2                 x 
------ buy         (+ purchase)                                    buy (item)                          1			
------ catch                                                       catch (obj)                         1                 x	
------ clean       (+ polish, wipe)                                clean (obj)                         1                 x 
------ climb                                                       climb (obj)                         1                 x 
------ climb_on                                                    climb on (surface)                  1						
+----- burn_with                                                   burn (obj) with (instr)             2                 x
+----- buy         (+ purchase)                                    buy (item)                          1
+----- catch                                                       catch (obj)                         1                 x
+----- clean       (+ polish, wipe)                                clean (obj)                         1                 x
+----- climb                                                       climb (obj)                         1                 x
+----- climb_on                                                    climb on (surface)                  1
 ----- climb_through                                               climb through (obj)                 1                 x
 ----- close       (+ shut)                                        close (obj)                         1                 x
 ----- close_with                                                  close (obj) with (instr)            2                 x
------ consult                                                     consult (source) about (topic)      2			
------ credits     (+ acknowledgments, author, copyright)          credits                             2 					
+----- consult                                                     consult (source) about (topic)      2
+----- credits     (+ acknowledgments, author, copyright)          credits                             2
 ----- cut                                                         cut (obj)                           1                 x
------ cut_with                                                    cut (obj) with (instr)              2                 x 
+----- cut_with                                                    cut (obj) with (instr)              2                 x
 ----- dance                                                       dance                               0
 ----- dig                                                         dig (obj)                           1                 x
 ----- dive                                                        dive                                0
@@ -43,95 +43,95 @@
 ----- drink                                                       drink (liq)                         1
 ----- drive                                                       drive (vehicle)                     1
 ----- drop        (+ discard, dump, reject)                       drop (obj)                          1                 x
------ eat                                                         eat (food)                          1		
+----- eat                                                         eat (food)                          1
 ----- empty                                                       empty (obj)                         1                 x
 ----- empty_in                                                    empty (obj) in (cont)               2                 x
 ----- empty_on                                                    empty (obj) on (surface)            2                 x
 ----- enter                                                       enter (obj)                         1
 ----- examine     (+ check, inspect, observe, x)                  examine (obj)                       1                 x
 ----- exit                                                        exit (obj)                          1
------ extinguish  (+ put out, quench)                             extinguish (obj)                    1                 x 
------ fill                                                        fill (cont)                         1			
------ fill_with                                                   fill (cont) with (substance)        1			
+----- extinguish  (+ put out, quench)                             extinguish (obj)                    1                 x
+----- fill                                                        fill (cont)                         1
+----- fill_with                                                   fill (cont) with (substance)        1
 ----- find        (+ locate)                                      find (obj)                          1                 x
 ----- fire                                                        fire (weapon)                       1
------ fire_at										  fire (weapon) at (target)	      1
------ fix		  (+ mend, repair)						  fix (obj)					 1                 x					 
------ follow                                                      follow (act)                        1			
+----- fire_at                     fire (weapon) at (target)       1
+----- fix     (+ mend, repair)              fix (obj)          1                 x
+----- follow                                                      follow (act)                        1
 ----- free        (+ release)                                     free (obj)                          1                 x
------ get_up                                                      get up                              0					
+----- get_up                                                      get up                              0
 ----- get_off                                                     get off (obj)                       1                 x
 ----- give                                                        give (obj) to (recipient)           1                 x
------ go_to                                                       go to (dest)                        1			
+----- go_to                                                       go to (dest)                        1
 ----- hint        (+ hints)                                       hint                                0
------ i   		  (+ inv, inventory						  inventory                           0
+----- i         (+ inv, inventory             inventory                           0
 ----- jump                                                        jump                                0
------ jump_in                                                     jump in (cont)                      1			
------ jump_on                                                     jump on (surface)                   1 			
+----- jump_in                                                     jump in (cont)                      1
+----- jump_on                                                     jump on (surface)                   1
 ----- kick                                                        kick (target)                       1
------ kill        (+ murder)                                      kill (victim)                       1			
------ kill_with                                                   kill (victim) with (weapon)         2			
+----- kill        (+ murder)                                      kill (victim)                       1
+----- kill_with                                                   kill (victim) with (weapon)         2
 ----- kiss        (+ hug, embrace)                                kiss (obj)                          1                 x
 ----- knock
 ----- lie_down                                                    lie down                            0
------ lie_in                                                      lie in (cont)                       1     
+----- lie_in                                                      lie in (cont)                       1
 ----- lie_on                                                      lie on (surface)                    1
 ----- lift                                                        lift (obj)                          1                 x
 ----- light       (+ lit)                                         light (obj)                         1                 x
 ----- listen0                                                     listen                              0
 ----- listen                                                      listen to (obj)                     1                 x
 ----- lock                                                        lock (obj)                          1                 x
------ lock_with                                                   lock (obj) with (key)               2                 x	
------ look        (+ gaze, peek)                                  look                                0						
+----- lock_with                                                   lock (obj) with (key)               2                 x
+----- look        (+ gaze, peek)                                  look                                0
 ----- look_at                                                     look at (obj)                       1                 x
------ look_behind                                                 look behind (bulk)                  1			
------ look_in                                                     look in (cont)                      1			
------ look_out_of                                                 look out of (obj)                   1                 x				
------ look_through                                                look through (bulk)                 1  		
------ look_under                                                  look under (bulk)                   1 			
+----- look_behind                                                 look behind (bulk)                  1
+----- look_in                                                     look in (cont)                      1
+----- look_out_of                                                 look out of (obj)                   1                 x
+----- look_through                                                look through (bulk)                 1
+----- look_under                                                  look under (bulk)                   1
 ----- look_up                                                     look up                             0
------ no                                                          no                                  0						
+----- no                                                          no                                  0
 ----- notify (on, off)                                            notify. notify on. notify off       0
 ----- open                                                        open (obj)                          1                 x
------ open_with                                                   open (obj) with (instr)             2                 x	
+----- open_with                                                   open (obj) with (instr)             2                 x
 ----- play                                                        play (obj)                          1                 x
 ----- play_with                                                   play with (obj)                     1                 x
 ----- pour        (= defined at the verb 'empty)                  pour (obj)                          1                 x
------ pour_in     (= defined at the verb 'emtpy_in')              pour (obj) in (cont)                2                 x  
+----- pour_in     (= defined at the verb 'emtpy_in')              pour (obj) in (cont)                2                 x
 ----- pour_on     (= defined at the verb 'empty_on')              pour (obj) on (surface)             2                 x
 ----- pray                                                        pray                                0
 ----- pry                                                         pry (obj)                           1                 x
 ----- pry_with                                                    pry (obj) with (instr)              2                 x
 ----- pull                                                        pull (obj)                          1                 x
 ----- push                                                        push (obj)                          1                 x
------ push_with                                                   push (obj) with (instr)             2                 x	
+----- push_with                                                   push (obj) with (instr)             2                 x
 ----- put         (+ lay, place)                                  put (obj)                           1                 x
------ put_against									  put (obj) against (bulk))		 2			   x
------ put_behind                                                  put (obj) behind (bulk)             2                 x			
+----- put_against                   put (obj) against (bulk))    2         x
+----- put_behind                                                  put (obj) behind (bulk)             2                 x
 ----- put_down                                                    put down (obj)                      1                 x
 ----- put_in      (+ insert)                                      put (obj) in (cont)                 2                 x
 ----- put_near                                                    put (obj) near (bulk)               2                 x
 ----- put_on                                                      put (obj) on (surface)              2                 x
------ put_under                                                   put (obj) under (bulk)              2                 x 
+----- put_under                                                   put (obj) under (bulk)              2                 x
 ----- read                                                        read (obj)                          1                 x
------ remove										  remove (obj)					 1			   x
------ restart                                                     restart                             0					
------ restore                                                     restore                             0		
+----- remove                      remove (obj)           1         x
+----- restart                                                     restart                             0
+----- restore                                                     restore                             0
 ----- rub                                                         rub (obj)                           1                 x
 ----- save                                                        save                                0
------ say                                                         say (topic)                         1  
+----- say                                                         say (topic)                         1
 ----- say_to                                                      say (topic) to (act)                2
------ score                                                       score                               0 
+----- score                                                       score                               0
 ----- scratch                                                     scratch (obj)                       1                 x
 ----- script                                                      script. script on. script off.      0
 ----- search                                                      search (obj)                        1                 x
------ sell                                                        sell (item)                         1 
+----- sell                                                        sell (item)                         1
 ----- shake                                                       shake (obj)                         1                 x
 ----- shoot (at)                                                  shoot at (target)                   1
------ shoot_with                                                  shoot (target) with (weapon)        2			
------ shout       (+ scream, yell)                                shout                               0 
+----- shoot_with                                                  shoot (target) with (weapon)        2
+----- shout       (+ scream, yell)                                shout                               0
 ----- show        (+ reveal)                                      show (obj) to (act)                 2                 x
------ sing                                                        sing                                0						
+----- sing                                                        sing                                0
 ----- sip                                                         sip (liq)                           1
 ----- sit (down)                                                  sit.  sit down.                     0
 ----- sit_on                                                      sit on (surface)                    1
@@ -143,43 +143,43 @@
 ----- stand_on                                                    stand on (surface)                  1
 ----- swim                                                        swim                                0
 ----- swim_in                                                     swim in (liq)                       1
------ switch										  switch (obj)				      1			  x		
------ switch_on	  (defined at the verb 'turn_on')			  switch on (app)                     1
------ switch_off  (defined at the verb 'turn_off')			  switch off (app)                    1
+----- switch                      switch (obj)              1       x
+----- switch_on   (defined at the verb 'turn_on')       switch on (app)                     1
+----- switch_off  (defined at the verb 'turn_off')        switch off (app)                    1
 ----- take        (+ carry, get, grab, hold, obtain)              take (obj)                          1                 x
 ----- take_from   (+ remove from)                                 take (obj) from (holder)            2                 x
------ talk                                                        talk                                0						
+----- talk                                                        talk                                0
 ----- talk_to     (+ speak)                                       talk to (act)                       1
 ----- taste       (+ lick)                                        taste (obj)                         1                 x
 ----- tear        (+ rip)                                         tear (obj)                          1                 x
------ tell        (+ enlighten, inform)                           tell (act) about (topic)            2	
+----- tell        (+ enlighten, inform)                           tell (act) about (topic)            2
 ----- think                                                       think                               0
 ----- think_about                                                 think about (topic)                 1
 ----- throw                                                       throw (projectile)                  1
------ throw_at                                                    throw (projectile) at (target)      2	
+----- throw_at                                                    throw (projectile) at (target)      2
 ----- throw_in                                                    throw (projectile) in (cont)        2
------ throw_to                                                    throw (projectile) to (recipient)   2 
+----- throw_to                                                    throw (projectile) to (recipient)   2
 ----- tie                                                         tie (obj)                           1                 x
 ----- tie_to                                                      tie (obj) to (target)               2                 x
------ touch       (+ feel)                                        touch (obj)                         1                 x			
------ turn        (+ rotate)                                      turn (obj)                          1                 x 
------ turn_on                                                     turn on (app)                       1                 
+----- touch       (+ feel)                                        touch (obj)                         1                 x
+----- turn        (+ rotate)                                      turn (obj)                          1                 x
+----- turn_on                                                     turn on (app)                       1
 ----- turn_off                                                    turn off (app)                      1
------ undress										  undress					      0
+----- undress                     undress               0
 ----- unlock                                                      unlock (obj)                        1                 x
------ unlock_with                                                 unlock (obj) with (key)             2                 x	
------ use                                                         use (obj)                           1                 x 
+----- unlock_with                                                 unlock (obj) with (key)             2                 x
+----- use                                                         use (obj)                           1                 x
 ----- use_with                                                    use (obj) with (instr)              2                 x
 ----- verbose                                                     verbose                             0
 ----- wait        (+ z)                                           wait                                0
------ wear											  wear (obj)					 1			   x	
+----- wear                        wear (obj)           1         x
 ----- what_am_i                                                   what am i                           0
------ what_is                                                     what is (obj)                       1                 x	
+----- what_is                                                     what is (obj)                       1                 x
 ----- where_am_i                                                  where am i                          0
 ----- where_is                                                    where is (obj)                      1                 x
 ----- who_am_i                                                    who am i                            0
------ who_is                                                      who is (obj)                        1                 x 
------ write                                                       write (txt) on (obj)                2                 x 
+----- who_is                                                      who is (obj)                        1                 x
+----- write                                                       write (txt) on (obj)                2                 x
 ----- yes                                                         yes                                 0
 
 
@@ -200,29 +200,29 @@
 -- =============================================================
 
 
------ ABOUT 
- 
+----- ABOUT
+
 
 -- =============================================================
 
 
 SYNTAX 'about' = 'about'.
-	 
+
 
 VERB 'about'
-	CHECK my_game CAN about
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		"[This is a text adventure, also called interactive fiction, which means that what
-		goes on in the story depends on what you type at the prompt. Commands you can type 
-		are for example GO NORTH (or NORTH or just N), WEST, SOUTHEAST, UP, IN etc for 
-		moving around, but you can try many
-	      other things too, like TAKE LAMP, DROP EVERYTHING, EAT APPLE, EXAMINE BIRD or
-		FOLLOW OLD MAN, to name just a few. LOOK (L) describes your surroundings, and 
-		INVENTORY (I) lists what you are carrying. You can SAVE your game and RESTORE it 
-		later on. 
-		$pType CREDITS to see information about the author and the copyright issues.
-		$pTo stop playing and end the program, type QUIT.]$p"
+  CHECK my_game CAN about
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "[This is a text adventure, also called interactive fiction, which means that what
+    goes on in the story depends on what you type at the prompt. Commands you can type
+    are for example GO NORTH (or NORTH or just N), WEST, SOUTHEAST, UP, IN etc for
+    moving around, but you can try many
+        other things too, like TAKE LAMP, DROP EVERYTHING, EAT APPLE, EXAMINE BIRD or
+    FOLLOW OLD MAN, to name just a few. LOOK (L) describes your surroundings, and
+    INVENTORY (I) lists what you are carrying. You can SAVE your game and RESTORE it
+    later on.
+    $pType CREDITS to see information about the author and the copyright issues.
+    $pTo stop playing and end the program, type QUIT.]$p"
 END VERB.
 
 
@@ -243,11 +243,11 @@ SYNTAX again = again.
 
 
 VERB again
-	CHECK my_game CAN 'again'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		"[The AGAIN command is not supported in this game. As a workaround, try using
-		 the 'up' and 'down' arrow keys to scroll through your previous commands.]" 
+  CHECK my_game CAN 'again'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "[The AGAIN command is not supported in this game. As a workaround, try using
+     the 'up' and 'down' arrow keys to scroll through your previous commands.]"
 END VERB.
 
 
@@ -258,24 +258,24 @@ SYNONYMS g = again.
 -- =============================================================
 
 
------ ANSWER   	(+ reply)
+----- ANSWER    (+ reply)
 
 
 -- =============================================================
 
 
 SYNTAX answer = answer (topic)
-	WHERE topic ISA STRING
-		ELSE SAY illegal_parameter_string OF my_game.
+  WHERE topic ISA STRING
+    ELSE SAY illegal_parameter_string OF my_game.
 
 
 ADD TO EVERY STRING
-	VERB answer
-		CHECK my_game CAN answer
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-			"What was the question?"
-   	END VERB.
+  VERB answer
+    CHECK my_game CAN answer
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      "What was the question?"
+    END VERB.
 END ADD TO.
 
 
@@ -292,51 +292,51 @@ SYNONYMS reply = answer.
 
 
 SYNTAX ask = ask (act) about (topic)!
-    	WHERE act ISA ACTOR
-      	ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter_talk_sg OF my_game. 
-				ELSE SAY illegal_parameter_talk_pl OF my_game.
-			END IF.
-    	AND topic ISA THING
-     		ELSE 
-			IF topic IS NOT plural 
-				THEN SAY illegal_parameter_about_sg OF my_game. 
-				ELSE SAY illegal_parameter_about_pl OF my_game. 
-			END IF.
-	 
-	 ask = enquire (act) about (topic)!.
+      WHERE act ISA ACTOR
+        ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter_talk_sg OF my_game.
+        ELSE SAY illegal_parameter_talk_pl OF my_game.
+      END IF.
+      AND topic ISA THING
+        ELSE
+      IF topic IS NOT plural
+        THEN SAY illegal_parameter_about_sg OF my_game.
+        ELSE SAY illegal_parameter_about_pl OF my_game.
+      END IF.
 
-	 ask = inquire (act) about (topic)!.
+   ask = enquire (act) about (topic)!.
 
-	 ask = interrogate (act) about (topic)!.
+   ask = inquire (act) about (topic)!.
 
-	-- Above, we define the alternative verbs in the syntax rather than as synonyms,
-	-- as the verb 'ask_for' below doesn't sound correct with these alternatives allowed.	
+   ask = interrogate (act) about (topic)!.
+
+  -- Above, we define the alternative verbs in the syntax rather than as synonyms,
+  -- as the verb 'ask_for' below doesn't sound correct with these alternatives allowed.
 
 
 ADD TO EVERY ACTOR
-	VERB ask
-    		WHEN act
-			CHECK my_game CAN ask
-				ELSE SAY restricted_response OF my_game.
-			AND act <> hero
-				ELSE SAY check_obj_not_hero1 OF my_game. 
-      		AND act CAN talk
-        			ELSE 
-					IF act IS NOT plural
-						THEN SAY check_act_can_talk_sg OF my_game.
-						ELSE SAY check_act_can_talk_pl OF my_game.
-					END IF.
-			AND act IS NOT distant			
-				ELSE 
-					IF act IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game.
-						ELSE SAY check_obj_not_distant_pl OF my_game.
-					END IF.
-      		DOES 
-				"There is no reply."
-  	END VERB.
+  VERB ask
+        WHEN act
+      CHECK my_game CAN ask
+        ELSE SAY restricted_response OF my_game.
+      AND act <> hero
+        ELSE SAY check_obj_not_hero1 OF my_game.
+          AND act CAN talk
+              ELSE
+          IF act IS NOT plural
+            THEN SAY check_act_can_talk_sg OF my_game.
+            ELSE SAY check_act_can_talk_pl OF my_game.
+          END IF.
+      AND act IS NOT distant
+        ELSE
+          IF act IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+          DOES
+        "There is no reply."
+    END VERB.
 END ADD TO.
 
 
@@ -355,77 +355,77 @@ END ADD TO.
 
 
 SYNTAX ask_for = ask (act) 'for' (obj)
-	WHERE act ISA ACTOR
-		ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter_talk_sg OF my_game. 
-				ELSE SAY illegal_parameter_talk_pl OF my_game. 
-			END IF.
-	AND obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_for_sg OF my_game. 
-				ELSE SAY illegal_parameter_for_pl OF my_game. 
-			END IF.
+  WHERE act ISA ACTOR
+    ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter_talk_sg OF my_game.
+        ELSE SAY illegal_parameter_talk_pl OF my_game.
+      END IF.
+  AND obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_for_sg OF my_game.
+        ELSE SAY illegal_parameter_for_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY ACTOR
-	VERB ask_for
-   		WHEN act
-			CHECK my_game CAN ask_for
-				ELSE SAY restricted_response OF my_game.
-			AND act <> hero
-				ELSE SAY check_obj_not_hero1 OF my_game. 
-      		AND act CAN talk 
-        			ELSE 
-					IF act IS NOT plural
-						THEN SAY check_act_can_talk_sg OF my_game.
-						ELSE SAY check_act_can_talk_pl OF my_game.
-					END IF.
-			AND obj IS examinable
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_for_sg OF my_game.
-						ELSE SAY check_obj2_suitable_for_pl OF my_game.
-					END IF. 
-			AND obj NOT IN hero
-				ELSE SAY check_obj2_not_in_hero3 OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND act IS NOT distant		
-				ELSE 
-					IF act IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game.
-					END IF.
-			AND obj IS takeable
-				ELSE SAY check_obj2_takeable2 OF my_game.
-		
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN SAY check_obj_reachable_ask OF my_game.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND obj IS NOT scenery
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj2_not_scenery_sg OF my_game.
-						ELSE SAY check_obj2_not_scenery_pl OF my_game.
-					END IF.
-			DOES 
-				MAKE act compliant.		
-				-- It is only possible to get something from an NPC
-				-- if the NPC is 'compliant'.
-				LOCATE obj IN hero.
-				SAY THE act. "gives" SAY THE obj. "to you."
-				MAKE act NOT compliant.			
-	END VERB. 
+  VERB ask_for
+      WHEN act
+      CHECK my_game CAN ask_for
+        ELSE SAY restricted_response OF my_game.
+      AND act <> hero
+        ELSE SAY check_obj_not_hero1 OF my_game.
+          AND act CAN talk
+              ELSE
+          IF act IS NOT plural
+            THEN SAY check_act_can_talk_sg OF my_game.
+            ELSE SAY check_act_can_talk_pl OF my_game.
+          END IF.
+      AND obj IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_for_sg OF my_game.
+            ELSE SAY check_obj2_suitable_for_pl OF my_game.
+          END IF.
+      AND obj NOT IN hero
+        ELSE SAY check_obj2_not_in_hero3 OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND act IS NOT distant
+        ELSE
+          IF act IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+      AND obj IS takeable
+        ELSE SAY check_obj2_takeable2 OF my_game.
+
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN SAY check_obj_reachable_ask OF my_game.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND obj IS NOT scenery
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_not_scenery_sg OF my_game.
+            ELSE SAY check_obj2_not_scenery_pl OF my_game.
+          END IF.
+      DOES
+        MAKE act compliant.
+        -- It is only possible to get something from an NPC
+        -- if the NPC is 'compliant'.
+        LOCATE obj IN hero.
+        SAY THE act. "gives" SAY THE obj. "to you."
+        MAKE act NOT compliant.
+  END VERB.
 END ADD TO.
 
 
@@ -434,19 +434,19 @@ END ADD TO.
 
 
 SYNTAX ask_for_error = ask 'for' (obj)
-	WHERE obj ISA OBJECT
-		ELSE "Please use the formulation ASK PERSON FOR THING to ask somebody for 
-			 something."
+  WHERE obj ISA OBJECT
+    ELSE "Please use the formulation ASK PERSON FOR THING to ask somebody for
+       something."
 
 
 ADD TO EVERY OBJECT
-	VERB ask_for_error
-		DOES 
-			"Please use the formulation ASK PERSON FOR THING to ask somebody for
-           	 something."
-	END VERB.
+  VERB ask_for_error
+    DOES
+      "Please use the formulation ASK PERSON FOR THING to ask somebody for
+             something."
+  END VERB.
 END ADD TO.
- 
+
 
 
 -- =============================================================
@@ -459,59 +459,59 @@ END ADD TO.
 
 
 SYNTAX attack = attack (target)
-    	WHERE target ISA THING
-     		ELSE 
-			IF target IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+      WHERE target ISA THING
+        ELSE
+      IF target IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB attack
-		CHECK my_game CAN attack
-			ELSE SAY restricted_response OF my_game.
-		AND target IS examinable
-			ELSE 
-				IF target IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF. 
-		AND target <> hero 
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		AND target NOT IN hero
-			ELSE SAY check_obj_not_in_hero1 OF my_game.
-		AND target NOT IN worn
-			ELSE SAY check_obj_not_in_worn2 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND target IS reachable AND target IS NOT distant
-			ELSE
-				IF target IS NOT reachable
-					THEN  
-						IF target IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF target IS distant
-					THEN
-						IF target IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting2 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down2 OF my_game.
-    		DOES 
-			"Resorting to brute force is not the solution here."
-  	END VERB.
+  VERB attack
+    CHECK my_game CAN attack
+      ELSE SAY restricted_response OF my_game.
+    AND target IS examinable
+      ELSE
+        IF target IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND target <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND target NOT IN hero
+      ELSE SAY check_obj_not_in_hero1 OF my_game.
+    AND target NOT IN worn
+      ELSE SAY check_obj_not_in_worn2 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND target IS reachable AND target IS NOT distant
+      ELSE
+        IF target IS NOT reachable
+          THEN
+            IF target IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF target IS distant
+          THEN
+            IF target IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting2 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down2 OF my_game.
+        DOES
+      "Resorting to brute force is not the solution here."
+    END VERB.
 END ADD TO.
 
 
 SYNONYMS beat, fight, hit, punch = attack.
- 
+
 -- Note that 'kick' is defined separately, to avoid absurd commands such as
 -- 'kick man with sword' (see 'attack_with' below)
 
@@ -527,64 +527,64 @@ SYNONYMS beat, fight, hit, punch = attack.
 
 
 SYNTAX attack_with = attack (target) 'with' (weapon)
-    	WHERE target ISA THING
-		ELSE 
-			IF target IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game.
-				ELSE SAY illegal_parameter_pl OF my_game.
-			END IF.
-    	AND weapon ISA WEAPON
-     		ELSE 
-			IF weapon IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
-			
+      WHERE target ISA THING
+    ELSE
+      IF target IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+      AND weapon ISA WEAPON
+        ELSE
+      IF weapon IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY THING
-	VERB attack_with
-    		WHEN target
-			CHECK my_game CAN attack_with
-				ELSE SAY restricted_response OF my_game.
-			AND target IS examinable
-	  			ELSE 
-					IF target IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF. 
-			AND target <> weapon
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-			AND target <> hero 
-				ELSE SAY check_obj_not_hero1 OF my_game.
-			AND target NOT IN hero
-				ELSE SAY check_obj_not_in_hero1 OF my_game. 
-			AND target NOT IN worn
-				ELSE SAY check_obj_not_in_worn2 OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND target IS reachable AND target IS NOT distant
-				ELSE
-					IF target IS NOT reachable
-						THEN  
-							IF target IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF target IS distant
-						THEN
-							IF target IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.	
-			AND hero IS NOT sitting
-				ELSE SAY check_hero_not_sitting2 OF my_game.
-			AND hero IS NOT lying_down
-				ELSE SAY check_hero_not_lying_down2 OF my_game.
-      		DOES 
-				"Resorting to brute force is not the solution here."
-	END VERB.
+  VERB attack_with
+        WHEN target
+      CHECK my_game CAN attack_with
+        ELSE SAY restricted_response OF my_game.
+      AND target IS examinable
+          ELSE
+          IF target IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND target <> weapon
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND target <> hero
+        ELSE SAY check_obj_not_hero1 OF my_game.
+      AND target NOT IN hero
+        ELSE SAY check_obj_not_in_hero1 OF my_game.
+      AND target NOT IN worn
+        ELSE SAY check_obj_not_in_worn2 OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND target IS reachable AND target IS NOT distant
+        ELSE
+          IF target IS NOT reachable
+            THEN
+              IF target IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF target IS distant
+            THEN
+              IF target IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND hero IS NOT sitting
+        ELSE SAY check_hero_not_sitting2 OF my_game.
+      AND hero IS NOT lying_down
+        ELSE SAY check_hero_not_lying_down2 OF my_game.
+          DOES
+        "Resorting to brute force is not the solution here."
+  END VERB.
 END ADD TO.
 
 
@@ -592,72 +592,72 @@ END ADD TO.
 -- ===============================================================
 
 
------ BITE 	(+ chew)
- 
+----- BITE  (+ chew)
+
 
 -- ===============================================================
 
 
 SYNTAX bite = bite (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF. 
-        
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB bite
-		CHECK my_game CAN bite
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS edible
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj IS takeable
-			ELSE SAY check_obj_takeable OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS NOT distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.		
-		DOES 
-			-- This if-statement takes care of implicit taking; i.e. if the hero
-			-- doesn't have the object, (s)he will take it automatically first
-			-- - unless it's carried by another actor.
-			-- This same if-statement is found in numerous other verbs throughout 
-			-- the library, as well.
+  VERB bite
+    CHECK my_game CAN bite
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS edible
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj IS takeable
+      ELSE SAY check_obj_takeable OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS NOT distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      -- This if-statement takes care of implicit taking; i.e. if the hero
+      -- doesn't have the object, (s)he will take it automatically first
+      -- - unless it's carried by another actor.
+      -- This same if-statement is found in numerous other verbs throughout
+      -- the library, as well.
 
-			-- implicit taking:
-			IF obj NOT DIRECTLY IN hero 
-				THEN LOCATE obj IN hero.
-				     SAY implicit_taking_message OF my_game.
-			END IF.								
-			-- end of implicit taking.
-			
-			"You take a bite of" SAY THE obj. "$$." 
-				IF obj IS NOT plural
-					THEN "It tastes nothing out of the ordinary."
-					ELSE "They taste nothing out of the ordinary."
-				END IF.
-			
-	END VERB.
+      -- implicit taking:
+      IF obj NOT DIRECTLY IN hero
+        THEN LOCATE obj IN hero.
+             SAY implicit_taking_message OF my_game.
+      END IF.
+      -- end of implicit taking.
+
+      "You take a bite of" SAY THE obj. "$$."
+        IF obj IS NOT plural
+          THEN "It tastes nothing out of the ordinary."
+          ELSE "They taste nothing out of the ordinary."
+        END IF.
+
+  END VERB.
 END ADD TO.
 
 
@@ -675,44 +675,44 @@ SYNONYMS chew = bite.
 
 
 SYNTAX break = break (obj)
-		WHERE obj ISA OBJECT
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB break
-		CHECK my_game CAN break
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES
-			"Resorting to brute force is not the solution here."
-	END VERB.
+  VERB break
+    CHECK my_game CAN break
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "Resorting to brute force is not the solution here."
+  END VERB.
 END ADD TO.
 
 
@@ -730,62 +730,62 @@ SYNONYMS destroy = break.
 
 
 SYNTAX break_with = break (obj) 'with' (instr)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND instr ISA OBJECT
-		ELSE 
-			IF instr IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND instr ISA OBJECT
+    ELSE
+      IF instr IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB break_with
-		WHEN obj
-			CHECK my_game CAN break_with
-				ELSE SAY restricted_response OF my_game.
-			AND obj IS examinable
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF. 
-			AND instr IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-			AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND instr IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.		
-			DOES		
-				"Trying to break" SAY THE obj. "with" SAY THE instr. 
-				"wouldn't accomplish anything."
-	END VERB.
+  VERB break_with
+    WHEN obj
+      CHECK my_game CAN break_with
+        ELSE SAY restricted_response OF my_game.
+      AND obj IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND instr IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND instr IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      DOES
+        "Trying to break" SAY THE obj. "with" SAY THE instr.
+        "wouldn't accomplish anything."
+  END VERB.
 END ADD TO.
 
 
@@ -808,12 +808,12 @@ SYNTAX brief = brief.
 
 
 VERB brief
-	CHECK my_game CAN brief
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		Visits 1000.
-		"Brief mode is now on. Location descriptions will only be shown
-		the first time you visit."
+  CHECK my_game CAN brief
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    Visits 1000.
+    "Brief mode is now on. Location descriptions will only be shown
+    the first time you visit."
 END VERB.
 
 
@@ -828,29 +828,29 @@ END VERB.
 
 
 SYNTAX burn = burn (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB burn
-		CHECK my_game CAN burn
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.		
-		DOES
-			"You must state what you want to burn" SAY THE obj. "with."
-	END VERB.
+  VERB burn
+    CHECK my_game CAN burn
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "You must state what you want to burn" SAY THE obj. "with."
+  END VERB.
 END ADD TO.
 
 
@@ -865,62 +865,62 @@ END ADD TO.
 
 
 SYNTAX burn_with = burn (obj) 'with' (instr)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.	
-	AND instr ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND instr ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB burn_with
-		WHEN obj
-			CHECK my_game CAN burn_with
-				ELSE SAY restricted_response OF my_game.
-			AND obj IS examinable
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.	
-			AND instr IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-			AND obj <> instr 
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-			AND instr IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			
-			DOES
-				"You can't burn" SAY THE obj. "with" SAY THE instr. "."
-	END VERB.
+  VERB burn_with
+    WHEN obj
+      CHECK my_game CAN burn_with
+        ELSE SAY restricted_response OF my_game.
+      AND obj IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND instr IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND instr IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+
+      DOES
+        "You can't burn" SAY THE obj. "with" SAY THE instr. "."
+  END VERB.
 END ADD TO.
 
 
@@ -935,31 +935,31 @@ END ADD TO.
 
 
 SYNTAX buy = buy (item)
-	WHERE item ISA OBJECT
-		ELSE  
-			IF item IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE item ISA OBJECT
+    ELSE
+      IF item IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB buy
-		CHECK my_game CAN buy
-			ELSE SAY restricted_response OF my_game.
-		AND item IS examinable
-			ELSE 
-				IF item IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		DOES
-			IF item IS NOT plural
-				THEN "That's not" 
-				ELSE "Those are not"
-			END IF. 
-			"for sale."
-	END VERB.
+  VERB buy
+    CHECK my_game CAN buy
+      ELSE SAY restricted_response OF my_game.
+    AND item IS examinable
+      ELSE
+        IF item IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    DOES
+      IF item IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "for sale."
+  END VERB.
 END ADD TO.
 
 
@@ -977,40 +977,40 @@ SYNONYMS purchase = buy.
 
 
 SYNTAX catch = catch (obj)
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB catch
-		CHECK my_game CAN catch
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj <> hero 
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting2 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down2 OF my_game.
-		DOES
-			IF obj IS NOT plural
-				THEN "That doesn't" 
-				ELSE "Those don't"
-			END IF.
-	
-	      	"need to be caught."
-	END VERB.
+  VERB catch
+    CHECK my_game CAN catch
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting2 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down2 OF my_game.
+    DOES
+      IF obj IS NOT plural
+        THEN "That doesn't"
+        ELSE "Those don't"
+      END IF.
+
+          "need to be caught."
+  END VERB.
 END ADD TO.
 
 
@@ -1025,45 +1025,45 @@ END ADD TO.
 
 
 SYNTAX clean = clean (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-				
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB clean
-		CHECK my_game CAN clean
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-			"Nothing would be achieved by that."
-	END VERB.
+  VERB clean
+    CHECK my_game CAN clean
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "Nothing would be achieved by that."
+  END VERB.
 END ADD TO.
 
 
@@ -1084,53 +1084,53 @@ SYNONYMS wipe, polish = clean.
 
 
 SYNTAX climb = climb (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game.
-				ELSE SAY illegal_parameter_pl OF my_game.
-			END IF.
-			
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
   VERB climb
-	CHECK my_game CAN climb
-		ELSE SAY restricted_response OF my_game.
-	AND obj IS examinable
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY check_obj_suitable_sg OF my_game. 
-				ELSE SAY check_obj_suitable_pl OF my_game. 
-			END IF.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-	AND hero IS NOT sitting
-		ELSE SAY check_hero_not_sitting3 OF my_game.
-	AND hero IS NOT lying_down
-		ELSE SAY check_hero_not_lying_down3 OF my_game.
-	DOES 
-		IF obj IS NOT plural
-			THEN "That's not" 
-			ELSE "Those are not"
-		END IF.
-		"something you can climb."
-	END VERB.
+  CHECK my_game CAN climb
+    ELSE SAY restricted_response OF my_game.
+  AND obj IS examinable
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY check_obj_suitable_sg OF my_game.
+        ELSE SAY check_obj_suitable_pl OF my_game.
+      END IF.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+  AND hero IS NOT sitting
+    ELSE SAY check_hero_not_sitting3 OF my_game.
+  AND hero IS NOT lying_down
+    ELSE SAY check_hero_not_lying_down3 OF my_game.
+  DOES
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can climb."
+  END VERB.
 END ADD TO.
 
 
@@ -1145,46 +1145,46 @@ END ADD TO.
 
 
 SYNTAX climb_on = climb 'on' (surface)
-	WHERE surface ISA SUPPORTER
-		ELSE 
-			IF surface IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
+  WHERE surface ISA SUPPORTER
+    ELSE
+      IF surface IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY SUPPORTER
-	VERB climb_on
-		CHECK my_game CAN climb_on
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND surface IS reachable AND surface IS NOT distant
-			ELSE
-				IF surface IS NOT reachable
-					THEN  
-						IF surface IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF surface IS NOT distant
-					THEN
-						IF surface IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game.
-						END IF.
-				END IF.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting3 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down3 OF my_game.
-		DOES 
-			IF surface IS NOT plural
-				THEN "That's not" 
-				ELSE "Those are not"
-			END IF.
-			"something you can climb on."
-	END VERB.
+  VERB climb_on
+    CHECK my_game CAN climb_on
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND surface IS reachable AND surface IS NOT distant
+      ELSE
+        IF surface IS NOT reachable
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF surface IS NOT distant
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting3 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down3 OF my_game.
+    DOES
+      IF surface IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can climb on."
+  END VERB.
 END ADD TO.
 
 
@@ -1199,52 +1199,52 @@ END ADD TO.
 
 
 SYNTAX climb_through = climb through (obj)
-		WHERE obj ISA OBJECT
-			ELSE
-			 	IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB climb_through
-		CHECK my_game CAN climb_through
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting3 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down3 OF my_game.
-		DOES 
-			IF obj IS NOT plural
-				THEN "That's not" 
-				ELSE "Those are not"
-			END IF.
-			"something you can climb through."
-	END VERB.
+  VERB climb_through
+    CHECK my_game CAN climb_through
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting3 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down3 OF my_game.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can climb through."
+  END VERB.
 END ADD TO.
 
 
@@ -1260,50 +1260,50 @@ END ADD TO.
 
 SYNTAX close = close (obj)
         WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB close
-		CHECK my_game CAN close
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS openable
-	    		ELSE
-		 		IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-		 		END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		AND obj IS open
-	    		ELSE
-		 		IF obj IS NOT plural
-					THEN SAY check_obj_open1_sg OF my_game.
-					ELSE SAY check_obj_open1_pl OF my_game.
-		 		END IF.
-		
-		DOES
-	    		MAKE obj NOT open.
-	    		"You close the" SAY THE obj. "."
+  VERB close
+    CHECK my_game CAN close
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS openable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND obj IS open
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_open1_sg OF my_game.
+          ELSE SAY check_obj_open1_pl OF my_game.
+        END IF.
+
+    DOES
+          MAKE obj NOT open.
+          "You close the" SAY THE obj. "."
   END VERB.
 END ADD TO.
 
@@ -1322,68 +1322,68 @@ SYNONYMS shut = close.
 
 
 SYNTAX close_with = close (obj) 'with' (instr)
-	WHERE obj ISA OBJECT
-	   	ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND instr ISA OBJECT
-	    	ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND instr ISA OBJECT
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB close_with
-		WHEN obj
-			CHECK my_game CAN close_with
-				ELSE SAY restricted_response OF my_game.
-			AND obj IS openable
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-		 			END IF.
-			AND instr IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-			AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-			AND instr IN hero
-				ELSE SAY check_obj2_in_hero OF my_game. 
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-				END IF.	
-			AND obj IS open
-	    			ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_open1_sg OF my_game.
-						ELSE SAY check_obj_open1_pl OF my_game.
-					END IF.
+  VERB close_with
+    WHEN obj
+      CHECK my_game CAN close_with
+        ELSE SAY restricted_response OF my_game.
+      AND obj IS openable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND instr IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND instr IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+        END IF.
+      AND obj IS open
+            ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_open1_sg OF my_game.
+            ELSE SAY check_obj_open1_pl OF my_game.
+          END IF.
 
-			DOES
-	    			"You can't $v" SAY THE obj. "with" SAY THE instr. "."
-	END VERB.
+      DOES
+            "You can't $v" SAY THE obj. "with" SAY THE instr. "."
+  END VERB.
 END ADD TO.
 
 
@@ -1398,55 +1398,55 @@ END ADD TO.
 
 
 SYNTAX consult = consult (source) about (topic)!
-	WHERE source ISA OBJECT
-		-- you can only consult an inanimate source, not a person.
-		ELSE 
-			IF source IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND topic ISA THING
-		ELSE 
-			IF topic IS NOT plural
-				THEN SAY illegal_parameter_consult_sg OF my_game.    
-				ELSE SAY illegal_parameter_consult_pl OF my_game. 
-			END IF.
-	
-	consult = 'look' 'up' (topic) 'in' (source).
+  WHERE source ISA OBJECT
+    -- you can only consult an inanimate source, not a person.
+    ELSE
+      IF source IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND topic ISA THING
+    ELSE
+      IF topic IS NOT plural
+        THEN SAY illegal_parameter_consult_sg OF my_game.
+        ELSE SAY illegal_parameter_consult_pl OF my_game.
+      END IF.
+
+  consult = 'look' 'up' (topic) 'in' (source).
 
 
 ADD TO EVERY THING
-	VERB consult
-		WHEN source
-			CHECK my_game CAN consult
-				ELSE SAY restricted_response OF my_game.
-			AND source IS examinable
-				ELSE 
-					IF source IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND source IS reachable AND source IS NOT distant
-				ELSE
-					IF source IS NOT reachable
-						THEN  
-							IF source IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF source IS distant
-						THEN
-							IF source IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			DOES
-				"You find nothing useful about" SAY THE topic. "in" SAY THE source. "."
-		
-	END VERB.
+  VERB consult
+    WHEN source
+      CHECK my_game CAN consult
+        ELSE SAY restricted_response OF my_game.
+      AND source IS examinable
+        ELSE
+          IF source IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND source IS reachable AND source IS NOT distant
+        ELSE
+          IF source IS NOT reachable
+            THEN
+              IF source IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF source IS distant
+            THEN
+              IF source IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      DOES
+        "You find nothing useful about" SAY THE topic. "in" SAY THE source. "."
+
+  END VERB.
 END ADD TO.
 
 
@@ -1454,16 +1454,16 @@ END ADD TO.
 
 
 SYNTAX consult_error = consult (source)
-	WHERE source ISA THING
-		ELSE "To consult something, please use the 
-			formulation CONSULT THING ABOUT PERSON/THING."	
+  WHERE source ISA THING
+    ELSE "To consult something, please use the
+      formulation CONSULT THING ABOUT PERSON/THING."
 
 
 ADD TO EVERY THING
-	VERB consult_error
-		DOES "To consult something, please use the formulation CONSULT THING 
-			ABOUT PERSON/THING."	
-  	END VERB.
+  VERB consult_error
+    DOES "To consult something, please use the formulation CONSULT THING
+      ABOUT PERSON/THING."
+    END VERB.
 END ADD TO.
 
 
@@ -1481,16 +1481,16 @@ SYNTAX credits = credits.
 
 
 VERB credits
-	CHECK my_game CAN credits
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		"The author retains the copyright to this game.
-		$pThis game was written using the ALAN Adventure Language. ALAN is 
-		an interactive fiction authoring system by Thomas Nilsson.
-		$nE-mail address: thomas@alanif.se $pFurther information 
-		about the ALAN system can be obtained from
-		the World Wide Web Internet site
-		$ihttp://www.alanif.se$p"
+  CHECK my_game CAN credits
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "The author retains the copyright to this game.
+    $pThis game was written using the ALAN Adventure Language. ALAN is
+    an interactive fiction authoring system by Thomas Nilsson.
+    $nE-mail address: thomas@alanif.se $pFurther information
+    about the ALAN system can be obtained from
+    the World Wide Web Internet site
+    $ihttp://www.alanif.se$p"
 END VERB.
 
 
@@ -1508,28 +1508,28 @@ SYNONYMS acknowledgments, author, copyright = credits.
 
 
 SYNTAX cut = cut (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB cut
-		CHECK my_game CAN cut
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.	
-		DOES "You need to specify what you want to cut" SAY THE obj. "with."
-  	END VERB.
+  VERB cut
+    CHECK my_game CAN cut
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES "You need to specify what you want to cut" SAY THE obj. "with."
+    END VERB.
 END ADD TO.
 
 
@@ -1544,61 +1544,61 @@ END ADD TO.
 
 
 SYNTAX cut_with = cut (obj) 'with' (instr)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND instr ISA OBJECT
-		ELSE 
-			IF instr IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND instr ISA OBJECT
+    ELSE
+      IF instr IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB cut_with
-		WHEN obj
-			CHECK my_game CAN cut_with
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-			AND obj IS examinable
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND instr IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-			AND instr IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.			
-			DOES 
-				"You can't cut" SAY THE obj. "with" SAY THE instr. "."
-	END VERB.
+  VERB cut_with
+    WHEN obj
+      CHECK my_game CAN cut_with
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND obj IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND instr IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND instr IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      DOES
+        "You can't cut" SAY THE obj. "with" SAY THE instr. "."
+  END VERB.
 END ADD TO.
 
 
@@ -1616,16 +1616,16 @@ SYNTAX dance = dance.
 
 
 VERB dance
-	CHECK my_game CAN dance
-		ELSE SAY restricted_response OF my_game.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	AND hero IS NOT sitting
-		ELSE SAY check_hero_not_sitting1 OF my_game.
-	AND hero IS NOT lying_down
-		ELSE SAY check_hero_not_lying_down1 OF my_game.
-  	DOES
-    		"How about a waltz?"
+  CHECK my_game CAN dance
+    ELSE SAY restricted_response OF my_game.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  AND hero IS NOT sitting
+    ELSE SAY check_hero_not_sitting1 OF my_game.
+  AND hero IS NOT lying_down
+    ELSE SAY check_hero_not_lying_down1 OF my_game.
+    DOES
+        "How about a waltz?"
 END VERB.
 
 
@@ -1640,42 +1640,42 @@ END VERB.
 
 
 SYNTAX dig = dig (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB dig
-		CHECK my_game CAN dig
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting2 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down2 OF my_game.
-		DOES 
-			"There is nothing suitable to dig here."
-	END VERB.
+  VERB dig
+    CHECK my_game CAN dig
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting2 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down2 OF my_game.
+    DOES
+      "There is nothing suitable to dig here."
+  END VERB.
 END ADD TO.
 
 
@@ -1692,17 +1692,17 @@ END ADD TO.
 SYNTAX dive = dive.
 
 
-VERB dive 	
-	CHECK my_game CAN dive
-		ELSE SAY restricted_response OF my_game.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	AND hero IS NOT sitting
-		ELSE SAY check_hero_not_sitting3 OF my_game.
-	AND hero IS NOT lying_down
-		ELSE SAY check_hero_not_lying_down3 OF my_game.
-	DOES 
-		"There is no water suitable for swimming here."
+VERB dive
+  CHECK my_game CAN dive
+    ELSE SAY restricted_response OF my_game.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  AND hero IS NOT sitting
+    ELSE SAY check_hero_not_sitting3 OF my_game.
+  AND hero IS NOT lying_down
+    ELSE SAY check_hero_not_lying_down3 OF my_game.
+  DOES
+    "There is no water suitable for swimming here."
 END VERB.
 
 
@@ -1717,41 +1717,41 @@ END VERB.
 
 
 SYNTAX dive_in = dive 'in' (liq)
-	WHERE liq ISA LIQUID  	-- see 'classes.i'
-		ELSE 
-			IF liq IS NOT plural
-				THEN SAY illegal_parameter_in_sg OF my_game. 
-				ELSE SAY illegal_parameter_in_pl OF my_game. 
-			END IF.
+  WHERE liq ISA LIQUID    -- see 'classes.i'
+    ELSE
+      IF liq IS NOT plural
+        THEN SAY illegal_parameter_in_sg OF my_game.
+        ELSE SAY illegal_parameter_in_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB dive_in
-		CHECK my_game CAN dive_in
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting3 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down3 OF my_game.	
-		-- notice that, unlike 'swim_in', it is possible to dive in a 
-		-- not reachable object (for example from a clifftop into a river)
-		-- but not to a distant object:
-		AND liq IS NOT distant
-			ELSE
-				IF liq IS NOT plural
-					THEN SAY check_obj_not_distant_sg OF my_game. 
-					ELSE SAY check_obj_not_distant_pl OF my_game. 
-				END IF.
-		DOES 
-			IF liq IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-		
-			"something you can dive in."
-	END VERB.
+  VERB dive_in
+    CHECK my_game CAN dive_in
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting3 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down3 OF my_game.
+    -- notice that, unlike 'swim_in', it is possible to dive in a
+    -- not reachable object (for example from a clifftop into a river)
+    -- but not to a distant object:
+    AND liq IS NOT distant
+      ELSE
+        IF liq IS NOT plural
+          THEN SAY check_obj_not_distant_sg OF my_game.
+          ELSE SAY check_obj_not_distant_pl OF my_game.
+        END IF.
+    DOES
+      IF liq IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+
+      "something you can dive in."
+  END VERB.
 END ADD TO.
 
 
@@ -1759,82 +1759,82 @@ END ADD TO.
 -- ==============================================================
 
 
------ DRINK 
+----- DRINK
 
 
 -- ==============================================================
 
 
 SYNTAX drink = drink (liq)
-	WHERE liq ISA LIQUID		-- see 'classes.i'
-		ELSE 
-			IF liq IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE liq ISA LIQUID    -- see 'classes.i'
+    ELSE
+      IF liq IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY LIQUID
-	VERB drink
-		CHECK my_game CAN drink
-			ELSE SAY restricted_response OF my_game.
-		AND liq IS drinkable
-			ELSE 
-				IF liq IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND liq IS reachable AND liq IS NOT distant
-			ELSE
-				IF liq IS NOT reachable
-					THEN  
-						IF liq IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF liq IS distant
-					THEN
-						IF liq IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES
-			IF vessel OF liq = null_vessel		
-				-- here, if the liquid is in no container, for 
-				-- example the hero takes a sip of water from a river,
-				-- the action is allowed to succeed so that the hero 
-				-- drinks some of the liquid:
+  VERB drink
+    CHECK my_game CAN drink
+      ELSE SAY restricted_response OF my_game.
+    AND liq IS drinkable
+      ELSE
+        IF liq IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND liq IS reachable AND liq IS NOT distant
+      ELSE
+        IF liq IS NOT reachable
+          THEN
+            IF liq IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF liq IS distant
+          THEN
+            IF liq IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF vessel OF liq = null_vessel
+        -- here, if the liquid is in no container, for
+        -- example the hero takes a sip of water from a river,
+        -- the action is allowed to succeed so that the hero
+        -- drinks some of the liquid:
 
-				THEN "You drink a bit of" SAY THE liq. "."
-				ELSE 
-					-- = if the liquid is in a container:
+        THEN "You drink a bit of" SAY THE liq. "."
+        ELSE
+          -- = if the liquid is in a container:
 
-					-- implicit taking:
-					IF vessel OF liq NOT DIRECTLY IN hero
-						THEN 
-							IF vessel OF liq IS NOT takeable
-								THEN "You can't carry" SAY THE liq. "around in your bare hands."
-									-- the action stops here if the container is not takeable.
-								ELSE
-									LOCATE vessel OF liq IN hero.
-									"(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
-							END IF.
-						
-					END IF.
-					-- end of implicit taking.
-		
-					IF liq IN hero 		
-						-- i.e. if the implicit taking was successful
-						THEN
-							"You drink all of" SAY THE liq. "."
-							LOCATE liq AT nowhere.
-					END IF.
-			END IF.
+          -- implicit taking:
+          IF vessel OF liq NOT DIRECTLY IN hero
+            THEN
+              IF vessel OF liq IS NOT takeable
+                THEN "You can't carry" SAY THE liq. "around in your bare hands."
+                  -- the action stops here if the container is not takeable.
+                ELSE
+                  LOCATE vessel OF liq IN hero.
+                  "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+              END IF.
 
-	END VERB.
+          END IF.
+          -- end of implicit taking.
+
+          IF liq IN hero
+            -- i.e. if the implicit taking was successful
+            THEN
+              "You drink all of" SAY THE liq. "."
+              LOCATE liq AT nowhere.
+          END IF.
+      END IF.
+
+  END VERB.
 END ADD TO.
 
 
@@ -1852,51 +1852,51 @@ END ADD TO.
 
 
 SYNTAX drive = drive (vehicle)
-	WHERE vehicle ISA OBJECT
-		ELSE 
-			IF vehicle IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE vehicle ISA OBJECT
+    ELSE
+      IF vehicle IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB drive
-		CHECK my_game CAN drive
-			ELSE SAY restricted_response OF my_game.
-		AND vehicle IS examinable
-			ELSE 
-				IF vehicle IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND vehicle IS reachable AND vehicle IS NOT distant
-			ELSE
-				IF vehicle IS NOT reachable
-					THEN  
-						IF vehicle IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF vehicle IS distant
-					THEN
-						IF vehicle IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down3 OF my_game.
-		DOES 
-			IF vehicle IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-	
-			"something you can drive."
-	END VERB.
+  VERB drive
+    CHECK my_game CAN drive
+      ELSE SAY restricted_response OF my_game.
+    AND vehicle IS examinable
+      ELSE
+        IF vehicle IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND vehicle IS reachable AND vehicle IS NOT distant
+      ELSE
+        IF vehicle IS NOT reachable
+          THEN
+            IF vehicle IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF vehicle IS distant
+          THEN
+            IF vehicle IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down3 OF my_game.
+    DOES
+      IF vehicle IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+
+      "something you can drive."
+  END VERB.
 END ADD TO.
 
 
@@ -1907,7 +1907,7 @@ SYNTAX drive_error = drive.
 
 
 VERB drive_error
-	DOES "To drive something, use the phrasing DRIVE SOMETHING."
+  DOES "To drive something, use the phrasing DRIVE SOMETHING."
 END VERB.
 
 
@@ -1922,99 +1922,99 @@ END VERB.
 
 
 SYNTAX drop = drop (obj)*
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-  	
-	drop = put (obj) * down.
-	
-	drop = put down (obj)*.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
+  drop = put (obj) * down.
+
+  drop = put down (obj)*.
 
 
 ADD TO EVERY OBJECT
-	VERB drop
-		CHECK my_game CAN drop
-			ELSE SAY restricted_response OF my_game.
-   		AND obj IN hero
-      		ELSE 
-				IF obj IN worn
-					THEN SAY check_obj_not_in_worn3 OF my_game.
-					ELSE SAY check_obj_in_hero OF my_game.
-    				END IF.	
-		DOES
-      		LOCATE obj HERE.
-      		"Dropped."
-  	END VERB.
+  VERB drop
+    CHECK my_game CAN drop
+      ELSE SAY restricted_response OF my_game.
+      AND obj IN hero
+          ELSE
+        IF obj IN worn
+          THEN SAY check_obj_not_in_worn3 OF my_game.
+          ELSE SAY check_obj_in_hero OF my_game.
+            END IF.
+    DOES
+          LOCATE obj HERE.
+          "Dropped."
+    END VERB.
 END ADD TO.
 
 
 SYNONYMS
-	discard, dump, reject = drop.
+  discard, dump, reject = drop.
 
 
 
 -- ==============================================================
 
 
------ EAT 
+----- EAT
 
 
 -- ==============================================================
 
 
 SYNTAX eat = eat (food)
-	WHERE food ISA OBJECT
-		ELSE 
-			IF food IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE food ISA OBJECT
+    ELSE
+      IF food IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB eat
-		CHECK my_game CAN eat
-			ELSE SAY restricted_response OF my_game.
-		AND food IS edible
-			ELSE 
-				IF food IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND food IS takeable
-			ELSE SAY check_obj_takeable OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND food IS reachable AND food IS NOT distant
-			ELSE
-				IF food IS NOT reachable
-					THEN  
-						IF food IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF food IS distant
-					THEN
-						IF food IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-			-- implicit taking:
-			IF food NOT DIRECTLY IN hero 
-				THEN LOCATE food IN hero.
-					SAY implicit_taking_message OF my_game.	
-			END IF.
-			-- end of implicit taking.
-			
-			"You eat all of" SAY THE food. "."
-			LOCATE food AT nowhere.
-			
-	END VERB.
+  VERB eat
+    CHECK my_game CAN eat
+      ELSE SAY restricted_response OF my_game.
+    AND food IS edible
+      ELSE
+        IF food IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND food IS takeable
+      ELSE SAY check_obj_takeable OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND food IS reachable AND food IS NOT distant
+      ELSE
+        IF food IS NOT reachable
+          THEN
+            IF food IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF food IS distant
+          THEN
+            IF food IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      -- implicit taking:
+      IF food NOT DIRECTLY IN hero
+        THEN LOCATE food IN hero.
+          SAY implicit_taking_message OF my_game.
+      END IF.
+      -- end of implicit taking.
+
+      "You eat all of" SAY THE food. "."
+      LOCATE food AT nowhere.
+
+  END VERB.
 END ADD.
 
 
@@ -2029,8 +2029,8 @@ END ADD.
 
 
 -- The verbs 'empty' and 'pour' have similar syntaxes and behaviour here. They are, however,
--- not declared as synonyms but kept separate, as their usage doesn't overlap 100%; for example 
--- you can pour liquids but not empty them. 
+-- not declared as synonyms but kept separate, as their usage doesn't overlap 100%; for example
+-- you can pour liquids but not empty them.
 -- That's why in 'classes.i', liquids are defined only to work with the verb 'pour',
 -- and the verb 'empty' is disabled for liquids.
 
@@ -2038,84 +2038,84 @@ END ADD.
 
 
 SYNTAX 'empty' = 'empty' (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND obj ISA CONTAINER
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	
-	pour = pour (obj)
-		WHERE obj ISA OBJECT
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
-		AND obj ISA CONTAINER
-			ELSE
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND obj ISA CONTAINER
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
+  pour = pour (obj)
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+    AND obj ISA CONTAINER
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB 'empty', pour
-		CHECK my_game CAN 'empty' AND my_game CAN pour
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS takeable
-			ELSE SAY check_obj_takeable OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		AND obj IS open
-			ELSE  
-				IF obj IS NOT plural
-					THEN SAY check_obj_open2_sg OF my_game.
-					ELSE SAY check_obj_open2_pl OF my_game.
-				END IF.
-		DOES 
-			
-			-- implicit taking:
-			IF obj NOT DIRECTLY IN hero 
-				THEN LOCATE obj IN hero.
-					SAY implicit_taking_message OF my_game.
-			END IF.									
-			-- end of implicit taking.
+  VERB 'empty', pour
+    CHECK my_game CAN 'empty' AND my_game CAN pour
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS takeable
+      ELSE SAY check_obj_takeable OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND obj IS open
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_open2_sg OF my_game.
+          ELSE SAY check_obj_open2_pl OF my_game.
+        END IF.
+    DOES
 
-			IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
-				THEN "There is nothing in" SAY THE obj. "."
-				ELSE
-					"You $v the contents of" SAY THE obj.
-						IF floor HERE
-							THEN "on the floor."
-							ELSE "on the ground."
-						END IF.
-					EMPTY obj AT hero.
-			END IF.
-		
-	END VERB.
+      -- implicit taking:
+      IF obj NOT DIRECTLY IN hero
+        THEN LOCATE obj IN hero.
+          SAY implicit_taking_message OF my_game.
+      END IF.
+      -- end of implicit taking.
+
+      IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
+        THEN "There is nothing in" SAY THE obj. "."
+        ELSE
+          "You $v the contents of" SAY THE obj.
+            IF floor HERE
+              THEN "on the floor."
+              ELSE "on the ground."
+            END IF.
+          EMPTY obj AT hero.
+      END IF.
+
+  END VERB.
 END ADD TO.
 
 
@@ -2123,7 +2123,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ EMPTY IN	(+ POUR IN)	
+----- EMPTY IN  (+ POUR IN)
 
 
 -- ==============================================================
@@ -2131,132 +2131,132 @@ END ADD TO.
 
 
 SYNTAX empty_in = 'empty' (obj) 'in' (cont)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND obj ISA CONTAINER
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND cont ISA OBJECT					
-		ELSE 
-			IF cont ISA ACTOR
-				THEN SAY illegal_parameter_act OF my_game.
-				ELSE SAY illegal_parameter2_there OF my_game.
-			END IF. 
-	AND cont ISA CONTAINER
-		ELSE SAY illegal_parameter2_there OF my_game. 
-	
-		
-				
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND obj ISA CONTAINER
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND cont ISA OBJECT
+    ELSE
+      IF cont ISA ACTOR
+        THEN SAY illegal_parameter_act OF my_game.
+        ELSE SAY illegal_parameter2_there OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE SAY illegal_parameter2_there OF my_game.
+
+
+
 pour_in = pour (obj) 'in' (cont)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND obj ISA CONTAINER
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND cont ISA OBJECT					
-		ELSE 
-			IF cont ISA ACTOR
-				THEN SAY illegal_parameter_act OF my_game.
-				ELSE SAY illegal_parameter2_there OF my_game.
-			END IF. 
-	AND cont ISA CONTAINER
-		ELSE SAY illegal_parameter2_there OF my_game.
-			
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND obj ISA CONTAINER
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND cont ISA OBJECT
+    ELSE
+      IF cont ISA ACTOR
+        THEN SAY illegal_parameter_act OF my_game.
+        ELSE SAY illegal_parameter2_there OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE SAY illegal_parameter2_there OF my_game.
+
 
 
 
 ADD TO EVERY OBJECT
-	VERB empty_in, pour_in
-		WHEN obj
-			CHECK my_game CAN empty_in AND my_game CAN pour_in
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> cont
-				ELSE SAY check_obj_not_obj2_in OF my_game. 
-			AND obj IS takeable
-				ELSE SAY check_obj_takeable OF my_game. 
-			AND cont NOT IN obj
-				ELSE SAY check_cont_not_in_obj OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND cont IS reachable AND cont IS NOT distant
-				ELSE
-					IF cont IS NOT reachable
-						THEN  
-							IF cont IS NOT plural
-								THEN SAY check_obj2_reachable_sg OF my_game.
-								ELSE SAY check_obj2_reachable_pl OF my_game.
-							END IF.
-					ELSIF cont IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj2_not_distant_sg OF my_game. 
-								ELSE SAY check_obj2_not_distant_pl OF my_game. 
-							END IF.
-					END IF.	
-			AND obj IN allowed OF cont
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_allowed_in_sg OF my_game.
-						ELSE SAY check_obj_allowed_in_pl OF my_game.
-					END IF.					
-			AND obj IS open
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_open2_sg OF my_game.
-						ELSE SAY check_obj_open2_pl OF my_game.
-					END IF.
-			AND cont IS open
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj2_open_sg OF my_game.
-						ELSE SAY check_obj2_open_pl OF my_game.
-					END IF.
-			DOES
+  VERB empty_in, pour_in
+    WHEN obj
+      CHECK my_game CAN empty_in AND my_game CAN pour_in
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> cont
+        ELSE SAY check_obj_not_obj2_in OF my_game.
+      AND obj IS takeable
+        ELSE SAY check_obj_takeable OF my_game.
+      AND cont NOT IN obj
+        ELSE SAY check_cont_not_in_obj OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND cont IS reachable AND cont IS NOT distant
+        ELSE
+          IF cont IS NOT reachable
+            THEN
+              IF cont IS NOT plural
+                THEN SAY check_obj2_reachable_sg OF my_game.
+                ELSE SAY check_obj2_reachable_pl OF my_game.
+              END IF.
+          ELSIF cont IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj2_not_distant_sg OF my_game.
+                ELSE SAY check_obj2_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND obj IN allowed OF cont
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_allowed_in_sg OF my_game.
+            ELSE SAY check_obj_allowed_in_pl OF my_game.
+          END IF.
+      AND obj IS open
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_open2_sg OF my_game.
+            ELSE SAY check_obj_open2_pl OF my_game.
+          END IF.
+      AND cont IS open
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_open_sg OF my_game.
+            ELSE SAY check_obj2_open_pl OF my_game.
+          END IF.
+      DOES
 
-			-- implicit taking:
-			IF obj NOT DIRECTLY IN hero 
-				THEN LOCATE obj IN hero.
-					SAY implicit_taking_message OF my_game.
-			END IF.									
-			-- end of implicit taking.
+      -- implicit taking:
+      IF obj NOT DIRECTLY IN hero
+        THEN LOCATE obj IN hero.
+          SAY implicit_taking_message OF my_game.
+      END IF.
+      -- end of implicit taking.
 
-			IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
-				THEN "There is nothing in" SAY THE obj. "."
-				ELSE 
-					EMPTY obj IN cont.
-					"You $v the contents of" SAY THE obj.
-					"in" SAY THE cont. "."
-			END IF.
-     END VERB.			
+      IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
+        THEN "There is nothing in" SAY THE obj. "."
+        ELSE
+          EMPTY obj IN cont.
+          "You $v the contents of" SAY THE obj.
+          "in" SAY THE cont. "."
+      END IF.
+     END VERB.
 END ADD TO.
 
 
@@ -2264,7 +2264,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ EMPTY ON	(+ POUR ON)
+----- EMPTY ON  (+ POUR ON)
 
 
 -- ==============================================================
@@ -2272,108 +2272,108 @@ END ADD TO.
 
 
 SYNTAX empty_on = 'empty' (obj) 'on' (surface)
-		WHERE obj ISA OBJECT
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game.
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
-		AND obj ISA CONTAINER
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
-		AND surface ISA THING
-			ELSE SAY illegal_parameter2_there OF my_game.
-		AND surface ISA CONTAINER
-			ELSE SAY illegal_parameter2_there OF my_game.
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+    AND obj ISA CONTAINER
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+    AND surface ISA THING
+      ELSE SAY illegal_parameter2_there OF my_game.
+    AND surface ISA CONTAINER
+      ELSE SAY illegal_parameter2_there OF my_game.
 
-	pour_on = pour (obj) 'on' (surface)
-		WHERE obj ISA OBJECT
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
-		AND obj ISA CONTAINER
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.			
-		AND surface ISA OBJECT
-			ELSE SAY illegal_parameter2_there OF my_game. 
-		AND surface ISA CONTAINER
-			ELSE SAY illegal_parameter2_there OF my_game. 
+  pour_on = pour (obj) 'on' (surface)
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+    AND obj ISA CONTAINER
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+    AND surface ISA OBJECT
+      ELSE SAY illegal_parameter2_there OF my_game.
+    AND surface ISA CONTAINER
+      ELSE SAY illegal_parameter2_there OF my_game.
 
 
 ADD TO EVERY THING
-	VERB empty_on, pour_on
-   		WHEN obj
-			CHECK my_game CAN empty_on AND my_game CAN pour_on
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> surface
-				ELSE SAY check_obj_not_obj2_on OF my_game. 
-			AND obj IS takeable
-				ELSE SAY check_obj_takeable OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND surface IS reachable AND surface IS NOT distant	
-				ELSE	
-					IF surface IS NOT reachable
-						THEN  
-							IF surface IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF surface IS distant
-						THEN
-							IF surface IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.	
-			AND obj IS open
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_open2_sg OF my_game.
-						ELSE SAY check_obj_open2_pl OF my_game.
-					END IF.
-			DOES		
-				-- implicit taking:
-				IF obj NOT DIRECTLY IN hero 
-					THEN LOCATE obj IN hero.
-						SAY implicit_taking_message OF my_game.
-				END IF.									
-				-- end of implicit taking.
+  VERB empty_on, pour_on
+      WHEN obj
+      CHECK my_game CAN empty_on AND my_game CAN pour_on
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> surface
+        ELSE SAY check_obj_not_obj2_on OF my_game.
+      AND obj IS takeable
+        ELSE SAY check_obj_takeable OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND surface IS reachable AND surface IS NOT distant
+        ELSE
+          IF surface IS NOT reachable
+            THEN
+              IF surface IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF surface IS distant
+            THEN
+              IF surface IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND obj IS open
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_open2_sg OF my_game.
+            ELSE SAY check_obj_open2_pl OF my_game.
+          END IF.
+      DOES
+        -- implicit taking:
+        IF obj NOT DIRECTLY IN hero
+          THEN LOCATE obj IN hero.
+            SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
 
-				IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
-					THEN "There is nothing in" SAY THE obj. "."
-					ELSE 
-						IF surface = floor OR surface = ground
-							THEN EMPTY obj AT hero.
-						 	ELSE EMPTY obj IN surface.
-						END IF.
-						"You $v the contents of" SAY THE obj.
-						"on" SAY THE surface. "."
-				END IF.
-	END VERB.
+        IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
+          THEN "There is nothing in" SAY THE obj. "."
+          ELSE
+            IF surface = floor OR surface = ground
+              THEN EMPTY obj AT hero.
+              ELSE EMPTY obj IN surface.
+            END IF.
+            "You $v the contents of" SAY THE obj.
+            "on" SAY THE surface. "."
+        END IF.
+  END VERB.
 END ADD TO.
 
 
@@ -2381,7 +2381,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ ENTER 
+----- ENTER
 
 
 -- ==============================================================
@@ -2394,30 +2394,30 @@ END ADD TO.
 
 
 SYNTAX enter = enter (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB enter
-		CHECK my_game CAN enter
-			ELSE SAY restricted_response OF my_game.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting2 OF my_game.
-	 	AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down2 OF my_game.
-   	 	DOES 
-			IF obj IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can enter."
-	END VERB.
+  VERB enter
+    CHECK my_game CAN enter
+      ELSE SAY restricted_response OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting2 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down2 OF my_game.
+      DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can enter."
+  END VERB.
 END ADD TO.
 
 
@@ -2428,8 +2428,8 @@ SYNTAX enter_error = enter.
 
 
 VERB enter_error
-	DOES "You must state what you want to enter."
-END VERB. 
+  DOES "You must state what you want to enter."
+END VERB.
 
 
 
@@ -2442,73 +2442,73 @@ END VERB.
 -- ==============================================================
 
 
-SYNTAX examine = examine (obj) 
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_examine_sg OF my_game. 
-				ELSE SAY illegal_parameter_examine_pl OF my_game. 
-			END IF.
+SYNTAX examine = examine (obj)
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_examine_sg OF my_game.
+        ELSE SAY illegal_parameter_examine_pl OF my_game.
+      END IF.
 
 
-	examine = 'look' 'at' (obj).
-	
-	examine = 'look' (obj).			
-		-- note that this formulation is allowed, too
+  examine = 'look' 'at' (obj).
+
+  examine = 'look' (obj).
+    -- note that this formulation is allowed, too
 
 
 ADD TO EVERY THING
-	VERB examine
-		CHECK my_game CAN examine
-			ELSE SAY restricted_response OF my_game.
-    		AND obj IS examinable
-      		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_examine_sg OF my_game. 
-					ELSE SAY check_obj_suitable_examine_pl OF my_game. 
-				END IF.
-    		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game. 
-		AND obj IS NOT scenery
-			ELSE 
-				IF obj IS NOT PLURAL
-					THEN SAY check_obj_not_scenery_sg OF my_game.
-					ELSE SAY check_obj_not_scenery_pl OF my_game.
-				END IF.
-    		DOES
-			IF obj IS readable			
-			-- for readable objects, 'examine' behaves just as 'read'
-				THEN 
-					IF text OF obj = ""
-						THEN "There is nothing written on" SAY THE obj. "."
-						ELSE "You read" SAY THE obj. "."
-							IF obj IS NOT plural
-								THEN "It says"
-								ELSE "They say"
-							END IF.  
-							"""$$" SAY text OF obj. "$$""."
-					END IF.
-      			ELSE 
-					IF ex OF obj <> ""
-						THEN SAY ex OF obj.
-					ELSIF obj = hero
-						THEN "You notice nothing unusual about yourself."
-						ELSE "You notice nothing unusual about" SAY THE obj. "."
-					END IF. 
-			END IF.
-	END VERB.
+  VERB examine
+    CHECK my_game CAN examine
+      ELSE SAY restricted_response OF my_game.
+        AND obj IS examinable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_examine_sg OF my_game.
+          ELSE SAY check_obj_suitable_examine_pl OF my_game.
+        END IF.
+        AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS NOT scenery
+      ELSE
+        IF obj IS NOT PLURAL
+          THEN SAY check_obj_not_scenery_sg OF my_game.
+          ELSE SAY check_obj_not_scenery_pl OF my_game.
+        END IF.
+        DOES
+      IF obj IS readable
+      -- for readable objects, 'examine' behaves just as 'read'
+        THEN
+          IF text OF obj = ""
+            THEN "There is nothing written on" SAY THE obj. "."
+            ELSE "You read" SAY THE obj. "."
+              IF obj IS NOT plural
+                THEN "It says"
+                ELSE "They say"
+              END IF.
+              """$$" SAY text OF obj. "$$""."
+          END IF.
+            ELSE
+          IF ex OF obj <> ""
+            THEN SAY ex OF obj.
+          ELSIF obj = hero
+            THEN "You notice nothing unusual about yourself."
+            ELSE "You notice nothing unusual about" SAY THE obj. "."
+          END IF.
+      END IF.
+  END VERB.
 END ADD TO.
 
 
 SYNONYMS
-	'check', inspect, observe, x = examine.
+  'check', inspect, observe, x = examine.
 
 
 
 -- ==============================================================
 
 
------ EXIT 
+----- EXIT
 
 
 -- ==============================================================
@@ -2520,26 +2520,26 @@ SYNONYMS
 
 
 SYNTAX 'exit' = 'exit' (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 
 ADD TO EVERY OBJECT
-	VERB 'exit'
-		CHECK my_game CAN 'exit'
-			ELSE SAY restricted_response OF my_game.	
-		DOES 
-			IF obj IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.		
-			"something you can exit."
-  	END VERB.
+  VERB 'exit'
+    CHECK my_game CAN 'exit'
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can exit."
+    END VERB.
 END ADD TO.
 
 
@@ -2550,8 +2550,8 @@ SYNTAX exit_error = 'exit'.
 
 
 VERB exit_error
-	DOES 
-		"You must state what you want to exit."
+  DOES
+    "You must state what you want to exit."
 END VERB.
 
 
@@ -2559,7 +2559,7 @@ END VERB.
 -- ==============================================================
 
 
------ EXTINGUISH	(+ put out)
+----- EXTINGUISH  (+ put out)
 
 
 -- ==============================================================
@@ -2567,50 +2567,50 @@ END VERB.
 
 
 SYNTAX extinguish = extinguish (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-       
-	extinguish = put 'out' (obj).
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
-	extinguish = put (obj) 'out'.
+  extinguish = put 'out' (obj).
+
+  extinguish = put (obj) 'out'.
 
 
 ADD TO EVERY OBJECT
-	VERB extinguish
-		CHECK my_game CAN extinguish
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			IF obj IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"on fire."
-  	END VERB.
+  VERB extinguish
+    CHECK my_game CAN extinguish
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "on fire."
+    END VERB.
 END ADD TO.
 
 
@@ -2628,35 +2628,35 @@ SYNONYMS quench = extinguish.
 
 
 SYNTAX fill = fill (cont)
-	WHERE cont ISA OBJECT
-		ELSE 
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND cont ISA CONTAINER
-		ELSE 	
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE cont ISA OBJECT
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB fill
-		CHECK my_game CAN fill
-			ELSE SAY restricted_response OF my_game.
-		AND cont IS examinable
-			ELSE 
-				IF cont IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.	
-		DOES 
-			"You have to say what you want to fill" SAY THE cont. "with."
-  	END VERB.
+  VERB fill
+    CHECK my_game CAN fill
+      ELSE SAY restricted_response OF my_game.
+    AND cont IS examinable
+      ELSE
+        IF cont IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "You have to say what you want to fill" SAY THE cont. "with."
+    END VERB.
 END ADD TO.
 
 
@@ -2671,79 +2671,79 @@ END ADD TO.
 
 
 SYNTAX fill_with = fill (cont) 'with' (substance)
-	WHERE cont ISA OBJECT
-		ELSE 
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND cont ISA CONTAINER
-		ELSE 
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND substance ISA OBJECT
-		ELSE 
-			IF substance IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE cont ISA OBJECT
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND substance ISA OBJECT
+    ELSE
+      IF substance IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB fill_with
-    		WHEN cont
-			CHECK my_game CAN fill_with
-				ELSE SAY restricted_response OF my_game.
-			AND cont <> substance
-				ELSE SAY check_obj_not_obj2_with OF my_game. 
-			AND substance IS examinable
-				ELSE
-					IF substance IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND substance NOT IN cont
-				ELSE SAY check_obj_not_in_cont2 OF my_game. 
-			AND substance IS takeable
-				ELSE SAY check_obj2_takeable1 OF my_game.
-			AND cont IS reachable AND cont IS NOT distant
-				ELSE
-					IF cont IS NOT reachable
-						THEN  
-							IF cont IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF cont IS distant
-						THEN
-							IF cont IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. "."
-								ELSE SAY check_obj_not_distant_pl OF my_game. "."
-							END IF.
-					END IF.
-			AND substance IS reachable AND substance IS NOT distant
-				ELSE
-					IF substance IS NOT reachable
-						THEN  
-							IF substance IS NOT plural
-								THEN SAY check_obj2_reachable_sg OF my_game.
-								ELSE SAY check_obj2_reachable_pl OF my_game.
-							END IF.
-					ELSIF substance IS distant
-						THEN
-							IF substance IS NOT plural
-								THEN SAY check_obj2_not_distant_sg OF my_game. "."
-								ELSE SAY check_obj2_not_distant_pl OF my_game. "."
-							END IF.
-					END IF.	
-			DOES 	
-				"You can't fill" SAY THE cont. "with" SAY THE substance. "."
-				-- allow the action at individual substances only
-	END VERB.
+  VERB fill_with
+        WHEN cont
+      CHECK my_game CAN fill_with
+        ELSE SAY restricted_response OF my_game.
+      AND cont <> substance
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND substance IS examinable
+        ELSE
+          IF substance IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND substance NOT IN cont
+        ELSE SAY check_obj_not_in_cont2 OF my_game.
+      AND substance IS takeable
+        ELSE SAY check_obj2_takeable1 OF my_game.
+      AND cont IS reachable AND cont IS NOT distant
+        ELSE
+          IF cont IS NOT reachable
+            THEN
+              IF cont IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF cont IS distant
+            THEN
+              IF cont IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game. "."
+                ELSE SAY check_obj_not_distant_pl OF my_game. "."
+              END IF.
+          END IF.
+      AND substance IS reachable AND substance IS NOT distant
+        ELSE
+          IF substance IS NOT reachable
+            THEN
+              IF substance IS NOT plural
+                THEN SAY check_obj2_reachable_sg OF my_game.
+                ELSE SAY check_obj2_reachable_pl OF my_game.
+              END IF.
+          ELSIF substance IS distant
+            THEN
+              IF substance IS NOT plural
+                THEN SAY check_obj2_not_distant_sg OF my_game. "."
+                ELSE SAY check_obj2_not_distant_pl OF my_game. "."
+              END IF.
+          END IF.
+      DOES
+        "You can't fill" SAY THE cont. "with" SAY THE substance. "."
+        -- allow the action at individual substances only
+  END VERB.
 END ADD TO.
 
 
@@ -2758,31 +2758,31 @@ END ADD TO.
 
 
 SYNTAX
-	find = find (obj)!
-		WHERE obj ISA THING
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
+  find = find (obj)!
+    WHERE obj ISA THING
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
 
 
 ADD TO EVERY THING
-	VERB find
-		CHECK my_game CAN find
-			ELSE SAY restricted_response OF my_game.
-		AND obj <> hero 
-			ELSE SAY check_obj_not_hero4 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj NOT AT hero
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_not_at_hero_sg OF my_game.
-					ELSE SAY check_obj_not_at_hero_pl OF my_game.
-				END IF.
-		DOES
-			"You'll have to $v it yourself."
+  VERB find
+    CHECK my_game CAN find
+      ELSE SAY restricted_response OF my_game.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero4 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj NOT AT hero
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_not_at_hero_sg OF my_game.
+          ELSE SAY check_obj_not_at_hero_pl OF my_game.
+        END IF.
+    DOES
+      "You'll have to $v it yourself."
   END VERB.
 END ADD TO.
 
@@ -2801,29 +2801,29 @@ SYNONYMS 'locate' = find.
 
 
 SYNTAX fire = fire (weapon)
-	WHERE weapon ISA WEAPON
-		ELSE 
-			IF weapon IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE weapon ISA WEAPON
+    ELSE
+      IF weapon IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY WEAPON
-	VERB fire
-		CHECK my_game CAN fire
-			ELSE SAY restricted_response OF my_game.
-		AND weapon IS fireable
-			ELSE 
-				IF weapon IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game.
-					ELSE SAY check_obj_suitable_pl OF my_game.
-				END IF.
-	
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	DOES 
-		"You fire" SAY THE weapon. "into the air."
+  VERB fire
+    CHECK my_game CAN fire
+      ELSE SAY restricted_response OF my_game.
+    AND weapon IS fireable
+      ELSE
+        IF weapon IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  DOES
+    "You fire" SAY THE weapon. "into the air."
   END VERB.
 END ADD TO.
 
@@ -2839,46 +2839,46 @@ END ADD TO.
 
 
 SYNTAX fire_at = fire (weapon) 'at' (target)
-	WHERE weapon ISA WEAPON
-		ELSE 
-			IF weapon IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND target ISA THING
-		ELSE SAY illegal_parameter_at OF my_game. 
-			
+  WHERE weapon ISA WEAPON
+    ELSE
+      IF weapon IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND target ISA THING
+    ELSE SAY illegal_parameter_at OF my_game.
+
 
 
 ADD TO EVERY WEAPON
-	VERB fire_at
-		WHEN weapon
-			CHECK my_game CAN fire_at
-				ELSE SAY restricted_response OF my_game.
-			AND weapon IS fireable
-				ELSE 
-					IF weapon IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game.
-						ELSE SAY check_obj_suitable_pl OF my_game.
-					END IF.
-			AND target IS examinable
-				ELSE SAY check_obj_suitable_at OF my_game.
-			AND weapon <> target
-				ELSE SAY check_obj_not_obj2_at OF my_game.
-			AND target <> hero 
-				ELSE SAY check_obj_not_hero2 OF my_game.
-			AND target IS NOT distant 
-				-- note that it is possible to fire at a "not reachable" target
-				ELSE
-					IF target IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game.
-						ELSE SAY check_obj_not_distant_pl OF my_game.
-					END IF.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			DOES 
-				"Resorting to violence is not the solution here."
-	END VERB.
+  VERB fire_at
+    WHEN weapon
+      CHECK my_game CAN fire_at
+        ELSE SAY restricted_response OF my_game.
+      AND weapon IS fireable
+        ELSE
+          IF weapon IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND target IS examinable
+        ELSE SAY check_obj_suitable_at OF my_game.
+      AND weapon <> target
+        ELSE SAY check_obj_not_obj2_at OF my_game.
+      AND target <> hero
+        ELSE SAY check_obj_not_hero2 OF my_game.
+      AND target IS NOT distant
+        -- note that it is possible to fire at a "not reachable" target
+        ELSE
+          IF target IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      DOES
+        "Resorting to violence is not the solution here."
+  END VERB.
 END ADD TO.
 
 
@@ -2886,24 +2886,24 @@ END ADD TO.
 
 
 SYNTAX fire_at_error = fire 'at' (target)
-	WHERE target ISA THING
-		ELSE 
-			IF target IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE target ISA THING
+    ELSE
+      IF target IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB fire_at_error
-		CHECK COUNT ISA WEAPON, IS fireable, DIRECTLY IN hero > 0
-			ELSE SAY check_count_weapon_in_hero OF my_game.
-		AND target <> hero
-			ELSE SAY check_obj_not_hero2 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES 
-			"Resorting to violence is not the solution here."
+  VERB fire_at_error
+    CHECK COUNT ISA WEAPON, IS fireable, DIRECTLY IN hero > 0
+      ELSE SAY check_count_weapon_in_hero OF my_game.
+    AND target <> hero
+      ELSE SAY check_obj_not_hero2 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "Resorting to violence is not the solution here."
 END VERB.
 END ADD TO.
 
@@ -2919,44 +2919,44 @@ END ADD TO.
 
 
 SYNTAX fix = fix (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB fix
-		CHECK my_game CAN fix
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS broken
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_broken_sg OF my_game.
-					ELSE SAY check_obj_broken_pl OF my_game.
-				END IF.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-			"Please be more specific. How do you intend to fix it?"
-	END VERB.
+  VERB fix
+    CHECK my_game CAN fix
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS broken
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_broken_sg OF my_game.
+          ELSE SAY check_obj_broken_pl OF my_game.
+        END IF.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "Please be more specific. How do you intend to fix it?"
+  END VERB.
 END ADD TO.
 
 
@@ -2974,38 +2974,38 @@ SYNONYMS mend, repair = fix.
 
 
 SYNTAX follow = follow (act)!
-	WHERE act ISA ACTOR
-		ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE act ISA ACTOR
+    ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB follow
-		CHECK my_game CAN follow
-			ELSE SAY restricted_response OF my_game.
-		AND act <> hero
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND act NOT AT hero
-			ELSE 
-				IF act IS NOT plural
-					THEN SAY check_obj_not_at_hero_sg OF my_game.
-					ELSE SAY check_obj_not_at_hero_pl OF my_game.
-				END IF.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting2 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down2 OF my_game.
-		AND act NEAR hero							
-			ELSE SAY check_act_near_hero OF my_game.
-		DOES 
-			LOCATE hero AT act.
-			"You follow" SAY THE act. "."		
-  	END VERB.
+  VERB follow
+    CHECK my_game CAN follow
+      ELSE SAY restricted_response OF my_game.
+    AND act <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND act NOT AT hero
+      ELSE
+        IF act IS NOT plural
+          THEN SAY check_obj_not_at_hero_sg OF my_game.
+          ELSE SAY check_obj_not_at_hero_pl OF my_game.
+        END IF.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting2 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down2 OF my_game.
+    AND act NEAR hero
+      ELSE SAY check_act_near_hero OF my_game.
+    DOES
+      LOCATE hero AT act.
+      "You follow" SAY THE act. "."
+    END VERB.
 END ADD TO.
 
 
@@ -3020,49 +3020,49 @@ END ADD TO.
 
 
 SYNTAX free = free (obj)
-	WHERE obj ISA THING
-		ELSE
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB free
-		CHECK my_game CAN free
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero5 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			IF obj IS NOT plural
-				THEN "That doesn't need to be $vd."
-				ELSE "Those don't need to be $vd."
-			END IF.
-	END VERB.
+  VERB free
+    CHECK my_game CAN free
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero5 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF obj IS NOT plural
+        THEN "That doesn't need to be $vd."
+        ELSE "Those don't need to be $vd."
+      END IF.
+  END VERB.
 END ADD TO.
 
 
@@ -3080,25 +3080,25 @@ SYNONYMS release = free.
 
 
 SYNTAX get_off = get off (surface)
-	WHERE surface ISA SUPPORTER
-		ELSE 
-			IF surface IS NOT plural
-				THEN SAY illegal_parameter_off_sg OF my_game. 
-				ELSE SAY illegal_parameter_off_pl OF my_game. 
-			END IF.
+  WHERE surface ISA SUPPORTER
+    ELSE
+      IF surface IS NOT plural
+        THEN SAY illegal_parameter_off_sg OF my_game.
+        ELSE SAY illegal_parameter_off_pl OF my_game.
+      END IF.
 
 ADD TO EVERY SUPPORTER
-	VERB get_off
-		CHECK my_game CAN get_off
-			ELSE SAY restricted_response OF my_game.
-		DOES
-			IF hero IS sitting OR hero IS lying_down
-				THEN "You get off" SAY THE surface. "."
-					MAKE hero NOT lying_down.
-					MAKE hero NOT sitting.
-				ELSE "You're standing up already."
-			END IF.
-  	END VERB.
+  VERB get_off
+    CHECK my_game CAN get_off
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      IF hero IS sitting OR hero IS lying_down
+        THEN "You get off" SAY THE surface. "."
+          MAKE hero NOT lying_down.
+          MAKE hero NOT sitting.
+        ELSE "You're standing up already."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -3111,23 +3111,23 @@ END ADD TO.
 -- ==============================================================
 
 
-SYNTAX get_up = get up.		
-		
+SYNTAX get_up = get up.
+
 
 VERB get_up
-	CHECK my_game CAN get_up
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		IF hero IS sitting 
-			THEN "You stand up."
-				MAKE hero NOT sitting.
-				MAKE hero NOT lying_down.
-		ELSIF hero IS lying_down
-			THEN "You get up."
-				MAKE hero NOT lying_down.
-				MAKE hero NOT sitting.
-		ELSE "You're standing up already."
-		END IF.
+  CHECK my_game CAN get_up
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    IF hero IS sitting
+      THEN "You stand up."
+        MAKE hero NOT sitting.
+        MAKE hero NOT lying_down.
+    ELSIF hero IS lying_down
+      THEN "You get up."
+        MAKE hero NOT lying_down.
+        MAKE hero NOT sitting.
+    ELSE "You're standing up already."
+    END IF.
 END VERB.
 
 
@@ -3142,79 +3142,79 @@ END VERB.
 
 
 SYNTAX give = 'give' (obj) 'to' (recipient)
-    	WHERE obj ISA OBJECT
-     		ELSE SAY illegal_parameter_obj OF my_game.
-    	AND recipient ISA ACTOR
-     		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter2_to_sg OF my_game. 
-				ELSE SAY illegal_parameter2_to_pl OF my_game. 
-			END IF.
-  	 
+      WHERE obj ISA OBJECT
+        ELSE SAY illegal_parameter_obj OF my_game.
+      AND recipient ISA ACTOR
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter2_to_sg OF my_game.
+        ELSE SAY illegal_parameter2_to_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB give
-    		WHEN obj
-			CHECK my_game CAN give
-				ELSE SAY restricted_response OF my_game.
-			AND obj IS takeable
-				ELSE SAY check_obj_takeable OF my_game.
-			AND obj <> recipient
-				ELSE SAY check_obj_not_obj2_to OF my_game. 
-			AND recipient <> hero
-				ELSE SAY check_obj2_not_hero3 OF my_game. 
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj NOT IN recipient
-				ELSE 
-					IF recipient IS NOT plural
-						THEN SAY check_obj_not_in_act_sg OF my_game.
-						ELSE SAY check_obj_not_in_act_pl OF my_game.
-					END IF.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND recipient IS reachable AND recipient IS NOT distant
-				ELSE
-					IF recipient IS NOT reachable
-						THEN  
-							IF recipient IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF recipient IS distant
-						THEN
-							IF recipient IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.					
-     			DOES
-				-- implicit taking:
-				IF obj NOT DIRECTLY IN hero
-					THEN SAY implicit_taking_message OF my_game.
-					LOCATE obj IN hero.
-				END IF.
-				-- end of implicit taking.
+  VERB give
+        WHEN obj
+      CHECK my_game CAN give
+        ELSE SAY restricted_response OF my_game.
+      AND obj IS takeable
+        ELSE SAY check_obj_takeable OF my_game.
+      AND obj <> recipient
+        ELSE SAY check_obj_not_obj2_to OF my_game.
+      AND recipient <> hero
+        ELSE SAY check_obj2_not_hero3 OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj NOT IN recipient
+        ELSE
+          IF recipient IS NOT plural
+            THEN SAY check_obj_not_in_act_sg OF my_game.
+            ELSE SAY check_obj_not_in_act_pl OF my_game.
+          END IF.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND recipient IS reachable AND recipient IS NOT distant
+        ELSE
+          IF recipient IS NOT reachable
+            THEN
+              IF recipient IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF recipient IS distant
+            THEN
+              IF recipient IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          DOES
+        -- implicit taking:
+        IF obj NOT DIRECTLY IN hero
+          THEN SAY implicit_taking_message OF my_game.
+          LOCATE obj IN hero.
+        END IF.
+        -- end of implicit taking.
 
-				LOCATE obj IN recipient.	
-				"You give" SAY THE obj. "to" SAY THE recipient. "."
-	  			
+        LOCATE obj IN recipient.
+        "You give" SAY THE obj. "to" SAY THE recipient. "."
 
-	END VERB.
+
+  END VERB.
 END ADD TO.
 
 
@@ -3231,58 +3231,58 @@ SYNONYMS hand, offer = give.
 -- ==============================================================
 
 
-SYNTAX go_to = 'to' (dest)!					
-	-- Because 'go' is predefined in the parser, it can't be used in verb definitions.
-	-- The player will still be able to type 'go to [dest]' successfully.
-	WHERE dest ISA THING						
-		ELSE SAY illegal_parameter_go OF my_game.
+SYNTAX go_to = 'to' (dest)!
+  -- Because 'go' is predefined in the parser, it can't be used in verb definitions.
+  -- The player will still be able to type 'go to [dest]' successfully.
+  WHERE dest ISA THING
+    ELSE SAY illegal_parameter_go OF my_game.
 
 
 ADD TO EVERY THING
-	VERB go_to
-		CHECK my_game CAN go_to
-			ELSE SAY restricted_response OF my_game.
-		AND dest <> hero
-			ELSE SAY check_obj_not_hero4 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting3 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down3 OF my_game.
-		AND dest NOT AT hero
-			ELSE 
-				IF dest IS NOT plural
-					THEN SAY check_obj_not_at_hero_sg OF my_game. 
-					ELSE SAY check_obj_not_at_hero_pl OF my_game.
-				END IF.
-		AND dest IS reachable AND dest IS NOT distant
-			ELSE
-				IF dest IS NOT reachable
-					THEN  
-						IF dest IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF dest IS distant
-					THEN
-						IF dest IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"You can't see" SAY THE dest. "anywhere nearby. You must state a
-			direction where you want to go."
-  	END VERB.
+  VERB go_to
+    CHECK my_game CAN go_to
+      ELSE SAY restricted_response OF my_game.
+    AND dest <> hero
+      ELSE SAY check_obj_not_hero4 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting3 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down3 OF my_game.
+    AND dest NOT AT hero
+      ELSE
+        IF dest IS NOT plural
+          THEN SAY check_obj_not_at_hero_sg OF my_game.
+          ELSE SAY check_obj_not_at_hero_pl OF my_game.
+        END IF.
+    AND dest IS reachable AND dest IS NOT distant
+      ELSE
+        IF dest IS NOT reachable
+          THEN
+            IF dest IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF dest IS distant
+          THEN
+            IF dest IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "You can't see" SAY THE dest. "anywhere nearby. You must state a
+      direction where you want to go."
+    END VERB.
 END ADD TO.
 
 
-SYNONYMS walk = go.		
-	-- here we define a synonym for the predefined parser word 'go'
-	-- which is not visible in the syntax itself.
-	-- Thus, you will be able to say for example both 'go to shop' and 'walk to shop'
-	-- (as well as for example both 'go east' and 'walk east').
+SYNONYMS walk = go.
+  -- here we define a synonym for the predefined parser word 'go'
+  -- which is not visible in the syntax itself.
+  -- Thus, you will be able to say for example both 'go to shop' and 'walk to shop'
+  -- (as well as for example both 'go east' and 'walk east').
 
 
 
@@ -3311,15 +3311,15 @@ SYNTAX hint = hint.
 
 
 VERB hint
-	CHECK my_game CAN hint
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		"Unfortunately hints are not available in this game."
+  CHECK my_game CAN hint
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "Unfortunately hints are not available in this game."
 END VERB.
 
 
 SYNONYMS
-	hints = hint.
+  hints = hint.
 
 
 
@@ -3337,15 +3337,15 @@ SYNTAX i = i.
 
 
 VERB i
-	CHECK my_game CAN i
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		LIST hero.
-		
-		IF COUNT DIRECTLY IN worn > 0		-- See the file 'classes.i', subclass 'clothing'.
-			THEN LIST worn. 		-- This code will list what the hero is wearing.
-		END IF.
-	
+  CHECK my_game CAN i
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    LIST hero.
+
+    IF COUNT DIRECTLY IN worn > 0   -- See the file 'classes.i', subclass 'clothing'.
+      THEN LIST worn.     -- This code will list what the hero is wearing.
+    END IF.
+
 END VERB.
 
 
@@ -3366,14 +3366,14 @@ SYNTAX jump = jump.
 
 
 VERB jump
-	CHECK my_game CAN jump
-		ELSE SAY restricted_response OF my_game.
-	AND hero IS NOT sitting
-		ELSE SAY check_hero_not_sitting1 OF my_game.
-	AND hero IS NOT lying_down
-		ELSE SAY check_hero_not_lying_down1 OF my_game.
-	DOES
-		"You jump on the spot, to no avail."
+  CHECK my_game CAN jump
+    ELSE SAY restricted_response OF my_game.
+  AND hero IS NOT sitting
+    ELSE SAY check_hero_not_sitting1 OF my_game.
+  AND hero IS NOT lying_down
+    ELSE SAY check_hero_not_lying_down1 OF my_game.
+  DOES
+    "You jump on the spot, to no avail."
 END VERB.
 
 
@@ -3388,52 +3388,52 @@ END VERB.
 
 
 SYNTAX jump_in = jump 'in' (cont)
-	WHERE cont ISA OBJECT
-		ELSE
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_in_sg OF my_game. 
-				ELSE SAY illegal_parameter_in_pl OF my_game. 
-			END IF.
-	AND cont ISA CONTAINER
-		ELSE
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_in_sg OF my_game. 
-				ELSE SAY illegal_parameter_in_pl OF my_game. 
-			END IF.
-				
+  WHERE cont ISA OBJECT
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_in_sg OF my_game.
+        ELSE SAY illegal_parameter_in_pl OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_in_sg OF my_game.
+        ELSE SAY illegal_parameter_in_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB jump_in
-		CHECK my_game CAN jump_in
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND cont IS reachable AND cont IS NOT distant
-			ELSE
-				IF cont IS NOT reachable
-					THEN  
-						IF cont IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF cont IS distant
-					THEN
-						IF cont IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting1 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down1 OF my_game.
-		DOES
-			IF cont IS NOT plural
-				THEN "That's not something you can jump into."
-				ELSE "Those are not something you can jump into."
-			END IF.
-  	END VERB.
+  VERB jump_in
+    CHECK my_game CAN jump_in
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND cont IS reachable AND cont IS NOT distant
+      ELSE
+        IF cont IS NOT reachable
+          THEN
+            IF cont IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF cont IS distant
+          THEN
+            IF cont IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting1 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down1 OF my_game.
+    DOES
+      IF cont IS NOT plural
+        THEN "That's not something you can jump into."
+        ELSE "Those are not something you can jump into."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -3448,31 +3448,31 @@ END ADD TO.
 
 
 SYNTAX jump_on = jump 'on' (surface)
-	WHERE surface ISA SUPPORTER
-		ELSE 
-			IF surface IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
+  WHERE surface ISA SUPPORTER
+    ELSE
+      IF surface IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB jump_on
-		CHECK my_game CAN jump_on
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.	
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting1 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down1 OF my_game.
-		DOES
-			IF surface IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can jump onto."	
-  	END VERB.
+  VERB jump_on
+    CHECK my_game CAN jump_on
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting1 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down1 OF my_game.
+    DOES
+      IF surface IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can jump onto."
+    END VERB.
 END ADD TO.
 
 
@@ -3480,56 +3480,56 @@ END ADD TO.
 -- =============================================================
 
 
------ KICK 
+----- KICK
 
 
 -- =============================================================
 
 
 SYNTAX kick = kick (target)
-    	WHERE target ISA THING
-     		ELSE 
-			IF target IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+      WHERE target ISA THING
+        ELSE
+      IF target IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB kick
-		CHECK my_game CAN kick
-			ELSE SAY restricted_response OF my_game.
-		AND target IS examinable
-			ELSE 
-				IF target IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND target <> hero 
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		AND target NOT IN hero
-			ELSE SAY check_obj_not_in_hero1 OF my_game.
-		AND target NOT IN worn
-			ELSE SAY check_obj_not_in_worn2 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND target IS reachable AND target IS NOT distant
-			ELSE
-				IF target IS NOT reachable
-					THEN  
-						IF target IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF target IS distant
-					THEN
-						IF target IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-    		DOES "Resorting to brute force is not the solution here."
-	END VERB.
+  VERB kick
+    CHECK my_game CAN kick
+      ELSE SAY restricted_response OF my_game.
+    AND target IS examinable
+      ELSE
+        IF target IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND target <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND target NOT IN hero
+      ELSE SAY check_obj_not_in_hero1 OF my_game.
+    AND target NOT IN worn
+      ELSE SAY check_obj_not_in_worn2 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND target IS reachable AND target IS NOT distant
+      ELSE
+        IF target IS NOT reachable
+          THEN
+            IF target IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF target IS distant
+          THEN
+            IF target IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+        DOES "Resorting to brute force is not the solution here."
+  END VERB.
 END ADD TO.
 
 
@@ -3544,30 +3544,30 @@ END ADD TO.
 
 
 SYNTAX kill = kill (victim)
-	WHERE victim ISA ACTOR
-		ELSE 
-			IF victim IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE victim ISA ACTOR
+    ELSE
+      IF victim IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY ACTOR
-	VERB kill
-		CHECK my_game CAN kill
-			ELSE SAY restricted_response OF my_game.
-		AND victim IS examinable
-			ELSE 
-				IF victim IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND victim <> hero 
-			ELSE SAY check_obj_not_hero2 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.			
-		DOES "You have to state what you want to kill" SAY THE victim. "with."		
-  	END VERB.
+  VERB kill
+    CHECK my_game CAN kill
+      ELSE SAY restricted_response OF my_game.
+    AND victim IS examinable
+      ELSE
+        IF victim IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND victim <> hero
+      ELSE SAY check_obj_not_hero2 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES "You have to state what you want to kill" SAY THE victim. "with."
+    END VERB.
 END ADD TO.
 
 
@@ -3575,47 +3575,47 @@ END ADD TO.
 -- ==============================================================
 
 
--- KILL WITH 
+-- KILL WITH
 
 
 -- ==============================================================
 
 
 SYNTAX kill_with = kill (victim) 'with' (weapon)
-	WHERE victim ISA ACTOR
-		ELSE 
-			IF victim IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND weapon ISA WEAPON
-		ELSE 
-			IF weapon IS NOT plural
-				THEN SAY illegal_parameter_with_sg OF my_game. 
-				ELSE SAY illegal_parameter_with_pl OF my_game. 
-			END IF.
+  WHERE victim ISA ACTOR
+    ELSE
+      IF victim IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND weapon ISA WEAPON
+    ELSE
+      IF weapon IS NOT plural
+        THEN SAY illegal_parameter_with_sg OF my_game.
+        ELSE SAY illegal_parameter_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY ACTOR
-	VERB kill_with
-		WHEN victim
-			CHECK my_game CAN kill_with
-				ELSE SAY restricted_response OF my_game.
-			AND victim <> hero 
-				ELSE SAY check_obj_not_hero2 OF my_game. 
-			AND weapon IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND victim IS NOT distant
-				ELSE
-					IF victim IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game. 
-					END IF.	
-			DOES 
-				"That would be needlessly brutal."
-  	END VERB.
+  VERB kill_with
+    WHEN victim
+      CHECK my_game CAN kill_with
+        ELSE SAY restricted_response OF my_game.
+      AND victim <> hero
+        ELSE SAY check_obj_not_hero2 OF my_game.
+      AND weapon IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND victim IS NOT distant
+        ELSE
+          IF victim IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+      DOES
+        "That would be needlessly brutal."
+    END VERB.
 END ADD TO.
 
 
@@ -3630,49 +3630,49 @@ END ADD TO.
 
 
 SYNTAX kiss = kiss (obj)
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB kiss
-		CHECK my_game CAN kiss
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero6 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES
-			IF obj ISA ACTOR
-				THEN SAY THE obj. "avoids your advances."
-				ELSE "Nothing would be achieved by that."
-			END IF.
-  	END VERB.
+  VERB kiss
+    CHECK my_game CAN kiss
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero6 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF obj ISA ACTOR
+        THEN SAY THE obj. "avoids your advances."
+        ELSE "Nothing would be achieved by that."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -3683,53 +3683,53 @@ SYNONYMS hug, embrace = kiss.
 -- ==============================================================
 
 
------ KNOCK 
+----- KNOCK
 
 
 -- ==============================================================
 
 
 SYNTAX knock = knock 'on' (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
-	
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
+
        knock = knock (obj).
 
 
 ADD TO EVERY OBJECT
-	VERB knock
-		CHECK my_game CAN knock
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_on_sg OF my_game. 
-					ELSE SAY check_obj_suitable_on_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-			"You knock on" SAY THE obj. "$$. Nothing happens."
-  	END VERB.
+  VERB knock
+    CHECK my_game CAN knock
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_on_sg OF my_game.
+          ELSE SAY check_obj_suitable_on_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "You knock on" SAY THE obj. "$$. Nothing happens."
+    END VERB.
 END ADD TO.
 
 
@@ -3740,8 +3740,8 @@ SYNTAX knock_error = knock.
 
 
 VERB knock_error
-	DOES 
-		"Please use the formulation KNOCK ON SOMETHING to knock on something."
+  DOES
+    "Please use the formulation KNOCK ON SOMETHING to knock on something."
 END VERB.
 
 
@@ -3756,29 +3756,29 @@ END VERB.
 
 
 SYNTAX lie_down = lie 'down'.
-	 
-	  lie_down = lie.
+
+    lie_down = lie.
 
 
 VERB lie_down
-	CHECK my_game CAN lie_down
-		ELSE SAY restricted_response OF my_game.
-	AND hero IS NOT lying_down
-		ELSE SAY check_hero_not_lying_down4 OF my_game.
-	DOES 
-		"There's no need to lie down right now."
-		-- If you need this to work, insert the following lines instead of the above:
-				-- DOES "You lie down."
-				-- MAKE hero lying_down.
-				-- MAKE hero NOT sitting_down.
+  CHECK my_game CAN lie_down
+    ELSE SAY restricted_response OF my_game.
+  AND hero IS NOT lying_down
+    ELSE SAY check_hero_not_lying_down4 OF my_game.
+  DOES
+    "There's no need to lie down right now."
+    -- If you need this to work, insert the following lines instead of the above:
+        -- DOES "You lie down."
+        -- MAKE hero lying_down.
+        -- MAKE hero NOT sitting_down.
 END VERB.
 
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
--- perform certain actions, as numerous verbs in the library have checks for this. 
+-- perform certain actions, as numerous verbs in the library have checks for this.
 -- For example, if the hero is lying down and the player types 'attack [something]',
 -- the response will be "It will be difficult to attack anything while
--- lying down." 
+-- lying down."
 
 -- Also, it is often essential to make certain objects NOT reachable when you are sitting
 -- or lying down.
@@ -3795,60 +3795,60 @@ END VERB.
 
 
 SYNTAX lie_in = lie 'in' (cont)
-	WHERE cont ISA OBJECT
-		ELSE 
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_in_sg OF my_game. 
-				ELSE SAY illegal_parameter_in_pl OF my_game. 
-			END IF.
-	AND cont ISA CONTAINER
-		ELSE 
-			IF cont IS NOT plural
-				THEN SAY illegal_parameter_in_sg OF my_game. 
-				ELSE SAY illegal_parameter_in_pl OF my_game. 
-			END IF.
-	
+  WHERE cont ISA OBJECT
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_in_sg OF my_game.
+        ELSE SAY illegal_parameter_in_pl OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE
+      IF cont IS NOT plural
+        THEN SAY illegal_parameter_in_sg OF my_game.
+        ELSE SAY illegal_parameter_in_pl OF my_game.
+      END IF.
+
        lie_in = lie 'down' 'in' (cont).
-	
+
 
 ADD TO EVERY OBJECT
-	VERB lie_in
-		CHECK my_game CAN lie_in
-			ELSE SAY restricted_response OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down4 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND cont IS reachable AND cont IS NOT distant
-			ELSE
-				IF cont IS NOT reachable
-					THEN  
-						IF cont IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF cont IS distant
-					THEN
-						IF cont IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES 
-			"There's no need to lie down in" SAY THE cont. "."
-			-- If you need this to work, make a nested location
-			-- (for example THE in_bed ISA LOCATION AT bedroom; etc.)
-			-- Remember to: MAKE hero lying_down.
-			-- Presently, an actor cannot be located inside a container object. 
-	END VERB.
+  VERB lie_in
+    CHECK my_game CAN lie_in
+      ELSE SAY restricted_response OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down4 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND cont IS reachable AND cont IS NOT distant
+      ELSE
+        IF cont IS NOT reachable
+          THEN
+            IF cont IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF cont IS distant
+          THEN
+            IF cont IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "There's no need to lie down in" SAY THE cont. "."
+      -- If you need this to work, make a nested location
+      -- (for example THE in_bed ISA LOCATION AT bedroom; etc.)
+      -- Remember to: MAKE hero lying_down.
+      -- Presently, an actor cannot be located inside a container object.
+  END VERB.
 END ADD TO.
 
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
--- perform certain actions, as numerous verbs in the library have checks for this. 
+-- perform certain actions, as numerous verbs in the library have checks for this.
 -- For example, if the hero is lying down and the player types 'attack [something]',
 -- the response will be "It will be difficult to attack anything while
--- lying down." 
+-- lying down."
 
 -- Also, it is often essential to make certain objects NOT reachable when you are sitting
 -- or lying down.
@@ -3865,56 +3865,56 @@ END ADD TO.
 
 
 SYNTAX lie_on = lie 'on' (surface)
-	WHERE surface ISA SUPPORTER
-		ELSE 
-			IF surface IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
-       
-	 lie_on = lie 'down' 'on' (surface).
+  WHERE surface ISA SUPPORTER
+    ELSE
+      IF surface IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
+
+   lie_on = lie 'down' 'on' (surface).
 
 
 ADD TO EVERY OBJECT
-	VERB lie_on
-		CHECK my_game CAN lie_on
-			ELSE SAY restricted_response OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down4 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND surface IS reachable AND surface IS NOT distant
-			ELSE
-				IF surface IS NOT reachable
-					THEN  
-						IF surface IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF surface IS distant
-					THEN
-						IF surface IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES 
-			"There's no need to lie down on" SAY THE surface. "."
-			-- If you need this to work, make a nested location
-			-- (for example THE on_bed ISA LOCATION AT bedroom; etc.)
-			-- Remember to: MAKE hero lying_down.
+  VERB lie_on
+    CHECK my_game CAN lie_on
+      ELSE SAY restricted_response OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down4 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND surface IS reachable AND surface IS NOT distant
+      ELSE
+        IF surface IS NOT reachable
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF surface IS distant
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "There's no need to lie down on" SAY THE surface. "."
+      -- If you need this to work, make a nested location
+      -- (for example THE on_bed ISA LOCATION AT bedroom; etc.)
+      -- Remember to: MAKE hero lying_down.
                 -- Presently, an actor cannot be located inside a container object
-			-- or on a supporter.
-  	END VERB.
+      -- or on a supporter.
+    END VERB.
 END ADD TO.
 
 
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
--- perform certain actions, as numerous verbs in the library have checks for this. 
+-- perform certain actions, as numerous verbs in the library have checks for this.
 -- For example, if the hero is lying down and the player types 'attack [something]',
 -- the response will be "It will be difficult to attack anything while
--- lying down." 
+-- lying down."
 
 -- Also, it is often essential to make certain objects NOT reachable when you are sitting
 -- or lying down.
@@ -3931,53 +3931,53 @@ END ADD TO.
 
 
 SYNTAX lift = lift (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB lift  
-		CHECK my_game CAN lift
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.	
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj NOT IN hero
-			ELSE SAY check_obj_not_in_hero1 OF my_game.
-		AND obj IS movable
-			ELSE SAY check_obj_movable OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND weight OF obj < 50
-			ELSE 
-				IF obj IS NOT PLURAL
-					THEN SAY check_obj_weight_sg OF my_game.
-					ELSE SAY check_obj_weight_pl OF my_game.
-				END IF.
-	DOES 
-		"That wouldn't accomplish anything."	
+  VERB lift
+    CHECK my_game CAN lift
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj NOT IN hero
+      ELSE SAY check_obj_not_in_hero1 OF my_game.
+    AND obj IS movable
+      ELSE SAY check_obj_movable OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND weight OF obj < 50
+      ELSE
+        IF obj IS NOT PLURAL
+          THEN SAY check_obj_weight_sg OF my_game.
+          ELSE SAY check_obj_weight_pl OF my_game.
+        END IF.
+  DOES
+    "That wouldn't accomplish anything."
   END VERB.
 END ADD TO.
 
@@ -3995,45 +3995,45 @@ SYNONYMS raise = lift.
 
 
 SYNTAX light = light (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
   VERB light
-	CHECK my_game CAN light
-			ELSE SAY restricted_response OF my_game.
-	AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-	AND obj IS reachable AND obj IS NOT distant
-		ELSE
-			IF obj IS NOT reachable
-				THEN  
-					IF obj IS NOT plural
-						THEN SAY check_obj_reachable_sg OF my_game.
-						ELSE SAY check_obj_reachable_pl OF my_game.
-					END IF.
-			ELSIF obj IS distant
-				THEN
-					IF obj IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game. 						
-					END IF.
-			END IF.			
-	DOES
-		IF obj IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can $v."
+  CHECK my_game CAN light
+      ELSE SAY restricted_response OF my_game.
+  AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+  AND obj IS reachable AND obj IS NOT distant
+    ELSE
+      IF obj IS NOT reachable
+        THEN
+          IF obj IS NOT plural
+            THEN SAY check_obj_reachable_sg OF my_game.
+            ELSE SAY check_obj_reachable_pl OF my_game.
+          END IF.
+      ELSIF obj IS distant
+        THEN
+          IF obj IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+      END IF.
+  DOES
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can $v."
   END VERB.
 END ADD TO.
 
@@ -4055,10 +4055,10 @@ SYNTAX listen0 = listen.
 
 
 VERB listen0
-	CHECK my_game CAN listen0
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		"You hear nothing unusual."
+  CHECK my_game CAN listen0
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "You hear nothing unusual."
 END VERB.
 
 
@@ -4073,36 +4073,36 @@ END VERB.
 
 
 SYNTAX listen = listen 'to' (obj)!
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_to_sg OF my_game. 
-				ELSE SAY illegal_parameter_to_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_to_sg OF my_game.
+        ELSE SAY illegal_parameter_to_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB listen
-		CHECK my_game CAN listen
-			ELSE SAY restricted_response OF my_game.
-		AND obj <> hero 
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		DOES
-			IF obj AT hero
-				THEN 
-					IF obj ISA ACTOR
-						THEN SAY THE obj.
-							IF obj IS NOT PLURAL
-								THEN "is"
-								ELSE "are"
-							END IF.
-							"not talking right now."
-						ELSE "You hear nothing unusual."
-					END IF.
-			ELSIF obj NEAR hero
-				THEN "You can't hear" SAY THE obj. "very well from here."
-			END IF.
-  	END VERB.
+  VERB listen
+    CHECK my_game CAN listen
+      ELSE SAY restricted_response OF my_game.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    DOES
+      IF obj AT hero
+        THEN
+          IF obj ISA ACTOR
+            THEN SAY THE obj.
+              IF obj IS NOT PLURAL
+                THEN "is"
+                ELSE "are"
+              END IF.
+              "not talking right now."
+            ELSE "You hear nothing unusual."
+          END IF.
+      ELSIF obj NEAR hero
+        THEN "You can't hear" SAY THE obj. "very well from here."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -4117,64 +4117,64 @@ END ADD TO.
 
 
 SYNTAX lock = lock (obj)
-    	WHERE obj ISA OBJECT
-     		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+      WHERE obj ISA OBJECT
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB lock
-		CHECK my_game CAN lock
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS lockable
-	    		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		AND obj IS NOT locked
-	    		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_not_locked_sg OF my_game.
-					ELSE SAY check_obj_not_locked_pl OF my_game.
-			END IF.
-	DOES
-		IF matching_key OF obj IN hero
-			THEN MAKE obj locked.
-				"(with" SAY THE matching_key OF obj. "$$)$n"
-				"You" 
+  VERB lock
+    CHECK my_game CAN lock
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS lockable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND obj IS NOT locked
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_not_locked_sg OF my_game.
+          ELSE SAY check_obj_not_locked_pl OF my_game.
+      END IF.
+  DOES
+    IF matching_key OF obj IN hero
+      THEN MAKE obj locked.
+        "(with" SAY THE matching_key OF obj. "$$)$n"
+        "You"
 
-				IF obj IS open
-					THEN "close and"
-						MAKE obj NOT open.
-		 		END IF.
+        IF obj IS open
+          THEN "close and"
+            MAKE obj NOT open.
+        END IF.
 
-				"lock" SAY THE obj. "."
-	    		ELSE	"You have to state what you want to lock" SAY THE obj. "with."
-		END IF.
+        "lock" SAY THE obj. "."
+          ELSE  "You have to state what you want to lock" SAY THE obj. "with."
+    END IF.
 
   END VERB.
-END ADD TO. 
+END ADD TO.
 
 
 
@@ -4188,76 +4188,76 @@ END ADD TO.
 
 
 SYNTAX lock_with = lock (obj) 'with' (key)
-	WHERE obj ISA OBJECT
-	  	ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND key ISA OBJECT
-	  	ELSE 
-			IF key IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND key ISA OBJECT
+      ELSE
+      IF key IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-  	VERB lock_with
-    		WHEN obj
-			CHECK my_game CAN lock_with
-				ELSE SAY restricted_response OF my_game.
-	    		AND obj IS lockable
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND key IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF.
-			AND obj <> key
-				ELSE SAY check_obj_not_obj2_with OF my_game. 
-	    		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-	    		AND obj IS NOT locked
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_not_locked_sg OF my_game.
-						ELSE SAY check_obj_not_locked_pl OF my_game.
-					END IF.
-	    		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.	
-	    		AND key IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.  
-	    		AND key = matching_key OF obj
-				ELSE SAY check_door_matching_key OF my_game.	
-	   		 DOES
-				MAKE obj locked. "You"
+    VERB lock_with
+        WHEN obj
+      CHECK my_game CAN lock_with
+        ELSE SAY restricted_response OF my_game.
+          AND obj IS lockable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND key IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND obj <> key
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+          AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+          AND obj IS NOT locked
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_not_locked_sg OF my_game.
+            ELSE SAY check_obj_not_locked_pl OF my_game.
+          END IF.
+          AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          AND key IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+          AND key = matching_key OF obj
+        ELSE SAY check_door_matching_key OF my_game.
+         DOES
+        MAKE obj locked. "You"
 
-		 		IF obj IS open
-					THEN "close and"
-						MAKE obj NOT open.
-		 		END IF.
+        IF obj IS open
+          THEN "close and"
+            MAKE obj NOT open.
+        END IF.
 
-		 		"lock" SAY THE obj. "with" SAY THE key. "."
-  	END VERB.
+        "lock" SAY THE obj. "with" SAY THE key. "."
+    END VERB.
 END ADD TO.
 
 
@@ -4275,12 +4275,12 @@ SYNTAX 'look' = 'look'.
 
 
 VERB 'look'
-	CHECK my_game CAN 'look'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		INCREASE described OF CURRENT LOCATION. 		
-		-- see 'locations.i', attribute 'described'.
-		LOOK.
+  CHECK my_game CAN 'look'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    INCREASE described OF CURRENT LOCATION.
+    -- see 'locations.i', attribute 'described'.
+    LOOK.
 END VERB.
 
 
@@ -4310,26 +4310,26 @@ SYNONYMS l = 'look'.
 
 
 SYNTAX look_behind = 'look' behind (bulk)
-	WHERE bulk ISA THING
-		ELSE SAY illegal_parameter_there OF my_game.
+  WHERE bulk ISA THING
+    ELSE SAY illegal_parameter_there OF my_game.
 
 
 ADD TO EVERY THING
-	VERB look_behind 
-		CHECK my_game CAN look_behind
-			ELSE SAY restricted_response OF my_game.
-		AND bulk IS examinable
-			ELSE SAY check_obj_suitable_there OF my_game. 	
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND bulk <> hero 
-			ELSE SAY check_obj_not_hero7 OF my_game.
-		DOES 
-			IF bulk IN hero
-				THEN "You turn" SAY THE bulk. "in your hands but notice nothing unusual about it."
-				ELSE "You notice nothing unusual behind" SAY THE bulk. "."
-			END IF.
-  	END VERB.
+  VERB look_behind
+    CHECK my_game CAN look_behind
+      ELSE SAY restricted_response OF my_game.
+    AND bulk IS examinable
+      ELSE SAY check_obj_suitable_there OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND bulk <> hero
+      ELSE SAY check_obj_not_hero7 OF my_game.
+    DOES
+      IF bulk IN hero
+        THEN "You turn" SAY THE bulk. "in your hands but notice nothing unusual about it."
+        ELSE "You notice nothing unusual behind" SAY THE bulk. "."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -4344,30 +4344,30 @@ END ADD TO.
 
 
 SYNTAX
-	look_in = 'look' 'in' (cont) 
-		WHERE cont ISA OBJECT
-			ELSE SAY illegal_parameter_there OF my_game. 
-		AND cont ISA CONTAINER
-			ELSE SAY illegal_parameter_there OF my_game. 
+  look_in = 'look' 'in' (cont)
+    WHERE cont ISA OBJECT
+      ELSE SAY illegal_parameter_there OF my_game.
+    AND cont ISA CONTAINER
+      ELSE SAY illegal_parameter_there OF my_game.
 
 
 ADD TO EVERY OBJECT
-	VERB look_in
-		CHECK my_game CAN look_in
-			ELSE SAY restricted_response OF my_game.
-		AND cont IS examinable
-			ELSE SAY check_obj_suitable_there OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND cont IS open
-			ELSE 
-				IF cont IS NOT plural
-					THEN SAY check_obj_open2_sg OF my_game.
-					ELSE SAY check_obj_open2_pl OF my_game.
-				END IF.
-		DOES  
-			LIST cont.
-  	END VERB.
+  VERB look_in
+    CHECK my_game CAN look_in
+      ELSE SAY restricted_response OF my_game.
+    AND cont IS examinable
+      ELSE SAY check_obj_suitable_there OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND cont IS open
+      ELSE
+        IF cont IS NOT plural
+          THEN SAY check_obj_open2_sg OF my_game.
+          ELSE SAY check_obj_open2_pl OF my_game.
+        END IF.
+    DOES
+      LIST cont.
+    END VERB.
 END ADD TO.
 
 
@@ -4382,34 +4382,34 @@ END ADD TO.
 
 
 SYNTAX look_out_of = 'look' 'out' 'of' (obj)
-	WHERE obj ISA OBJECT
-		ELSE
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_look_out_sg OF my_game. 
-				ELSE SAY illegal_parameter_look_out_pl OF my_game. 
-			END IF. 
-				
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_look_out_sg OF my_game.
+        ELSE SAY illegal_parameter_look_out_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB look_out_of 
-		CHECK my_game CAN look_out_of
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_look_out_sg OF my_game. 
-					ELSE SAY check_obj_suitable_look_out_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES 
-			IF obj IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can look out of."
-  	END VERB.
+  VERB look_out_of
+    CHECK my_game CAN look_out_of
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_look_out_sg OF my_game.
+          ELSE SAY check_obj_suitable_look_out_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can look out of."
+    END VERB.
 END ADD TO.
 
 
@@ -4424,21 +4424,21 @@ END ADD TO.
 
 
 SYNTAX look_through = 'look' through (bulk)
-	WHERE bulk ISA OBJECT
-		ELSE SAY illegal_parameter_look_through OF my_game. 
-	
+  WHERE bulk ISA OBJECT
+    ELSE SAY illegal_parameter_look_through OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-	VERB look_through
-		CHECK my_game CAN look_through
-			ELSE SAY restricted_response OF my_game.
-		AND bulk IS examinable
-			ELSE SAY check_obj_suitable_look_through OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES 
-			"You can't see through" SAY THE bulk. "."
+  VERB look_through
+    CHECK my_game CAN look_through
+      ELSE SAY restricted_response OF my_game.
+    AND bulk IS examinable
+      ELSE SAY check_obj_suitable_look_through OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "You can't see through" SAY THE bulk. "."
   END VERB.
 END ADD TO.
 
@@ -4454,24 +4454,24 @@ END ADD TO.
 
 
 SYNTAX look_under = 'look' under (bulk)
-	WHERE bulk ISA THING
-		ELSE SAY illegal_parameter_there OF my_game.
-					
+  WHERE bulk ISA THING
+    ELSE SAY illegal_parameter_there OF my_game.
+
 
 
 ADD TO EVERY THING
-	VERB look_under 
-		CHECK my_game CAN look_under
-			ELSE SAY restricted_response OF my_game.
-		AND bulk IS examinable
-			ELSE SAY check_obj_suitable_there OF my_game. 
-		AND bulk <> hero
-			ELSE SAY check_obj_not_hero8 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES 
-			"You notice nothing unusual under" SAY THE bulk. "."
-  	END VERB.
+  VERB look_under
+    CHECK my_game CAN look_under
+      ELSE SAY restricted_response OF my_game.
+    AND bulk IS examinable
+      ELSE SAY check_obj_suitable_there OF my_game.
+    AND bulk <> hero
+      ELSE SAY check_obj_not_hero8 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "You notice nothing unusual under" SAY THE bulk. "."
+    END VERB.
 END ADD TO.
 
 
@@ -4479,7 +4479,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ LOOK UP 	(-> see also CONSULT)
+----- LOOK UP   (-> see also CONSULT)
 
 
 -- ==============================================================
@@ -4489,9 +4489,9 @@ SYNTAX look_up = 'look' up.
 
 
 VERB look_up
-	CHECK my_game CAN look_up
-		ELSE SAY restricted_response OF my_game.
-	DOES "Looking up, you see nothing unusual."
+  CHECK my_game CAN look_up
+    ELSE SAY restricted_response OF my_game.
+  DOES "Looking up, you see nothing unusual."
 END VERB.
 
 
@@ -4509,9 +4509,9 @@ SYNTAX 'no' = 'no'.
 
 
 VERB 'no'
-	CHECK my_game CAN 'no'
-		ELSE SAY restricted_response OF my_game.
-	DOES "Really?"
+  CHECK my_game CAN 'no'
+    ELSE SAY restricted_response OF my_game.
+  DOES "Really?"
 END VERB.
 
 
@@ -4530,99 +4530,99 @@ END VERB.
 
 
 
-SYNTAX notify = notify. 
+SYNTAX notify = notify.
 
-	 notify_on = notify 'on'.	
-		-- The instructions tell the player that mere 'notify'
-		-- is enough, but these two verbs are implemented
-	 notify_off = notify 'off'.	
-		-- In case (s)he adds the prepositions to the end anyway.
+   notify_on = notify 'on'.
+    -- The instructions tell the player that mere 'notify'
+    -- is enough, but these two verbs are implemented
+   notify_off = notify 'off'.
+    -- In case (s)he adds the prepositions to the end anyway.
 
 
-VERB notify 
-	CHECK my_game CAN notify
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		IF my_game HAS notify_turned_on 
-			THEN MAKE my_game NOT notify_turned_on. 
-				"Score notification is now disabled. (You can turn it back on 
-				using the NOTIFY command again.)" 
-			ELSE MAKE my_game notify_turned_on. "Score notification is now enabled. 
-				(You can turn it off using the NOTIFY command again.)" 
-		END IF. 
-END VERB. 
+VERB notify
+  CHECK my_game CAN notify
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    IF my_game HAS notify_turned_on
+      THEN MAKE my_game NOT notify_turned_on.
+        "Score notification is now disabled. (You can turn it back on
+        using the NOTIFY command again.)"
+      ELSE MAKE my_game notify_turned_on. "Score notification is now enabled.
+        (You can turn it off using the NOTIFY command again.)"
+    END IF.
+END VERB.
 
 
 VERB notify_on
-	CHECK my_game CAN notify_on
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		IF my_game HAS notify_turned_on 
-			THEN "Score notification is already enabled."
-			ELSE MAKE my_game notify_turned_on. 
-				"Score notification is now enabled. 
-				(You can turn it off using the NOTIFY command again.)" 
-		END IF. 
-END VERB. 
+  CHECK my_game CAN notify_on
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    IF my_game HAS notify_turned_on
+      THEN "Score notification is already enabled."
+      ELSE MAKE my_game notify_turned_on.
+        "Score notification is now enabled.
+        (You can turn it off using the NOTIFY command again.)"
+    END IF.
+END VERB.
 
 
 VERB notify_off
-	CHECK my_game CAN notify_off
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		IF my_game HAS notify_turned_on 
-			THEN MAKE my_game NOT notify_turned_on. 
-				"Score notification is now disabled. (You can turn it back on 
-				using the NOTIFY command again.)" 
-			ELSE "Score notification is already disabled." 
-		END IF. 
-END VERB. 
+  CHECK my_game CAN notify_off
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    IF my_game HAS notify_turned_on
+      THEN MAKE my_game NOT notify_turned_on.
+        "Score notification is now disabled. (You can turn it back on
+        using the NOTIFY command again.)"
+      ELSE "Score notification is already disabled."
+    END IF.
+END VERB.
 
 
--- The 'notify' verb allows the players to disable the score change 
--- messages. (Some players find such messages annoying.) 
--- The verb toggles the hero's 'notify_on' attribute on and off. That 
--- attribute is checked by the 'checkscore' event to determine whether 
--- to display the score msg or not. 
-	
--- The following event is run each turn to check if the game score is greater than 
--- the last recorded score (which is stored in the Hero's 'oldscore' 
--- attribute). If the score is greater, then the 'Score has gone up...' 
--- text is displayed (as long as the player hasn't disabled it by using the 
--- 'notify' verb - which sets 'notify_on' to off 
--- - i.e. the hero 'IS NOT notify_on'.) 
+-- The 'notify' verb allows the players to disable the score change
+-- messages. (Some players find such messages annoying.)
+-- The verb toggles the hero's 'notify_on' attribute on and off. That
+-- attribute is checked by the 'checkscore' event to determine whether
+-- to display the score msg or not.
 
--- NOTE: The ALAN scoring system records the game score in a thing called 
--- score. It isn't called score OF anything; its just 'score'. 
+-- The following event is run each turn to check if the game score is greater than
+-- the last recorded score (which is stored in the Hero's 'oldscore'
+-- attribute). If the score is greater, then the 'Score has gone up...'
+-- text is displayed (as long as the player hasn't disabled it by using the
+-- 'notify' verb - which sets 'notify_on' to off
+-- - i.e. the hero 'IS NOT notify_on'.)
 
--- NOTE: This event assumes score can only increase, if score can go 
--- down then you would need to modify this code a bit. 
+-- NOTE: The ALAN scoring system records the game score in a thing called
+-- score. It isn't called score OF anything; its just 'score'.
+
+-- NOTE: This event assumes score can only increase, if score can go
+-- down then you would need to modify this code a bit.
 
 
-EVENT check_score 
-	IF oldscore OF my_game < score 
-		THEN 
-			IF my_game HAS notify_turned_on 
-				THEN 			
-					-- ie: the player wants to see score msgs 
-					"$p(Your score has just gone up by" SAY (score - oldscore OF my_game). 
-					IF (score - oldscore OF my_game) = 1
-						THEN "point.)"
-						ELSE "points.)"
-					END IF. 
-					-- this msg only displayed the first time player is notified 
-					-- of a score change 
-					IF my_game HAS NOT seen_notify 
-						THEN MAKE my_game seen_notify. 
-							"$p(You can use the NOTIFY command to disable score change messages.)" 
-					END IF. 
-			END IF.
- 
-			SET oldscore OF my_game TO score. 
-	END IF. 
-	-- run the 'check_score' event again next turn: 
-	SCHEDULE check_score AT hero AFTER 1.
-END EVENT. 
+EVENT check_score
+  IF oldscore OF my_game < score
+    THEN
+      IF my_game HAS notify_turned_on
+        THEN
+          -- ie: the player wants to see score msgs
+          "$p(Your score has just gone up by" SAY (score - oldscore OF my_game).
+          IF (score - oldscore OF my_game) = 1
+            THEN "point.)"
+            ELSE "points.)"
+          END IF.
+          -- this msg only displayed the first time player is notified
+          -- of a score change
+          IF my_game HAS NOT seen_notify
+            THEN MAKE my_game seen_notify.
+              "$p(You can use the NOTIFY command to disable score change messages.)"
+          END IF.
+      END IF.
+
+      SET oldscore OF my_game TO score.
+  END IF.
+  -- run the 'check_score' event again next turn:
+  SCHEDULE check_score AT hero AFTER 1.
+END EVENT.
 
 
 
@@ -4637,61 +4637,61 @@ END EVENT.
 
 
 SYNTAX open = open (obj)
-    	WHERE obj ISA OBJECT
-     		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+      WHERE obj ISA OBJECT
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB open
-		CHECK my_game CAN open
-			ELSE SAY restricted_response OF my_game.		
-    		AND obj IS openable
-      		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-		 		END IF.
-    		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-    		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-    		AND obj IS NOT open
-      		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_not_open_sg OF my_game.
-					ELSE SAY check_obj_not_open_pl OF my_game.
-				END IF.
-    		DOES
-			IF obj IS locked
-				THEN
-					IF matching_key OF obj IN hero
-						THEN MAKE obj NOT locked.
-							MAKE obj open.
-							"(with" SAY THE matching_key OF obj. "$$) 
-							$nYou unlock and open" SAY THE obj. "."
-						ELSE SAY THE obj. "appears to be locked."
-					END IF. 
-			ELSIF obj IS NOT locked
-				THEN MAKE obj open.
-				"You open" SAY THE obj. "."
-			END IF.
+  VERB open
+    CHECK my_game CAN open
+      ELSE SAY restricted_response OF my_game.
+        AND obj IS openable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+        AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+        AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+        AND obj IS NOT open
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_not_open_sg OF my_game.
+          ELSE SAY check_obj_not_open_pl OF my_game.
+        END IF.
+        DOES
+      IF obj IS locked
+        THEN
+          IF matching_key OF obj IN hero
+            THEN MAKE obj NOT locked.
+              MAKE obj open.
+              "(with" SAY THE matching_key OF obj. "$$)
+              $nYou unlock and open" SAY THE obj. "."
+            ELSE SAY THE obj. "appears to be locked."
+          END IF.
+      ELSIF obj IS NOT locked
+        THEN MAKE obj open.
+        "You open" SAY THE obj. "."
+      END IF.
   END VERB.
 END ADD TO.
 
@@ -4707,84 +4707,84 @@ END ADD TO.
 
 
 SYNTAX open_with = open (obj) 'with' (instr)
-    	WHERE obj ISA OBJECT
-     		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-    	AND instr ISA OBJECT
-     		ELSE 
-			IF instr IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+      WHERE obj ISA OBJECT
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+      AND instr ISA OBJECT
+        ELSE
+      IF instr IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 
 ADD TO EVERY OBJECT
-	VERB open_with
-    		WHEN obj
-			CHECK my_game CAN open_with
-				ELSE SAY restricted_response OF my_game.
-	    		AND obj IS openable
-		  		ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-		 			END IF.
-			AND instr IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-			AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-	    		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-	    		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.	
-	    		AND instr IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.
-	    		AND obj IS NOT open
-		  		ELSE   
-					IF obj IS NOT plural
-						THEN SAY check_obj_not_open_sg OF my_game.
-						ELSE SAY check_obj_not_open_pl OF my_game.
-					END IF. 
-	    		DOES
-				IF obj IS locked
-					THEN
-						IF instr = matching_key OF obj 
-							THEN MAKE obj NOT locked.
-								MAKE obj open.
-								"You unlock  and open" SAY THE obj. 
-								"with" SAY THE instr. "."
-							ELSE SAY THE obj.
-								IF obj IS NOT plural
-									THEN "is locked."
-									ELSE "are locked."
-								END IF.
-						END IF. 
-					ELSE "You can't open" SAY THE obj. "with" SAY THE instr. "."
-				END IF.
+  VERB open_with
+        WHEN obj
+      CHECK my_game CAN open_with
+        ELSE SAY restricted_response OF my_game.
+          AND obj IS openable
+          ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND instr IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+          AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+          AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          AND instr IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+          AND obj IS NOT open
+          ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_not_open_sg OF my_game.
+            ELSE SAY check_obj_not_open_pl OF my_game.
+          END IF.
+          DOES
+        IF obj IS locked
+          THEN
+            IF instr = matching_key OF obj
+              THEN MAKE obj NOT locked.
+                MAKE obj open.
+                "You unlock  and open" SAY THE obj.
+                "with" SAY THE instr. "."
+              ELSE SAY THE obj.
+                IF obj IS NOT plural
+                  THEN "is locked."
+                  ELSE "are locked."
+                END IF.
+            END IF.
+          ELSE "You can't open" SAY THE obj. "with" SAY THE instr. "."
+        END IF.
 
-		  	
-  	END VERB.
+
+    END VERB.
 END ADD TO.
 
 
@@ -4799,48 +4799,48 @@ END ADD TO.
 
 
 SYNTAX 'play' = 'play' (obj)
-	WHERE obj ISA OBJECT
-		ELSE
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB 'play'
-		CHECK my_game CAN 'play'
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_with_sg OF my_game.
-					ELSE SAY check_obj_suitable_with_pl OF my_game.
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			IF obj IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can play."
-  	END VERB.
+  VERB 'play'
+    CHECK my_game CAN 'play'
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_with_sg OF my_game.
+          ELSE SAY check_obj_suitable_with_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can play."
+    END VERB.
 END ADD TO.
 
 
@@ -4855,48 +4855,48 @@ END ADD TO.
 
 
 SYNTAX play_with = 'play' 'with' (obj)
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_with_sg OF my_game. 
-				ELSE SAY illegal_parameter_with_pl OF my_game. 
-			END IF.
-			
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_with_sg OF my_game.
+        ELSE SAY illegal_parameter_with_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY THING
-	VERB play_with
-		CHECK my_game CAN play_with
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_with_sg OF my_game.
-					ELSE SAY check_obj_suitable_with_pl OF my_game.
-				END IF.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero6 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"After second thought you don't find it purposeful to start
-		 	 playing with" SAY THE obj. "."
-  	END VERB.
+  VERB play_with
+    CHECK my_game CAN play_with
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_with_sg OF my_game.
+          ELSE SAY check_obj_suitable_with_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero6 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "After second thought you don't find it purposeful to start
+       playing with" SAY THE obj. "."
+    END VERB.
 END ADD TO.
 
 
@@ -4919,7 +4919,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ PRAY 
+----- PRAY
 
 
 -- ==============================================================
@@ -4929,9 +4929,9 @@ SYNTAX pray = pray.
 
 
 VERB pray
-	CHECK my_game CAN pray
-		ELSE SAY restricted_response OF my_game.
-	DOES "Your prayers don't seem to help right now."
+  CHECK my_game CAN pray
+    ELSE SAY restricted_response OF my_game.
+  DOES "Your prayers don't seem to help right now."
 END VERB.
 
 
@@ -4946,28 +4946,28 @@ END VERB.
 
 
 SYNTAX pry = pry (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB pry
-		CHECK my_game CAN pry
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES "You must state what you want to pry" SAY THE obj. "with."
-	END VERB.
+  VERB pry
+    CHECK my_game CAN pry
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES "You must state what you want to pry" SAY THE obj. "with."
+  END VERB.
 END ADD TO.
 
 
@@ -4982,59 +4982,59 @@ END ADD TO.
 
 
 SYNTAX pry_with = pry (obj) 'with' (instr)
-		WHERE obj ISA OBJECT
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
-		AND instr ISA OBJECT
-			ELSE
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter2_with_sg OF my_game. 
-					ELSE SAY illegal_parameter2_with_pl OF my_game. 
-				END IF.
-			
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+    AND instr ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter2_with_sg OF my_game.
+          ELSE SAY illegal_parameter2_with_pl OF my_game.
+        END IF.
+
 
 ADD TO EVERY OBJECT
 VERB pry_with
    WHEN obj
-	CHECK my_game CAN pry_with
-		ELSE SAY restricted_response OF my_game.
-	AND obj IS examinable
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY check_obj_suitable_sg OF my_game. 
-				ELSE SAY check_obj_suitable_pl OF my_game. 
-			END IF.
-	AND instr IS examinable
-		ELSE
-			IF obj IS NOT plural
-				THEN SAY check_obj2_suitable_with_sg OF my_game. 
-				ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-			END IF. 
-	AND obj <> instr
-		ELSE SAY check_obj_not_obj2_with OF my_game.
-	AND instr IN hero
-		ELSE SAY check_obj2_in_hero OF my_game.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	AND obj IS reachable AND obj IS NOT distant
-		ELSE
-			IF obj IS NOT reachable
-				THEN  						
-					IF obj IS NOT plural
-						THEN SAY check_obj_reachable_sg OF my_game.
-						ELSE SAY check_obj_reachable_pl OF my_game.
-					END IF.
-			ELSIF obj IS distant
-				THEN
-					IF obj IS NOT plural	
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game. 
-					END IF.
-			END IF.
-	DOES "That doesn't work."
+  CHECK my_game CAN pry_with
+    ELSE SAY restricted_response OF my_game.
+  AND obj IS examinable
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY check_obj_suitable_sg OF my_game.
+        ELSE SAY check_obj_suitable_pl OF my_game.
+      END IF.
+  AND instr IS examinable
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY check_obj2_suitable_with_sg OF my_game.
+        ELSE SAY check_obj2_suitable_with_pl OF my_game.
+      END IF.
+  AND obj <> instr
+    ELSE SAY check_obj_not_obj2_with OF my_game.
+  AND instr IN hero
+    ELSE SAY check_obj2_in_hero OF my_game.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  AND obj IS reachable AND obj IS NOT distant
+    ELSE
+      IF obj IS NOT reachable
+        THEN
+          IF obj IS NOT plural
+            THEN SAY check_obj_reachable_sg OF my_game.
+            ELSE SAY check_obj_reachable_pl OF my_game.
+          END IF.
+      ELSIF obj IS distant
+        THEN
+          IF obj IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+      END IF.
+  DOES "That doesn't work."
 END VERB.
 END ADD TO.
 
@@ -5050,44 +5050,44 @@ END ADD TO.
 
 
 SYNTAX pull = pull (obj)
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.		
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB pull
-		CHECK my_game CAN pull
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS movable
-			ELSE SAY check_obj_movable OF my_game.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		AND obj IS inanimate
-			ELSE SAY check_obj_inanimate1 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"That wouldn't accomplish anything."
-	END VERB.
+  VERB pull
+    CHECK my_game CAN pull
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS movable
+      ELSE SAY check_obj_movable OF my_game.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND obj IS inanimate
+      ELSE SAY check_obj_inanimate1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "That wouldn't accomplish anything."
+  END VERB.
 END ADD TO.
 
 
@@ -5102,43 +5102,43 @@ END ADD TO.
 
 
 SYNTAX push = push (obj)
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB push
-		CHECK my_game CAN push
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS movable
-	     		ELSE SAY check_obj_movable OF my_game.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero1 OF my_game. 
-		AND obj IS inanimate
-			ELSE SAY check_obj_inanimate1 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-	    		"You give" SAY THE obj. "a little push. Nothing happens."
+  VERB push
+    CHECK my_game CAN push
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS movable
+          ELSE SAY check_obj_movable OF my_game.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND obj IS inanimate
+      ELSE SAY check_obj_inanimate1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+          "You give" SAY THE obj. "a little push. Nothing happens."
     END VERB.
 END ADD TO.
 
@@ -5157,57 +5157,57 @@ SYNONYMS press = push.
 
 
 SYNTAX push_with = push (obj) 'with' (instr)
-	WHERE obj ISA THING
-   		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND instr ISA OBJECT
-   		ELSE SAY illegal_parameter2_with_sg OF my_game.
+  WHERE obj ISA THING
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND instr ISA OBJECT
+      ELSE SAY illegal_parameter2_with_sg OF my_game.
 
 
 ADD TO EVERY THING
-	VERB push_with
-		WHEN obj
-			CHECK my_game CAN push_with
-				ELSE SAY restricted_response OF my_game.
-			AND obj IS movable
-	   			ELSE SAY check_obj_movable OF my_game.
-			AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game.
-			AND instr IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF.  
-			AND instr IN hero
-				ELSE SAY check_obj2_in_hero OF my_game.
-			AND obj <> hero
-				ELSE SAY check_obj_not_hero1 OF my_game. 
-			AND obj IS inanimate
-				ELSE SAY check_obj_inanimate1 OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			DOES
-				"That wouldn't accomplish anything."
-    END VERB. 
+  VERB push_with
+    WHEN obj
+      CHECK my_game CAN push_with
+        ELSE SAY restricted_response OF my_game.
+      AND obj IS movable
+          ELSE SAY check_obj_movable OF my_game.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND instr IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+      AND instr IN hero
+        ELSE SAY check_obj2_in_hero OF my_game.
+      AND obj <> hero
+        ELSE SAY check_obj_not_hero1 OF my_game.
+      AND obj IS inanimate
+        ELSE SAY check_obj_inanimate1 OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      DOES
+        "That wouldn't accomplish anything."
+    END VERB.
 END ADD TO.
 
 
@@ -5221,28 +5221,28 @@ END ADD TO.
 -- ==============================================================
 
 
-SYNTAX put = put (obj) 
-	WHERE obj ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game. 
-				
+SYNTAX put = put (obj)
+  WHERE obj ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-	VERB put
-		CHECK my_game CAN put
-			ELSE SAY restricted_response OF my_game.
-		AND obj IN HERO
-			ELSE SAY check_obj_in_hero OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES
-			"You must state where you want to put" 
-			
-			IF obj IS NOT plural
-				THEN "it."
-				ELSE "them."
-			END IF.
-  	END VERB.
+  VERB put
+    CHECK my_game CAN put
+      ELSE SAY restricted_response OF my_game.
+    AND obj IN HERO
+      ELSE SAY check_obj_in_hero OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "You must state where you want to put"
+
+      IF obj IS NOT plural
+        THEN "it."
+        ELSE "them."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -5253,7 +5253,7 @@ SYNONYMS lay, place = put.
 -- ==============================================================
 
 
------ PUT DOWN	(works as  'drop')
+----- PUT DOWN  (works as  'drop')
 
 
 -- ==============================================================
@@ -5267,95 +5267,95 @@ SYNONYMS lay, place = put.
 -- ==============================================================
 
 
------ PUT IN	(+ insert)
+----- PUT IN  (+ insert)
 
 
 -- ==============================================================
 
 
 SYNTAX put_in = put (obj) 'in' (cont)
-	WHERE obj ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game.
-	AND cont ISA OBJECT
-		ELSE 
-			IF cont ISA ACTOR
-				THEN SAY illegal_parameter_act OF my_game.
-				ELSE SAY illegal_parameter2_there OF my_game.
-			END IF. 	
-	AND cont ISA CONTAINER
-		ELSE SAY illegal_parameter2_there OF my_game.
-			
-	 
-	put_in = insert (obj) 'in' (cont).
-		
+  WHERE obj ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+  AND cont ISA OBJECT
+    ELSE
+      IF cont ISA ACTOR
+        THEN SAY illegal_parameter_act OF my_game.
+        ELSE SAY illegal_parameter2_there OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+    ELSE SAY illegal_parameter2_there OF my_game.
+
+
+  put_in = insert (obj) 'in' (cont).
+
 
 ADD TO EVERY OBJECT
-	VERB put_in
-		WHEN obj
-			CHECK my_game CAN put_in
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> cont
-				ELSE SAY check_obj_not_obj2_in OF my_game.
-	    		AND obj IS takeable
-		  		ELSE SAY check_obj_takeable OF my_game.
-	    		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		AND obj NOT IN cont
-		  		ELSE 
-					IF cont ISA SUPPORTER
-						THEN SAY check_cont_not_supporter OF my_game.
-						ELSE 
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_in_cont_sg OF my_game.
-								ELSE SAY check_obj_not_in_cont_pl OF my_game.
-							END IF.
-					END IF.
-	    		AND cont IS reachable AND cont IS NOT distant
-				ELSE
-					IF cont IS NOT reachable
-						THEN  
-							IF cont IS NOT plural
-								THEN SAY check_obj2_reachable_sg OF my_game.
-								ELSE SAY check_obj2_reachable_pl OF my_game.
-							END IF.
-					ELSIF cont IS distant
-						THEN
-							IF cont IS NOT plural
-								THEN SAY check_obj2_not_distant_sg OF my_game. 
-								ELSE SAY check_obj2_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND obj IN allowed OF cont
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_allowed_in_sg OF my_game.
-						ELSE SAY check_obj_allowed_in_pl OF my_game.
-					END IF.
-			AND cont IS open
-		  		ELSE 
-					IF cont IS NOT plural
-						THEN SAY check_obj2_open_sg OF my_game.
-						ELSE SAY check_obj2_open_pl OF my_game.
-					END IF.
-	    		DOES
-				LOCATE obj IN cont.
-				"You put" SAY THE obj. "into" SAY THE cont. "."	
-	END VERB.
+  VERB put_in
+    WHEN obj
+      CHECK my_game CAN put_in
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> cont
+        ELSE SAY check_obj_not_obj2_in OF my_game.
+          AND obj IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+          AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          AND obj NOT IN cont
+          ELSE
+          IF cont ISA SUPPORTER
+            THEN SAY check_cont_not_supporter OF my_game.
+            ELSE
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_in_cont_sg OF my_game.
+                ELSE SAY check_obj_not_in_cont_pl OF my_game.
+              END IF.
+          END IF.
+          AND cont IS reachable AND cont IS NOT distant
+        ELSE
+          IF cont IS NOT reachable
+            THEN
+              IF cont IS NOT plural
+                THEN SAY check_obj2_reachable_sg OF my_game.
+                ELSE SAY check_obj2_reachable_pl OF my_game.
+              END IF.
+          ELSIF cont IS distant
+            THEN
+              IF cont IS NOT plural
+                THEN SAY check_obj2_not_distant_sg OF my_game.
+                ELSE SAY check_obj2_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND obj IN allowed OF cont
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_allowed_in_sg OF my_game.
+            ELSE SAY check_obj_allowed_in_pl OF my_game.
+          END IF.
+      AND cont IS open
+          ELSE
+          IF cont IS NOT plural
+            THEN SAY check_obj2_open_sg OF my_game.
+            ELSE SAY check_obj2_open_pl OF my_game.
+          END IF.
+          DOES
+        LOCATE obj IN cont.
+        "You put" SAY THE obj. "into" SAY THE cont. "."
+  END VERB.
 END ADD TO.
 
 
@@ -5371,86 +5371,86 @@ END ADD TO.
 
 
 SYNTAX put_against = put (obj) against (bulk)
-	WHERE obj ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game.
-	AND bulk ISA THING
-	    	ELSE SAY illegal_parameter2_there OF my_game.
-			
+  WHERE obj ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+  AND bulk ISA THING
+        ELSE SAY illegal_parameter2_there OF my_game.
+
 
 
 SYNTAX put_behind = put (obj) behind (bulk)
-	WHERE obj ISA OBJECT
- 		ELSE SAY illegal_parameter_obj OF my_game.
-	AND bulk ISA THING
-	    	ELSE SAY illegal_parameter2_there OF my_game.
-			
+  WHERE obj ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+  AND bulk ISA THING
+        ELSE SAY illegal_parameter2_there OF my_game.
+
 
 
 SYNTAX put_near = put (obj) 'near' (bulk)
-	WHERE obj ISA OBJECT
-	    	ELSE SAY illegal_parameter_obj OF my_game.
-	AND bulk ISA THING
-   		ELSE SAY illegal_parameter2_there OF my_game. 
-			
+  WHERE obj ISA OBJECT
+        ELSE SAY illegal_parameter_obj OF my_game.
+  AND bulk ISA THING
+      ELSE SAY illegal_parameter2_there OF my_game.
+
 
 
 SYNTAX put_under = put (obj) under (bulk)
-	WHERE obj ISA OBJECT
-   		ELSE SAY illegal_parameter_obj OF my_game.
-	AND bulk ISA THING
-   		ELSE SAY illegal_parameter2_there OF my_game.
-			
+  WHERE obj ISA OBJECT
+      ELSE SAY illegal_parameter_obj OF my_game.
+  AND bulk ISA THING
+      ELSE SAY illegal_parameter2_there OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-	VERB put_against, put_behind, put_near, put_under
-		WHEN obj	
-			CHECK my_game CAN put_against AND my_game CAN put_behind
-				AND my_game CAN put_near AND my_game CAN put_under
-				ELSE SAY restricted_response OF my_game.
-	    		AND bulk NOT IN hero
-		  		ELSE SAY check_obj2_not_in_hero2 OF my_game.
-			AND obj <> bulk
-		   		ELSE SAY check_obj_not_obj2_put OF my_game.
-	    		AND obj IS takeable
-		  		ELSE SAY check_obj_takeable OF my_game.	
-	    		AND bulk <> hero
-		   		ELSE SAY check_obj2_not_hero2 OF my_game.
-	    		AND CURRENT LOCATION IS lit
-		    		ELSE SAY check_current_loc_lit OF my_game.
-	    		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND bulk IS reachable AND bulk IS NOT distant
-				ELSE
-					IF bulk IS NOT reachable
-						THEN  
-							IF bulk IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF bulk IS distant
-						THEN
-							IF bulk IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		DOES
-		   		"That wouldn't accomplish anything."
-		
+  VERB put_against, put_behind, put_near, put_under
+    WHEN obj
+      CHECK my_game CAN put_against AND my_game CAN put_behind
+        AND my_game CAN put_near AND my_game CAN put_under
+        ELSE SAY restricted_response OF my_game.
+          AND bulk NOT IN hero
+          ELSE SAY check_obj2_not_in_hero2 OF my_game.
+      AND obj <> bulk
+          ELSE SAY check_obj_not_obj2_put OF my_game.
+          AND obj IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+          AND bulk <> hero
+          ELSE SAY check_obj2_not_hero2 OF my_game.
+          AND CURRENT LOCATION IS lit
+            ELSE SAY check_current_loc_lit OF my_game.
+          AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND bulk IS reachable AND bulk IS NOT distant
+        ELSE
+          IF bulk IS NOT reachable
+            THEN
+              IF bulk IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF bulk IS distant
+            THEN
+              IF bulk IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          DOES
+          "That wouldn't accomplish anything."
+
     END VERB.
 END ADD TO.
 
@@ -5468,82 +5468,82 @@ END ADD TO.
 -- To use this verb in the meaning 'wear', see the file 'classes.i',
 -- class 'clothing', verb 'wear'.
 
--- You can put things on the floor/ground (= drop them). In other 
+-- You can put things on the floor/ground (= drop them). In other
 -- cases, the action will fail by default. Allow the action with
 -- individual instances only.
 
 
 
 SYNTAX put_on = put (obj) 'on' (surface)
-	WHERE obj ISA OBJECT
-   		ELSE SAY illegal_parameter_obj OF my_game.
-	AND surface ISA SUPPORTER
-		ELSE SAY illegal_parameter2_there OF my_game. 
-		
+  WHERE obj ISA OBJECT
+      ELSE SAY illegal_parameter_obj OF my_game.
+  AND surface ISA SUPPORTER
+    ELSE SAY illegal_parameter2_there OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-	VERB put_on
-		WHEN obj
-			CHECK my_game CAN put_on
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> surface
-		   		ELSE SAY check_obj_not_obj2_on OF my_game.
-	    		AND obj IS takeable
-		   		ELSE SAY check_obj_takeable OF my_game.	
-	    		AND CURRENT LOCATION IS lit
-		    		ELSE SAY check_current_loc_lit OF my_game.
-	    		AND obj NOT IN surface
-		   		ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_not_on_surface_sg OF my_game.
-						ELSE SAY check_obj_not_on_surface_pl OF my_game.
-					END IF.
-	    		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		AND surface IS reachable AND surface IS NOT distant
-				ELSE
-					IF surface IS NOT reachable
-						THEN  
-							IF surface IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF surface IS distant
-						THEN
-							IF surface IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		DOES	  
-				-- implicit taking:
-				IF obj NOT DIRECTLY IN hero 
-					THEN LOCATE obj IN hero.
-					     SAY implicit_taking_message OF my_game.	
-				END IF.		
-				-- end of implicit taking.		
-				
-				IF surface = floor OR surface = ground
-					THEN LOCATE obj AT hero.
-					ELSE LOCATE obj IN surface.
-				END IF.
-				
-				"You put" SAY THE obj. "on" SAY THE surface. "."
-									
+  VERB put_on
+    WHEN obj
+      CHECK my_game CAN put_on
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> surface
+          ELSE SAY check_obj_not_obj2_on OF my_game.
+          AND obj IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+          AND CURRENT LOCATION IS lit
+            ELSE SAY check_current_loc_lit OF my_game.
+          AND obj NOT IN surface
+          ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_not_on_surface_sg OF my_game.
+            ELSE SAY check_obj_not_on_surface_pl OF my_game.
+          END IF.
+          AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          AND surface IS reachable AND surface IS NOT distant
+        ELSE
+          IF surface IS NOT reachable
+            THEN
+              IF surface IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF surface IS distant
+            THEN
+              IF surface IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          DOES
+        -- implicit taking:
+        IF obj NOT DIRECTLY IN hero
+          THEN LOCATE obj IN hero.
+               SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
+
+        IF surface = floor OR surface = ground
+          THEN LOCATE obj AT hero.
+          ELSE LOCATE obj IN surface.
+        END IF.
+
+        "You put" SAY THE obj. "on" SAY THE surface. "."
+
     END VERB.
 END ADD TO.
 
@@ -5572,14 +5572,14 @@ END ADD TO.
 
 
 SYNTAX
-	'quit' = 'quit'.
+  'quit' = 'quit'.
 
 
 VERB 'quit'
-	CHECK my_game CAN 'quit'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		QUIT.
+  CHECK my_game CAN 'quit'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    QUIT.
 END VERB.
 
 
@@ -5597,44 +5597,44 @@ SYNONYMS q = 'quit'.
 
 
 SYNTAX read = read (obj)
-	WHERE obj ISA OBJECT
-   		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
     VERB read
-		CHECK my_game CAN read
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS readable
-	    		ELSE
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT plural
-					THEN SAY check_obj_not_distant_sg OF my_game. 
-					ELSE SAY check_obj_not_distant_pl OF my_game. 
-				END IF.		
-		DOES
-			IF text OF obj = ""
-				THEN "There's nothing written on" SAY THE obj. "."
-				ELSE "You read" SAY THE obj. "." 
-		
-					IF obj IS NOT plural
-						THEN "It says"
-						ELSE "They say"
-					END IF.
-		
-					"""$$" SAY text OF obj. "$$""." 
-			END IF.
+    CHECK my_game CAN read
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS readable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_not_distant_sg OF my_game.
+          ELSE SAY check_obj_not_distant_pl OF my_game.
+        END IF.
+    DOES
+      IF text OF obj = ""
+        THEN "There's nothing written on" SAY THE obj. "."
+        ELSE "You read" SAY THE obj. "."
+
+          IF obj IS NOT plural
+            THEN "It says"
+            ELSE "They say"
+          END IF.
+
+          """$$" SAY text OF obj. "$$""."
+      END IF.
     END VERB.
 END ADD TO.
 
@@ -5651,34 +5651,34 @@ END ADD TO.
 -- this verb only works with clothing (see 'classes.i').
 
 SYNTAX remove = remove (obj)
-		WHERE obj ISA OBJECT
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. "since you're not wearing it."
-					ELSE SAY illegal_parameter_pl OF my_game. "since you're not wearing them."
-				END IF.
-	 remove = take 'off' (obj).
-	 remove = take (obj) 'off'.
-	 remove = doff (obj).
+    WHERE obj ISA OBJECT
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game. "since you're not wearing it."
+          ELSE SAY illegal_parameter_pl OF my_game. "since you're not wearing them."
+        END IF.
+   remove = take 'off' (obj).
+   remove = take (obj) 'off'.
+   remove = doff (obj).
 
 
 ADD TO EVERY OBJECT
-	VERB remove
-		CHECK my_game CAN remove
-			ELSE SAY restricted_response OF my_game.
-		DOES
-			IF obj IS NOT plural
-				THEN "That's"
-				ELSE "Those are"
-			END IF. 
-			
-			"not something you can remove since you're not wearing"
-					
-			IF obj IS NOT plural
-				THEN "it."
-				ELSE "them."
-			END IF. 
-	END VERB.
+  VERB remove
+    CHECK my_game CAN remove
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's"
+        ELSE "Those are"
+      END IF.
+
+      "not something you can remove since you're not wearing"
+
+      IF obj IS NOT plural
+        THEN "it."
+        ELSE "them."
+      END IF.
+  END VERB.
 END ADD TO.
 
 
@@ -5709,10 +5709,10 @@ SYNTAX 'restart' = 'restart'.
 
 
 VERB 'restart'
-	CHECK my_game CAN 'restart'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		RESTART.
+  CHECK my_game CAN 'restart'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    RESTART.
 END VERB.
 
 
@@ -5730,10 +5730,10 @@ SYNTAX 'restore' = 'restore'.
 
 
 VERB 'restore'
-	CHECK my_game CAN 'restore'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		RESTORE.
+  CHECK my_game CAN 'restore'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    RESTORE.
 END VERB.
 
 
@@ -5748,48 +5748,48 @@ END VERB.
 
 
 SYNTAX rub = rub (obj)
-	WHERE obj ISA THING
-		ELSE 	
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB rub
-		CHECK my_game CAN rub
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero6 OF my_game.
-		AND obj IS inanimate
-			ELSE SAY check_obj_inanimate2 OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.			
-		DOES
-			"Nothing would be achieved by that."
-	END VERB.
+  VERB rub
+    CHECK my_game CAN rub
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero6 OF my_game.
+    AND obj IS inanimate
+      ELSE SAY check_obj_inanimate2 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "Nothing would be achieved by that."
+  END VERB.
 END ADD TO.
 
 
@@ -5810,10 +5810,10 @@ SYNTAX 'save' = 'save'.
 
 
 VERB 'save'
-	CHECK my_game CAN 'save'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		SAVE.
+  CHECK my_game CAN 'save'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    SAVE.
 END VERB.
 
 
@@ -5828,17 +5828,17 @@ END VERB.
 
 
 SYNTAX 'say' = 'say' (topic)
-    	WHERE topic ISA STRING		
-		ELSE SAY illegal_parameter_string OF my_game. 
+      WHERE topic ISA STRING
+    ELSE SAY illegal_parameter_string OF my_game.
 
 
 ADD TO EVERY STRING
-	VERB 'say'
-		CHECK my_game CAN 'say'
-			ELSE SAY restricted_response OF my_game.
-    		DOES
-      		"Nothing happens."
-  	END VERB.
+  VERB 'say'
+    CHECK my_game CAN 'say'
+      ELSE SAY restricted_response OF my_game.
+        DOES
+          "Nothing happens."
+    END VERB.
 END ADD TO.
 
 
@@ -5854,43 +5854,43 @@ END ADD TO.
 
 
 SYNTAX say_to = 'say' (topic) 'to' (act)
-    	WHERE topic ISA STRING
-      	ELSE SAY illegal_parameter_string OF my_game.
-    	AND act ISA ACTOR
-     		ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter_talk_sg OF my_game. 
-				ELSE SAY illegal_parameter_talk_pl OF my_game. 
-			END IF.
+      WHERE topic ISA STRING
+        ELSE SAY illegal_parameter_string OF my_game.
+      AND act ISA ACTOR
+        ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter_talk_sg OF my_game.
+        ELSE SAY illegal_parameter_talk_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY ACTOR
-	VERB say_to
-    		WHEN act
-			CHECK my_game CAN say_to
-				ELSE SAY restricted_response OF my_game.
-			AND act <> hero
-				ELSE SAY check_obj2_not_hero1 OF my_game.
-      		AND act CAN talk
-				ELSE 
-					IF act IS NOT plural
-						THEN SAY check_act_can_talk_sg OF my_game.
-						ELSE SAY check_act_can_talk_pl OF my_game.
-					END IF.
-			AND act IS NOT distant
-				ELSE 
-					IF act IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game. 
-					END IF.	
-      		DOES
-				SAY THE act. 
-				IF act IS NOT plural
-					THEN "doesn't look"
-					ELSE "don't look"
-				END IF.
-				"interested."
-	END VERB.
+  VERB say_to
+        WHEN act
+      CHECK my_game CAN say_to
+        ELSE SAY restricted_response OF my_game.
+      AND act <> hero
+        ELSE SAY check_obj2_not_hero1 OF my_game.
+          AND act CAN talk
+        ELSE
+          IF act IS NOT plural
+            THEN SAY check_act_can_talk_sg OF my_game.
+            ELSE SAY check_act_can_talk_pl OF my_game.
+          END IF.
+      AND act IS NOT distant
+        ELSE
+          IF act IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+          DOES
+        SAY THE act.
+        IF act IS NOT plural
+          THEN "doesn't look"
+          ELSE "don't look"
+        END IF.
+        "interested."
+  END VERB.
 END ADD TO.
 
 
@@ -5908,13 +5908,13 @@ SYNTAX 'score' = 'score'.
 
 
 VERB 'score'
-	CHECK my_game CAN 'score'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		SCORE.
-		-- (or, if you wish to disable the score, use the following kind of 
-			-- line instead of the above:
-		-- "There is no score in this game.")
+  CHECK my_game CAN 'score'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    SCORE.
+    -- (or, if you wish to disable the score, use the following kind of
+      -- line instead of the above:
+    -- "There is no score in this game.")
 END VERB 'score'.
 
 
@@ -5929,48 +5929,48 @@ END VERB 'score'.
 
 
 SYNTAX scratch = scratch (obj)
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB scratch
-		CHECK my_game CAN scratch
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero3 OF my_game.
-		AND obj IS inanimate
-			ELSE SAY check_obj_inanimate1 OF my_game.		
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-			"Nothing would be achieved by that."
-  	END VERB.
+  VERB scratch
+    CHECK my_game CAN scratch
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero3 OF my_game.
+    AND obj IS inanimate
+      ELSE SAY check_obj_inanimate1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "Nothing would be achieved by that."
+    END VERB.
 END ADD TO.
 
 
@@ -5986,33 +5986,33 @@ END ADD TO.
 
 
 SYNTAX 'script' = 'script'.
-	 script_on = 'script' 'on'.
-	 script_off = 'script' 'off'.
+   script_on = 'script' 'on'.
+   script_off = 'script' 'off'.
 
 SYNONYMS 'transcript' = 'script'.
 
-VERB 'script' 
-	CHECK my_game CAN 'script'
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		"You can turn transcripting on and off using the 'script on/off' command within the game. 
-		The transcript will be available in a file with a name starting with the game name.
-		$pIn a GUI version you can also find this in the drop-down menu in the interpreter. 
-		$pIn a command line version you can start your game with the '-s' switch to get a transcript 
-		of the whole game."
+VERB 'script'
+  CHECK my_game CAN 'script'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "You can turn transcripting on and off using the 'script on/off' command within the game.
+    The transcript will be available in a file with a name starting with the game name.
+    $pIn a GUI version you can also find this in the drop-down menu in the interpreter.
+    $pIn a command line version you can start your game with the '-s' switch to get a transcript
+    of the whole game."
 END VERB.
 
 VERB script_on
-	CHECK my_game CAN script_on
-		ELSE SAY restricted_response OF my_game.
+  CHECK my_game CAN script_on
+    ELSE SAY restricted_response OF my_game.
     DOES
         TRANSCRIPT ON.
         "Transcripting turned on."
 END VERB.
 
 VERB script_off
-	CHECK my_game CAN script_off
-		ELSE SAY restricted_response OF my_game.
+  CHECK my_game CAN script_off
+    ELSE SAY restricted_response OF my_game.
     DOES
         TRANSCRIPT OFF.
         "Transcripting turned off."
@@ -6029,43 +6029,43 @@ END VERB.
 -- ==============================================================
 
 
-SYNTAX search = search (obj) 
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+SYNTAX search = search (obj)
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB search
-		CHECK my_game CAN search
-			ELSE SAY restricted_response OF my_game.
-		AND obj <> hero
-			ELSE LIST hero.
-		AND obj IS inanimate
-			ELSE SAY check_obj_inanimate1 OF my_game.
-		AND CURRENT LOCATION IS lit			
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES 
-			"You find nothing of interest."
-  	END VERB.
+  VERB search
+    CHECK my_game CAN search
+      ELSE SAY restricted_response OF my_game.
+    AND obj <> hero
+      ELSE LIST hero.
+    AND obj IS inanimate
+      ELSE SAY check_obj_inanimate1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "You find nothing of interest."
+    END VERB.
 END ADD TO.
 
 
@@ -6080,29 +6080,29 @@ END ADD TO.
 
 
 SYNTAX sell = sell (item)
-	WHERE item ISA OBJECT
-		ELSE 
-			IF item IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE item ISA OBJECT
+    ELSE
+      IF item IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-  	VERB sell
-		CHECK my_game CAN sell
-			ELSE SAY restricted_response OF my_game.
-		AND item IS examinable
-			ELSE 
-				IF item IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit			
-			ELSE SAY check_current_loc_lit OF my_game.
-		DOES
-			"There's nobody here who would be interested in buying" SAY THE item. "."
-  	END VERB.
+    VERB sell
+    CHECK my_game CAN sell
+      ELSE SAY restricted_response OF my_game.
+    AND item IS examinable
+      ELSE
+        IF item IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "There's nobody here who would be interested in buying" SAY THE item. "."
+    END VERB.
 END ADD TO.
 
 -- Depending on the situation, it might be good to add a check whether the item is carried
@@ -6120,50 +6120,50 @@ END ADD TO.
 
 
 SYNTAX shake = shake (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-			
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
 
 
 ADD TO EVERY OBJECT
-	VERB shake
-		CHECK my_game CAN shake
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj IS movable
-			ELSE SAY check_obj_movable OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			IF obj IN hero
-				THEN "You shake" SAY THE obj. "cautiously in your hands. Nothing happens."
-				ELSE "There is no reason to start shaking" SAY THE obj. "."
-			END IF.
-	END VERB.
+  VERB shake
+    CHECK my_game CAN shake
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj IS movable
+      ELSE SAY check_obj_movable OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF obj IN hero
+        THEN "You shake" SAY THE obj. "cautiously in your hands. Nothing happens."
+        ELSE "There is no reason to start shaking" SAY THE obj. "."
+      END IF.
+  END VERB.
 END ADD TO.
 
 
@@ -6171,7 +6171,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ SHOOT 
+----- SHOOT
 
 
 -- ==============================================================
@@ -6179,46 +6179,46 @@ END ADD TO.
 
 
 SYNTAX shoot = shoot (target)
-    	WHERE target ISA THING
-      	ELSE 
-			IF target IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	
+      WHERE target ISA THING
+        ELSE
+      IF target IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
        shoot = shoot 'at' (target).
 
 
 ADD TO EVERY THING
-  	VERB shoot
-		CHECK my_game CAN shoot
-			ELSE SAY restricted_response OF my_game.
-		AND target IS examinable
-			ELSE
-				IF target IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND target <> hero 
-			ELSE SAY check_obj_not_hero2 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND target NOT IN hero
-			ELSE SAY check_obj_not_in_hero1 OF my_game.
-		AND target NOT IN worn
-			ELSE SAY check_obj_not_in_worn2 OF my_game.
-		AND target IS NOT distant
-			ELSE
-				IF target IS NOT plural
-					THEN SAY check_obj_not_distant_sg OF my_game. 
-					ELSE SAY check_obj_not_distant_pl OF my_game. 
-				END IF.
-		DOES 
-			IF target ISA ACTOR
-				THEN "That's quite uncalled-for."
-           		ELSE "That wouldn't accomplish anything."
-			END IF.
-  	END VERB.
+    VERB shoot
+    CHECK my_game CAN shoot
+      ELSE SAY restricted_response OF my_game.
+    AND target IS examinable
+      ELSE
+        IF target IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND target <> hero
+      ELSE SAY check_obj_not_hero2 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND target NOT IN hero
+      ELSE SAY check_obj_not_in_hero1 OF my_game.
+    AND target NOT IN worn
+      ELSE SAY check_obj_not_in_worn2 OF my_game.
+    AND target IS NOT distant
+      ELSE
+        IF target IS NOT plural
+          THEN SAY check_obj_not_distant_sg OF my_game.
+          ELSE SAY check_obj_not_distant_pl OF my_game.
+        END IF.
+    DOES
+      IF target ISA ACTOR
+        THEN "That's quite uncalled-for."
+              ELSE "That wouldn't accomplish anything."
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -6232,12 +6232,12 @@ SYNTAX shoot_error = shoot.
 
 
 VERB shoot_error
-	DOES 
-		"You must state what you want to shoot, for example SHOOT BEAR WITH RIFLE."
+  DOES
+    "You must state what you want to shoot, for example SHOOT BEAR WITH RIFLE."
 END VERB.
 
 
-	
+
 -- ==============================================================
 
 
@@ -6248,56 +6248,56 @@ END VERB.
 
 
 SYNTAX shoot_with = shoot (target) 'with' (weapon)
-    		WHERE target ISA THING
-      		ELSE 
-				IF target IS NOT plural
-					THEN SAY illegal_parameter_sg OF my_game. 
-					ELSE SAY illegal_parameter_pl OF my_game. 
-				END IF.
-    		AND weapon ISA WEAPON
-      		ELSE 
-				IF weapon IS NOT plural
-					THEN SAY illegal_parameter2_with_sg OF my_game. 
-					ELSE SAY illegal_parameter2_with_pl OF my_game. 
-				END IF.
+        WHERE target ISA THING
+          ELSE
+        IF target IS NOT plural
+          THEN SAY illegal_parameter_sg OF my_game.
+          ELSE SAY illegal_parameter_pl OF my_game.
+        END IF.
+        AND weapon ISA WEAPON
+          ELSE
+        IF weapon IS NOT plural
+          THEN SAY illegal_parameter2_with_sg OF my_game.
+          ELSE SAY illegal_parameter2_with_pl OF my_game.
+        END IF.
 
-	 shoot_with = shoot (weapon) 'at' (target).
-		-- to allow player input such as 'shoot rifle at bear'
+   shoot_with = shoot (weapon) 'at' (target).
+    -- to allow player input such as 'shoot rifle at bear'
 
 
 ADD TO EVERY THING
-  	VERB shoot_with
-    		WHEN target
-			CHECK my_game CAN shoot_with
-				ELSE SAY restricted_response OF my_game.
-			AND target IS examinable
-				ELSE 
-					IF target IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND target <> hero 
-				ELSE SAY check_obj_not_hero2 OF my_game.
-			AND target <> weapon
-				ELSE SAY check_obj_not_obj2_with OF my_game. 
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND target NOT IN hero
-				ELSE SAY check_obj_not_in_hero1 OF my_game.
-			AND target NOT IN worn
-				ELSE SAY check_obj_not_in_worn2 OF my_game.
-			AND target IS NOT distant
-				ELSE
-					IF target IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game. 
-					END IF.
-      		DOES
-				IF target ISA ACTOR
-					THEN "That's quite uncalled-for."
-           			ELSE "That wouldn't accomplish anything."
-				END IF.
-  	END VERB.
+    VERB shoot_with
+        WHEN target
+      CHECK my_game CAN shoot_with
+        ELSE SAY restricted_response OF my_game.
+      AND target IS examinable
+        ELSE
+          IF target IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND target <> hero
+        ELSE SAY check_obj_not_hero2 OF my_game.
+      AND target <> weapon
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND target NOT IN hero
+        ELSE SAY check_obj_not_in_hero1 OF my_game.
+      AND target NOT IN worn
+        ELSE SAY check_obj_not_in_worn2 OF my_game.
+      AND target IS NOT distant
+        ELSE
+          IF target IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+          DOES
+        IF target ISA ACTOR
+          THEN "That's quite uncalled-for."
+                ELSE "That wouldn't accomplish anything."
+        END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -6315,10 +6315,10 @@ SYNTAX shout = shout.
 
 
 VERB shout
-	CHECK my_game CAN shout
-		ELSE SAY restricted_response OF my_game.
-  	DOES
-    		"Nothing results from your $ving."
+  CHECK my_game CAN shout
+    ELSE SAY restricted_response OF my_game.
+    DOES
+        "Nothing results from your $ving."
 END VERB.
 
 
@@ -6336,47 +6336,47 @@ SYNONYMS scream, yell = shout.
 
 
 SYNTAX 'show' = 'show' (obj) 'to' (act)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND act ISA ACTOR
-		ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter2_to_sg OF my_game. 
-				ELSE SAY illegal_parameter2_to_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND act ISA ACTOR
+    ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter2_to_sg OF my_game.
+        ELSE SAY illegal_parameter2_to_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB 'show'
-		WHEN obj
-			CHECK my_game CAN 'show'
-				ELSE SAY restricted_response OF my_game.
-			AND act <> hero 
-				ELSE SAY check_obj2_not_hero1 OF my_game.
-			AND obj IN hero
-				ELSE SAY check_obj_in_hero OF my_game.
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND act IS NOT distant
-				ELSE 
-					IF act IS NOT plural
-						THEN SAY check_obj2_not_distant_sg OF my_game.
-						ELSE SAY check_obj2_not_distant_pl OF my_game.
-					END IF.
-			DOES 
-				SAY THE act. 
-			
-				IF act IS NOT plural
-					THEN "is"
-					ELSE "are"
-				END IF.
+  VERB 'show'
+    WHEN obj
+      CHECK my_game CAN 'show'
+        ELSE SAY restricted_response OF my_game.
+      AND act <> hero
+        ELSE SAY check_obj2_not_hero1 OF my_game.
+      AND obj IN hero
+        ELSE SAY check_obj_in_hero OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND act IS NOT distant
+        ELSE
+          IF act IS NOT plural
+            THEN SAY check_obj2_not_distant_sg OF my_game.
+            ELSE SAY check_obj2_not_distant_pl OF my_game.
+          END IF.
+      DOES
+        SAY THE act.
 
-				"not especially interested."
-  	END VERB.
+        IF act IS NOT plural
+          THEN "is"
+          ELSE "are"
+        END IF.
+
+        "not especially interested."
+    END VERB.
 END ADD TO.
 
 
@@ -6397,10 +6397,10 @@ SYNTAX sing = sing.
 
 
 VERB sing
-	CHECK my_game CAN sing
-		ELSE SAY restricted_response OF my_game.
-  	DOES
-    		"You $v a little tune."
+  CHECK my_game CAN sing
+    ELSE SAY restricted_response OF my_game.
+    DOES
+        "You $v a little tune."
 END VERB.
 
 
@@ -6411,77 +6411,77 @@ SYNONYMS hum, whistle = sing.
 -- ==============================================================
 
 
------ SIP 
-	
+----- SIP
+
 
 -- ==============================================================
 
 
 SYNTAX sip = sip (liq)
-	WHERE liq ISA LIQUID
-		ELSE 
-			IF liq IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE liq ISA LIQUID
+    ELSE
+      IF liq IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY LIQUID
-  	VERB sip
-		CHECK my_game CAN sip
-			ELSE SAY restricted_response OF my_game.
-		AND liq IS drinkable
-			ELSE 
-				IF liq IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND liq IS reachable AND liq IS NOT distant
-			ELSE
-				IF liq IS NOT reachable
-					THEN  
-						IF liq IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF liq IS distant
-					THEN
-						IF liq IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES	
-			IF vessel OF liq = null_vessel		
-				-- here, if the liquid is in no container, for example
-				-- the hero takes a sip of water from a river,
-				-- the action is allowed to succeed.
-				THEN "You take a sip of" SAY THE liq. "."
-				ELSE 
-					-- implicit taking:
-					IF vessel OF liq NOT DIRECTLY IN hero
-						THEN 
-							IF vessel OF liq IS NOT takeable
-								THEN "You can't carry" SAY THE liq. "around in your bare hands."
-									-- the action stops here if the container is not takeable.
-								ELSE LOCATE vessel OF liq IN hero.
-								"(taking" SAY THE vessel OF liq. "first)$n"
-							END IF.
-					END IF.
-					-- end of implicit taking.
-			END IF.		
+    VERB sip
+    CHECK my_game CAN sip
+      ELSE SAY restricted_response OF my_game.
+    AND liq IS drinkable
+      ELSE
+        IF liq IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND liq IS reachable AND liq IS NOT distant
+      ELSE
+        IF liq IS NOT reachable
+          THEN
+            IF liq IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF liq IS distant
+          THEN
+            IF liq IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF vessel OF liq = null_vessel
+        -- here, if the liquid is in no container, for example
+        -- the hero takes a sip of water from a river,
+        -- the action is allowed to succeed.
+        THEN "You take a sip of" SAY THE liq. "."
+        ELSE
+          -- implicit taking:
+          IF vessel OF liq NOT DIRECTLY IN hero
+            THEN
+              IF vessel OF liq IS NOT takeable
+                THEN "You can't carry" SAY THE liq. "around in your bare hands."
+                  -- the action stops here if the container is not takeable.
+                ELSE LOCATE vessel OF liq IN hero.
+                "(taking" SAY THE vessel OF liq. "first)$n"
+              END IF.
+          END IF.
+          -- end of implicit taking.
+      END IF.
 
-			IF liq IN hero		-- i.e. if the implicit taking was successful
-		 		THEN 
-					IF vessel OF liq IS NOT open
-						THEN "You can't, since" SAY THE vessel OF liq. "is closed."
-						ELSE "You take a sip of" SAY THE liq. "."
-					END IF.
-			END IF.
-			
-  	END VERB.
+      IF liq IN hero    -- i.e. if the implicit taking was successful
+        THEN
+          IF vessel OF liq IS NOT open
+            THEN "You can't, since" SAY THE vessel OF liq. "is closed."
+            ELSE "You take a sip of" SAY THE liq. "."
+          END IF.
+      END IF.
+
+    END VERB.
 END ADD TO.
 
 
@@ -6498,31 +6498,31 @@ END ADD TO.
 
 
 SYNTAX sit = sit.
-	 
+
        sit = sit 'down'.
 
 
-VERB sit 
-	CHECK my_game CAN sit
-		ELSE SAY restricted_response OF my_game.
-	AND hero IS NOT sitting
-		ELSE SAY check_hero_not_sitting4 OF my_game.
-	DOES 
-		"You feel no urge to sit down at present."
-		-- (or, if you wish to make it work, use the following instead of the above:
-		-- IF hero IS lying_down
-		--	THEN "You sit up."
-		--		MAKE hero NOT lying_down.
-		-- 	ELSE "You sit down."
-		-- END IF.
-		-- MAKE hero sitting.
+VERB sit
+  CHECK my_game CAN sit
+    ELSE SAY restricted_response OF my_game.
+  AND hero IS NOT sitting
+    ELSE SAY check_hero_not_sitting4 OF my_game.
+  DOES
+    "You feel no urge to sit down at present."
+    -- (or, if you wish to make it work, use the following instead of the above:
+    -- IF hero IS lying_down
+    --  THEN "You sit up."
+    --    MAKE hero NOT lying_down.
+    --  ELSE "You sit down."
+    -- END IF.
+    -- MAKE hero sitting.
 END VERB.
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
--- perform certain actions, as numerous verbs in the library have checks for this. 
+-- perform certain actions, as numerous verbs in the library have checks for this.
 -- For example, if the hero is sitting and the player types 'attack [something]',
 -- the response will be "It will be difficult to attack anything while
--- sitting down." 
+-- sitting down."
 
 -- Also, it is often essential to make certain objects NOT reachable when
 -- sitting or lying down.
@@ -6539,56 +6539,56 @@ END VERB.
 
 
 SYNTAX sit_on = sit 'on' (surface)
-	WHERE surface ISA SUPPORTER
-		ELSE 
-			IF surface IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
+  WHERE surface ISA SUPPORTER
+    ELSE
+      IF surface IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY SUPPORTER
-  	VERB sit_on
-		CHECK my_game CAN sit_on
-			ELSE SAY restricted_response OF my_game.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting4 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND surface IS reachable AND surface IS NOT distant
-			ELSE
-				IF surface IS NOT reachable
-					THEN  
-						IF surface IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF surface IS distant
-					THEN
-						IF surface IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"You feel no urge to sit down at present."
+    VERB sit_on
+    CHECK my_game CAN sit_on
+      ELSE SAY restricted_response OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting4 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND surface IS reachable AND surface IS NOT distant
+      ELSE
+        IF surface IS NOT reachable
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF surface IS distant
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "You feel no urge to sit down at present."
 
-			-- (or, to make it work, use the following instead of the above:)
-			-- IF hero lying_down 
-			-- 	THEN "You get up and sit down on" SAY THE surface. "."
-			--		MAKE hero NOT lying_down.
-			--	ELSE "You sit down on" SAY THE surface. "."
-			-- END IF.
-			-- MAKE hero sitting.
-  	END VERB.
+      -- (or, to make it work, use the following instead of the above:)
+      -- IF hero lying_down
+      --  THEN "You get up and sit down on" SAY THE surface. "."
+      --    MAKE hero NOT lying_down.
+      --  ELSE "You sit down on" SAY THE surface. "."
+      -- END IF.
+      -- MAKE hero sitting.
+    END VERB.
 END ADD TO.
 
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
--- perform certain actions, as numerous verbs in the library have checks for this. 
+-- perform certain actions, as numerous verbs in the library have checks for this.
 -- For example, if the hero is sitting and the player types 'attack [something]',
 -- the response will be "It will be difficult to attack anything while
--- sitting down." 
+-- sitting down."
 
 -- Also, it is often essential to make certain objects NOT reachable when
 -- sitting or lying down.
@@ -6598,7 +6598,7 @@ END ADD TO.
 -- ==============================================================
 
 
------ SLEEP	(+ rest)
+----- SLEEP (+ rest)
 
 
 -- ==============================================================
@@ -6608,10 +6608,10 @@ SYNTAX sleep = sleep.
 
 
 VERB sleep
-	CHECK my_game CAN sleep
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		"There's no need to $v right now."
+  CHECK my_game CAN sleep
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "There's no need to $v right now."
 END VERB.
 
 
@@ -6632,10 +6632,10 @@ SYNTAX smell0 = smell.
 
 
 VERB smell0
-	CHECK my_game CAN smell0
-		ELSE SAY restricted_response OF my_game.
+  CHECK my_game CAN smell0
+    ELSE SAY restricted_response OF my_game.
      DOES
-		"You smell nothing unusual."
+    "You smell nothing unusual."
 END VERB.
 
 
@@ -6650,21 +6650,21 @@ END VERB.
 
 
 SYNTAX smell = smell (odour)
-	WHERE odour ISA THING
-	  	ELSE 
-			IF odour IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE odour ISA THING
+      ELSE
+      IF odour IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-  	VERB smell
-		CHECK my_game CAN smell
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-	    		"You smell nothing unusual."	
-  	END VERB.
+    VERB smell
+    CHECK my_game CAN smell
+      ELSE SAY restricted_response OF my_game.
+    DOES
+          "You smell nothing unusual."
+    END VERB.
 END ADD TO.
 
 
@@ -6679,44 +6679,44 @@ END ADD TO.
 
 
 SYNTAX squeeze = squeeze (obj)
-	WHERE obj ISA OBJECT
-	   	ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-   	VERB squeeze
-		CHECK my_game CAN squeeze
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.	
-		DOES
-	    		"Trying to squeeze" SAY THE obj. "wouldn't accomplish anything."		
-	END VERB.
+    VERB squeeze
+    CHECK my_game CAN squeeze
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+          "Trying to squeeze" SAY THE obj. "wouldn't accomplish anything."
+  END VERB.
 END ADD TO.
 
 
@@ -6732,19 +6732,19 @@ END ADD TO.
 
 SYNTAX stand = stand.
 
-	 stand = stand 'up'.
+   stand = stand 'up'.
 
 
-VERB stand 
-	CHECK my_game CAN stand
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		IF hero IS sitting OR hero IS lying_down
-			THEN "You get up."
-				MAKE hero NOT sitting.
-				MAKE hero NOT lying_down.
-			ELSE "You're standing up already."
-		END IF.
+VERB stand
+  CHECK my_game CAN stand
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    IF hero IS sitting OR hero IS lying_down
+      THEN "You get up."
+        MAKE hero NOT sitting.
+        MAKE hero NOT lying_down.
+      ELSE "You're standing up already."
+    END IF.
 END VERB.
 
 
@@ -6759,45 +6759,45 @@ END VERB.
 
 
 SYNTAX stand_on = stand 'on' (surface)
-	WHERE surface ISA SUPPORTER
-		ELSE 
-			IF surface IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
-	stand_on = get 'on' (surface).  
+  WHERE surface ISA SUPPORTER
+    ELSE
+      IF surface IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
+  stand_on = get 'on' (surface).
 
 
 ADD TO EVERY SUPPORTER
-	VERB stand_on
-		CHECK my_game CAN stand_on
-			ELSE SAY restricted_response OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND surface IS reachable AND surface IS NOT distant
-			ELSE
-				IF surface IS NOT reachable
-					THEN  
-						IF surface IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF surface IS distant
-					THEN
-						IF surface IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"You feel no urge to stand on" SAY THE surface. "."
-			-- or, to make it work, use the following instead of the above:
-			-- "You get on" SAY THE surface. "."
-			-- (Make an attribute for the hero to check that he's on the surface.
-			-- It is not possible to actually locate him on the surface (unless
-			-- you implement a nested location.)	
-			-- MAKE hero NOT sitting. MAKE hero NOT lying_down.
-	END VERB.
+  VERB stand_on
+    CHECK my_game CAN stand_on
+      ELSE SAY restricted_response OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND surface IS reachable AND surface IS NOT distant
+      ELSE
+        IF surface IS NOT reachable
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF surface IS distant
+          THEN
+            IF surface IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "You feel no urge to stand on" SAY THE surface. "."
+      -- or, to make it work, use the following instead of the above:
+      -- "You get on" SAY THE surface. "."
+      -- (Make an attribute for the hero to check that he's on the surface.
+      -- It is not possible to actually locate him on the surface (unless
+      -- you implement a nested location.)
+      -- MAKE hero NOT sitting. MAKE hero NOT lying_down.
+  END VERB.
 END ADD TO.
 
 
@@ -6814,17 +6814,17 @@ END ADD TO.
 SYNTAX swim = swim.
 
 
-VERB swim 
-	CHECK my_game CAN swim
-		ELSE SAY restricted_response OF my_game.
-	AND hero IS NOT sitting
-		ELSE SAY check_hero_not_sitting1 OF my_game.
-	AND hero IS NOT lying_down
-		ELSE SAY check_hero_not_lying_down1 OF my_game.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	DOES 
-		"There is no water suitable for swimming here."
+VERB swim
+  CHECK my_game CAN swim
+    ELSE SAY restricted_response OF my_game.
+  AND hero IS NOT sitting
+    ELSE SAY check_hero_not_sitting1 OF my_game.
+  AND hero IS NOT lying_down
+    ELSE SAY check_hero_not_lying_down1 OF my_game.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  DOES
+    "There is no water suitable for swimming here."
 END VERB.
 
 
@@ -6839,47 +6839,47 @@ END VERB.
 
 
 SYNTAX swim_in = swim 'in' (liq)
-	WHERE liq ISA LIQUID
-		ELSE 
-			IF liq IS NOT plural
-				THEN SAY illegal_parameter_in_sg OF my_game. 
-				ELSE SAY illegal_parameter_in_pl OF my_game. 
-			END IF.
+  WHERE liq ISA LIQUID
+    ELSE
+      IF liq IS NOT plural
+        THEN SAY illegal_parameter_in_sg OF my_game.
+        ELSE SAY illegal_parameter_in_pl OF my_game.
+      END IF.
 
 
 
 ADD TO EVERY OBJECT
-	VERB swim_in
-		CHECK my_game CAN swim_in
-			ELSE SAY restricted_response OF my_game.
-		AND hero IS NOT sitting
-			ELSE SAY check_hero_not_sitting3 OF my_game.
-		AND hero IS NOT lying_down
-			ELSE SAY check_hero_not_lying_down3 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND liq IS reachable AND liq IS NOT distant
-			ELSE
-				IF liq IS NOT reachable
-					THEN  
-						IF liq IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF liq IS distant
-					THEN
-						IF liq IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			IF liq IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
+  VERB swim_in
+    CHECK my_game CAN swim_in
+      ELSE SAY restricted_response OF my_game.
+    AND hero IS NOT sitting
+      ELSE SAY check_hero_not_sitting3 OF my_game.
+    AND hero IS NOT lying_down
+      ELSE SAY check_hero_not_lying_down3 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND liq IS reachable AND liq IS NOT distant
+      ELSE
+        IF liq IS NOT reachable
+          THEN
+            IF liq IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF liq IS distant
+          THEN
+            IF liq IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      IF liq IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
 
-			"something you can swim in."
+      "something you can swim in."
 END VERB.
 END ADD TO.
 
@@ -6888,42 +6888,42 @@ END ADD TO.
 -- ==============================================================
 
 
------ SWITCH 
+----- SWITCH
 
 
 -- ==============================================================
 
 
--- This is a mere 'switch' verb with no 'on' or 'off' following after it. 
+-- This is a mere 'switch' verb with no 'on' or 'off' following after it.
 -- This verb is defined further in 'classes.i', under 'device' and 'lightsource'.
 -- This verb exists just to cover cases where the player forgets to write
--- 'on' or 'off' after 'switch'. 
--- If the player types 'switch tv', the tv object will be switched on 
+-- 'on' or 'off' after 'switch'.
+-- If the player types 'switch tv', the tv object will be switched on
 -- if it is off, and vice cersa.
 -- Below, just the basic syntax is declared.
 
 
 
-SYNTAX switch = switch (app)			-- app = apparatus, appliance
-	WHERE app ISA OBJECT 
-		ELSE 
-			IF app IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-   
-     
+SYNTAX switch = switch (app)      -- app = apparatus, appliance
+  WHERE app ISA OBJECT
+    ELSE
+      IF app IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
+
 ADD TO EVERY OBJECT
-	VERB switch
-		CHECK my_game CAN switch
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-			IF app IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"not something you can switch."
-	END VERB.
+  VERB switch
+    CHECK my_game CAN switch
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      IF app IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "not something you can switch."
+  END VERB.
 END ADD TO.
 
 
@@ -6936,7 +6936,7 @@ END ADD TO.
 
 -- ==============================================================
 
-	
+
 ----- The syntax for 'switch on' has been declared in the 'turn_on' verb.
 
 
@@ -6959,102 +6959,102 @@ END ADD TO.
 -- ==============================================================
 
 
------ TAKE	(+ carry, get, grab, hold, obtain, pick up)
+----- TAKE  (+ carry, get, grab, hold, obtain, pick up)
 
 
 -- ==============================================================
 
 
 SYNTAX take = take (obj)
-    	WHERE obj ISA THING		
-     		ELSE  
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+      WHERE obj ISA THING
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
-	take = get (obj).
+  take = get (obj).
 
-  	take = pick up (obj).
+    take = pick up (obj).
 
-  	take = pick (obj) up.
+    take = pick (obj) up.
 
 
 ADD TO EVERY THING
-	VERB take
-		CHECK my_game CAN take
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj <> hero
-			ELSE SAY check_obj_not_hero1 OF my_game.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS NOT scenery
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_obj_not_scenery_sg OF my_game.
-					ELSE SAY check_obj_not_scenery_pl OF my_game.
-				END IF.
-		AND obj IS movable
-			ELSE SAY check_obj_movable OF my_game.
-    		AND obj IS takeable
-      		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj NOT DIRECTLY IN hero			
-			-- i.e. the object to be taken is not carried by the hero already						
-			ELSE SAY check_obj_not_in_hero2 OF my_game.					
-    		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-    		AND weight Of obj < 50					
-      		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_weight_sg OF my_game. 
-					ELSE SAY check_obj_weight_pl OF my_game. 
-				END IF. 
-    		DOES
-			IF obj ISA ACTOR
-				THEN SAY THE obj. "would probably object to that."
-			-- actors are not prohibited from being taken in the checks; this is to
-			-- allow for example a dog to be picked up, or a bird to be taken out of
-			-- a cage, etc.
-			
+  VERB take
+    CHECK my_game CAN take
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj <> hero
+      ELSE SAY check_obj_not_hero1 OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS NOT scenery
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_obj_not_scenery_sg OF my_game.
+          ELSE SAY check_obj_not_scenery_pl OF my_game.
+        END IF.
+    AND obj IS movable
+      ELSE SAY check_obj_movable OF my_game.
+        AND obj IS takeable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj NOT DIRECTLY IN hero
+      -- i.e. the object to be taken is not carried by the hero already
+      ELSE SAY check_obj_not_in_hero2 OF my_game.
+        AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+        AND weight Of obj < 50
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_weight_sg OF my_game.
+          ELSE SAY check_obj_weight_pl OF my_game.
+        END IF.
+        DOES
+      IF obj ISA ACTOR
+        THEN SAY THE obj. "would probably object to that."
+      -- actors are not prohibited from being taken in the checks; this is to
+      -- allow for example a dog to be picked up, or a bird to be taken out of
+      -- a cage, etc.
 
-			ELSIF obj ISA OBJECT
-				THEN IF obj DIRECTLY IN worn
-						THEN LOCATE obj IN hero.
-							"You take off" SAY THE obj. "and carry it in your hands."
-							IF obj ISA CLOTHING
-								THEN EXCLUDE obj FROM wearing OF hero.
-							END IF.
-						ELSE LOCATE obj IN hero.
-							"Taken."
-					END IF.
-			END IF.
 
-				-- Objects held by NPCs cannot be taken by the hero by default.
-				-- The hero must *ask for* the object to obtain it.
-							
+      ELSIF obj ISA OBJECT
+        THEN IF obj DIRECTLY IN worn
+            THEN LOCATE obj IN hero.
+              "You take off" SAY THE obj. "and carry it in your hands."
+              IF obj ISA CLOTHING
+                THEN EXCLUDE obj FROM wearing OF hero.
+              END IF.
+            ELSE LOCATE obj IN hero.
+              "Taken."
+          END IF.
+      END IF.
+
+        -- Objects held by NPCs cannot be taken by the hero by default.
+        -- The hero must *ask for* the object to obtain it.
+
   END VERB.
 END ADD TO.
 
@@ -7074,134 +7074,134 @@ SYNONYMS
 
 
 SYNTAX take_from = 'take' (obj) 'from' (holder)
-    	WHERE obj ISA THING
-     		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game.
-				ELSE SAY illegal_parameter_pl OF my_game.
-			END IF.
-    	AND holder ISA THING
-     		ELSE 
-			IF holder IS NOT plural
-				THEN SAY illegal_parameter2_from_sg OF my_game.
-				ELSE SAY illegal_parameter2_from_pl OF my_game.
-			END IF.
-    	AND holder ISA CONTAINER
-     		ELSE 
-			IF holder IS NOT plural
-				THEN SAY illegal_parameter2_from_sg OF my_game.
-				ELSE SAY illegal_parameter2_from_pl OF my_game.
-			END IF.
+      WHERE obj ISA THING
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+      AND holder ISA THING
+        ELSE
+      IF holder IS NOT plural
+        THEN SAY illegal_parameter2_from_sg OF my_game.
+        ELSE SAY illegal_parameter2_from_pl OF my_game.
+      END IF.
+      AND holder ISA CONTAINER
+        ELSE
+      IF holder IS NOT plural
+        THEN SAY illegal_parameter2_from_sg OF my_game.
+        ELSE SAY illegal_parameter2_from_pl OF my_game.
+      END IF.
 
- 	take_from = remove (obj)* 'from' (holder).
- 
-	take_from = get (obj) 'from' (holder).
+  take_from = remove (obj)* 'from' (holder).
+
+  take_from = get (obj) 'from' (holder).
 
 
 ADD TO EVERY THING
-  	VERB take_from
-    		WHEN obj
-			CHECK my_game CAN take_from
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> hero
-				ELSE SAY check_obj_not_hero1 OF my_game.
-			AND holder <> hero
-				ELSE SAY check_obj2_not_hero1 OF my_game. 
-      		AND obj NOT DIRECTLY IN hero 		
-	  			ELSE	SAY check_obj_not_in_hero2 OF my_game.
-			AND obj <> holder
-				ELSE SAY check_obj_not_obj2_from OF my_game. 
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS NOT scenery
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_not_scenery_sg OF my_game.
-						ELSE SAY check_obj_not_scenery_pl OF my_game.
-					END IF.
-			AND holder IS NOT scenery
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_not_scenery_sg OF my_game.
-						ELSE SAY check_obj2_not_scenery_pl OF my_game.
-					END IF.
-			AND obj IS movable
-				ELSE SAY check_obj_movable OF my_game.
-			AND obj IS takeable
-      			ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND holder IS reachable AND holder IS NOT distant
-				ELSE
-					IF holder IS NOT reachable
-						THEN  
-							IF holder IS NOT plural
-								THEN SAY check_obj2_reachable_sg OF my_game.
-								ELSE SAY check_obj2_reachable_pl OF my_game.
-							END IF.
-					ELSIF holder IS distant
-						THEN
-							IF holder IS NOT plural
-								THEN SAY check_obj2_not_distant_sg OF my_game. 
-								ELSE SAY check_obj2_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND weight Of obj < 50
-      			ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_weight_sg OF my_game. 
-						ELSE SAY check_obj_weight_pl OF my_game. 
-					END IF.
-      		AND obj IN holder 
-				ELSE
-		 			IF holder IS inanimate
-						THEN
-							IF holder ISA SUPPORTER
-								THEN 
-									IF obj IS NOT plural
-										THEN SAY check_obj_on_surface_sg OF my_game.
-										ELSE SAY check_obj_on_surface_pl OF my_game.
-									END IF.
-								ELSE
-									IF obj IS NOT plural
-										THEN SAY check_obj_in_cont_sg OF my_game.
-										ELSE SAY check_obj_in_cont_pl OF my_game.
-									END IF.
-							END IF.
-						ELSE 
-							IF holder IS NOT plural
-								THEN SAY check_obj_in_act_sg OF my_game. 
-								ELSE SAY check_obj_in_act_pl OF my_game.
-							END IF.
-					END IF.	
-			DOES 
-				IF obj ISA ACTOR
-					THEN SAY THE obj. "would probably object to that."
-						-- actors are not prohibited from being taken in the checks; this is to
-						-- allow for example a dog to be picked up, or a bird to be taken out of
-						-- a cage, etc.
-				ELSIF obj ISA OBJECT
-					THEN 
-						IF holder ISA LISTED_CONTAINER AND holder IS NOT open
-							THEN "You can't;" SAY THE holder.
-									IF holder IS NOT plural
-										THEN "is"
-										ELSE "are"
-									END IF.
-								"closed."
-							ELSE
-								LOCATE obj IN hero.
-	    							"You take" SAY THE obj. "from" SAY THE holder. "."
-						END IF.
-				END IF.
-	
-					-- Objects held by NPCs cannot be taken by the hero by default.
-					-- The hero must *ask for* the object to obtain it.
-				
-					
-  	END VERB.
+    VERB take_from
+        WHEN obj
+      CHECK my_game CAN take_from
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> hero
+        ELSE SAY check_obj_not_hero1 OF my_game.
+      AND holder <> hero
+        ELSE SAY check_obj2_not_hero1 OF my_game.
+          AND obj NOT DIRECTLY IN hero
+          ELSE  SAY check_obj_not_in_hero2 OF my_game.
+      AND obj <> holder
+        ELSE SAY check_obj_not_obj2_from OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS NOT scenery
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_not_scenery_sg OF my_game.
+            ELSE SAY check_obj_not_scenery_pl OF my_game.
+          END IF.
+      AND holder IS NOT scenery
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_not_scenery_sg OF my_game.
+            ELSE SAY check_obj2_not_scenery_pl OF my_game.
+          END IF.
+      AND obj IS movable
+        ELSE SAY check_obj_movable OF my_game.
+      AND obj IS takeable
+            ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND holder IS reachable AND holder IS NOT distant
+        ELSE
+          IF holder IS NOT reachable
+            THEN
+              IF holder IS NOT plural
+                THEN SAY check_obj2_reachable_sg OF my_game.
+                ELSE SAY check_obj2_reachable_pl OF my_game.
+              END IF.
+          ELSIF holder IS distant
+            THEN
+              IF holder IS NOT plural
+                THEN SAY check_obj2_not_distant_sg OF my_game.
+                ELSE SAY check_obj2_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND weight Of obj < 50
+            ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_weight_sg OF my_game.
+            ELSE SAY check_obj_weight_pl OF my_game.
+          END IF.
+          AND obj IN holder
+        ELSE
+          IF holder IS inanimate
+            THEN
+              IF holder ISA SUPPORTER
+                THEN
+                  IF obj IS NOT plural
+                    THEN SAY check_obj_on_surface_sg OF my_game.
+                    ELSE SAY check_obj_on_surface_pl OF my_game.
+                  END IF.
+                ELSE
+                  IF obj IS NOT plural
+                    THEN SAY check_obj_in_cont_sg OF my_game.
+                    ELSE SAY check_obj_in_cont_pl OF my_game.
+                  END IF.
+              END IF.
+            ELSE
+              IF holder IS NOT plural
+                THEN SAY check_obj_in_act_sg OF my_game.
+                ELSE SAY check_obj_in_act_pl OF my_game.
+              END IF.
+          END IF.
+      DOES
+        IF obj ISA ACTOR
+          THEN SAY THE obj. "would probably object to that."
+            -- actors are not prohibited from being taken in the checks; this is to
+            -- allow for example a dog to be picked up, or a bird to be taken out of
+            -- a cage, etc.
+        ELSIF obj ISA OBJECT
+          THEN
+            IF holder ISA LISTED_CONTAINER AND holder IS NOT open
+              THEN "You can't;" SAY THE holder.
+                  IF holder IS NOT plural
+                    THEN "is"
+                    ELSE "are"
+                  END IF.
+                "closed."
+              ELSE
+                LOCATE obj IN hero.
+                    "You take" SAY THE obj. "from" SAY THE holder. "."
+            END IF.
+        END IF.
+
+          -- Objects held by NPCs cannot be taken by the hero by default.
+          -- The hero must *ask for* the object to obtain it.
+
+
+    END VERB.
 END ADD TO.
 
 
@@ -7219,11 +7219,11 @@ SYNTAX talk = talk.
 
 
 VERB talk
-	CHECK my_game CAN talk
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		"To talk to somebody, you can ASK PERSON ABOUT THING
-		or TELL PERSON ABOUT THING."
+  CHECK my_game CAN talk
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "To talk to somebody, you can ASK PERSON ABOUT THING
+    or TELL PERSON ABOUT THING."
 END VERB.
 
 
@@ -7237,23 +7237,23 @@ END VERB.
 -- ==============================================================
 
 
-SYNTAX talk_to = talk 'to' (act) 
-    	WHERE act ISA ACTOR
-     		ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter_to_sg OF my_game. 
-				ELSE SAY illegal_parameter_to_pl OF my_game. 
-			END IF.
-  
+SYNTAX talk_to = talk 'to' (act)
+      WHERE act ISA ACTOR
+        ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter_to_sg OF my_game.
+        ELSE SAY illegal_parameter_to_pl OF my_game.
+      END IF.
+
 
 ADD TO EVERY ACTOR
-  	VERB talk_to
-		CHECK my_game CAN talk_to
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-			"To talk to somebody, you can ASK PERSON ABOUT THING or
-			TELL PERSON ABOUT THING."
-  	END VERB.
+    VERB talk_to
+    CHECK my_game CAN talk_to
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      "To talk to somebody, you can ASK PERSON ABOUT THING or
+      TELL PERSON ABOUT THING."
+    END VERB.
 END ADD TO.
 
 
@@ -7261,58 +7261,58 @@ END ADD TO.
 -- ==============================================================
 
 
------ TASTE		(+ lick)
+----- TASTE   (+ lick)
 
 
 -- ==============================================================
 
 
 SYNTAX taste = taste (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB taste
-		CHECK my_game CAN taste
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj IS edible OR obj IS drinkable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"You taste nothing unexpected."
-	END VERB.
-END ADD TO. 	
+  VERB taste
+    CHECK my_game CAN taste
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj IS edible OR obj IS drinkable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "You taste nothing unexpected."
+  END VERB.
+END ADD TO.
 
 
 SYNONYMS lick = taste.
@@ -7322,51 +7322,51 @@ SYNONYMS lick = taste.
 -- ==============================================================
 
 
------ TEAR	(+ rip)
+----- TEAR  (+ rip)
 
 
 -- ==============================================================
 
 
 SYNTAX tear = tear (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB tear
-		CHECK my_game CAN tear
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES 
-			"Trying to $v" SAY THE obj. "would be futile."
-  	END VERB.
+  VERB tear
+    CHECK my_game CAN tear
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      "Trying to $v" SAY THE obj. "would be futile."
+    END VERB.
 END ADD TO.
 
 
@@ -7377,57 +7377,57 @@ SYNONYMS rip = tear.
 -- ==============================================================
 
 
------ TELL 	(+ enlighten, inform)
+----- TELL  (+ enlighten, inform)
 
 
 -- ==============================================================
 
 
 SYNTAX tell = tell (act) about (topic)!
-    	WHERE act ISA ACTOR
-		ELSE 
-			IF act IS NOT plural
-     				THEN SAY illegal_parameter_talk_sg OF my_game.
-				ELSE SAY illegal_parameter_talk_pl OF my_game.
-			END IF.
-    	AND topic ISA THING
-     		ELSE 
-			IF topic IS NOT plural
-				THEN SAY illegal_parameter_about_sg OF my_game. 
-				ELSE SAY illegal_parameter_about_pl OF my_game. 
-			END IF.
+      WHERE act ISA ACTOR
+    ELSE
+      IF act IS NOT plural
+            THEN SAY illegal_parameter_talk_sg OF my_game.
+        ELSE SAY illegal_parameter_talk_pl OF my_game.
+      END IF.
+      AND topic ISA THING
+        ELSE
+      IF topic IS NOT plural
+        THEN SAY illegal_parameter_about_sg OF my_game.
+        ELSE SAY illegal_parameter_about_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY ACTOR
-	VERB tell
-    		WHEN act
-			CHECK my_game CAN tell
-				ELSE SAY restricted_response OF my_game.
-			AND act <> hero
-				ELSE SAY check_obj_not_hero1 OF my_game.
-      		AND act CAN talk
-        			ELSE 
-					IF act IS NOT plural
-						THEN SAY check_act_can_talk_sg OF my_game.
-						ELSE SAY check_act_can_talk_pl OF my_game.
-					END IF.
-			AND act IS NOT distant
-				ELSE 
-					IF act IS NOT plural
-						THEN SAY check_obj_not_distant_sg OF my_game. 
-						ELSE SAY check_obj_not_distant_pl OF my_game. 
-					END IF.		  
-      		DOES
-				SAY THE act. 
+  VERB tell
+        WHEN act
+      CHECK my_game CAN tell
+        ELSE SAY restricted_response OF my_game.
+      AND act <> hero
+        ELSE SAY check_obj_not_hero1 OF my_game.
+          AND act CAN talk
+              ELSE
+          IF act IS NOT plural
+            THEN SAY check_act_can_talk_sg OF my_game.
+            ELSE SAY check_act_can_talk_pl OF my_game.
+          END IF.
+      AND act IS NOT distant
+        ELSE
+          IF act IS NOT plural
+            THEN SAY check_obj_not_distant_sg OF my_game.
+            ELSE SAY check_obj_not_distant_pl OF my_game.
+          END IF.
+          DOES
+        SAY THE act.
 
-				IF act IS NOT plural
-					THEN "doesn't"
-					ELSE "don't"
-				END IF.
+        IF act IS NOT plural
+          THEN "doesn't"
+          ELSE "don't"
+        END IF.
 
-				"look interested."
+        "look interested."
 
-	END VERB.
+  END VERB.
 END ADD TO.
 
 
@@ -7438,7 +7438,7 @@ SYNONYMS enlighten, inform = tell.
 -- ==============================================================
 
 
------ THINK		(+ ponder, meditate, reflect)
+----- THINK   (+ ponder, meditate, reflect)
 
 
 -- ==============================================================
@@ -7448,10 +7448,10 @@ SYNTAX think = think.
 
 
 VERB think
-	CHECK my_game CAN think
-		ELSE SAY restricted_response OF my_game. 
-	DOES 
-		"Nothing helpful comes to your mind."
+  CHECK my_game CAN think
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "Nothing helpful comes to your mind."
 END VERB.
 
 
@@ -7469,21 +7469,21 @@ SYNONYMS ponder, meditate, reflect = think.
 
 
 SYNTAX think_about = think 'about' (topic)!
-	WHERE topic ISA THING
-		ELSE 
-			IF topic IS NOT plural
-				THEN SAY illegal_parameter_about_sg OF my_game. 
-				ELSE SAY illegal_parameter_about_pl OF my_game. 
-			END IF.
+  WHERE topic ISA THING
+    ELSE
+      IF topic IS NOT plural
+        THEN SAY illegal_parameter_about_sg OF my_game.
+        ELSE SAY illegal_parameter_about_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB think_about
-		CHECK my_game CAN think_about
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-			"Nothing helpful comes to your mind."
-  	END VERB.
+  VERB think_about
+    CHECK my_game CAN think_about
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      "Nothing helpful comes to your mind."
+    END VERB.
 END ADD TO.
 
 
@@ -7491,72 +7491,72 @@ END ADD TO.
 -- ==============================================================
 
 
------ THROW   
+----- THROW
 
 
 -- ==============================================================
 
 
-SYNTAX throw = throw (projectile) 
-	WHERE projectile ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game.
-			
+SYNTAX throw = throw (projectile)
+  WHERE projectile ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-  	VERB throw
-		CHECK my_game CAN throw
-			ELSE SAY restricted_response OF my_game.
-		AND projectile IS examinable
-			ELSE 
-				IF projectile IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND projectile IS takeable
-			ELSE SAY check_obj_takeable OF my_game. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND projectile IS reachable AND projectile IS NOT distant
-			ELSE
-				IF projectile IS NOT reachable
-					THEN  
-						IF projectile IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF projectile IS distant
-					THEN
-						IF projectile IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		DOES
-			-- implicit taking:
-			IF projectile NOT DIRECTLY IN hero 
-				THEN LOCATE projectile IN hero.
-					SAY implicit_taking_message OF my_game.
-			END IF.
-			-- end of implicit taking.			
-				
-			"You can't throw very far;" SAY THE projectile. 
-			
-			IF projectile IS NOT plural
-				THEN "ends up"
-				ELSE "end up"
-			END IF.
-						
-			IF floor HERE
-				THEN "on the floor"
-			ELSIF ground HERE 
-				THEN "on the ground"
-			END IF.
-		
-			"nearby."
-	    		LOCATE projectile AT hero.
-			
-	END VERB.
+    VERB throw
+    CHECK my_game CAN throw
+      ELSE SAY restricted_response OF my_game.
+    AND projectile IS examinable
+      ELSE
+        IF projectile IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND projectile IS takeable
+      ELSE SAY check_obj_takeable OF my_game.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND projectile IS reachable AND projectile IS NOT distant
+      ELSE
+        IF projectile IS NOT reachable
+          THEN
+            IF projectile IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF projectile IS distant
+          THEN
+            IF projectile IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    DOES
+      -- implicit taking:
+      IF projectile NOT DIRECTLY IN hero
+        THEN LOCATE projectile IN hero.
+          SAY implicit_taking_message OF my_game.
+      END IF.
+      -- end of implicit taking.
+
+      "You can't throw very far;" SAY THE projectile.
+
+      IF projectile IS NOT plural
+        THEN "ends up"
+        ELSE "end up"
+      END IF.
+
+      IF floor HERE
+        THEN "on the floor"
+      ELSIF ground HERE
+        THEN "on the ground"
+      END IF.
+
+      "nearby."
+          LOCATE projectile AT hero.
+
+  END VERB.
 END ADD TO.
 
 
@@ -7565,113 +7565,113 @@ END ADD TO.
 -- ==============================================================
 
 
------ THROW AT 	
+----- THROW AT
 
 
 -- ==============================================================
 
 
 SYNTAX throw_at = throw (projectile) 'at' (target)
-	WHERE projectile ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game. 
-	AND target ISA THING
-	    	ELSE SAY illegal_parameter_at OF my_game.
-	
+  WHERE projectile ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+  AND target ISA THING
+        ELSE SAY illegal_parameter_at OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-	VERB throw_at
-    		WHEN projectile
-			CHECK my_game CAN throw_at
-				ELSE SAY restricted_response OF my_game.
-	    		AND projectile IS examinable
-				ELSE 
-					IF projectile IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-	    		AND projectile IS takeable
-		  		ELSE SAY check_obj_takeable OF my_game.
-	    		AND target IS examinable
-			  	ELSE SAY check_obj_suitable_at OF my_game.
-	    		AND projectile <> target
-				ELSE SAY check_obj_not_obj2_at OF my_game. 
-	    		AND target NOT IN hero
-	        		ELSE SAY check_obj2_not_in_hero1 OF my_game.
-	    		AND target <> hero
-		   		ELSE SAY check_obj2_not_hero1 OF my_game.
-	    		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-	    		AND projectile IS reachable AND projectile IS NOT distant
-				ELSE
-					IF projectile IS NOT reachable
-						THEN  
-							IF projectile IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF projectile IS distant
-						THEN
-							IF projectile IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND target IS NOT distant
-				-- it is possible to throw something at an (otherwise) not reachable target
-				ELSE
-					IF target IS NOT plural
-						THEN SAY check_obj2_not_distant_sg OF my_game. 
-						ELSE SAY check_obj2_not_distant_pl OF my_game. 
-					END IF.
-	    		DOES 
-				-- implicit taking: 
-				IF projectile NOT DIRECTLY IN hero 
-					THEN LOCATE projectile IN hero.
-					     SAY implicit_taking_message OF my_game.
-				END IF.
-				-- end of implicit taking.
-      	  				
-				IF target IS inanimate
-					THEN 
-						IF target NOT DIRECTLY AT hero		
-							-- for example the target is inside a box
-							THEN "It wouldn't accomplish anything trying to throw
-								 something at" SAY THE target. "."
-							ELSE 
-								SAY THE projectile.
- 
-								IF projectile IS NOT plural
-									THEN "bounces"
-									ELSE "bounce"
-								END IF.
+  VERB throw_at
+        WHEN projectile
+      CHECK my_game CAN throw_at
+        ELSE SAY restricted_response OF my_game.
+          AND projectile IS examinable
+        ELSE
+          IF projectile IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+          AND projectile IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+          AND target IS examinable
+          ELSE SAY check_obj_suitable_at OF my_game.
+          AND projectile <> target
+        ELSE SAY check_obj_not_obj2_at OF my_game.
+          AND target NOT IN hero
+              ELSE SAY check_obj2_not_in_hero1 OF my_game.
+          AND target <> hero
+          ELSE SAY check_obj2_not_hero1 OF my_game.
+          AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+          AND projectile IS reachable AND projectile IS NOT distant
+        ELSE
+          IF projectile IS NOT reachable
+            THEN
+              IF projectile IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF projectile IS distant
+            THEN
+              IF projectile IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND target IS NOT distant
+        -- it is possible to throw something at an (otherwise) not reachable target
+        ELSE
+          IF target IS NOT plural
+            THEN SAY check_obj2_not_distant_sg OF my_game.
+            ELSE SAY check_obj2_not_distant_pl OF my_game.
+          END IF.
+          DOES
+        -- implicit taking:
+        IF projectile NOT DIRECTLY IN hero
+          THEN LOCATE projectile IN hero.
+               SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
 
-								"harmlessly off" 
+        IF target IS inanimate
+          THEN
+            IF target NOT DIRECTLY AT hero
+              -- for example the target is inside a box
+              THEN "It wouldn't accomplish anything trying to throw
+                 something at" SAY THE target. "."
+              ELSE
+                SAY THE projectile.
 
-								SAY THE target. "and"
+                IF projectile IS NOT plural
+                  THEN "bounces"
+                  ELSE "bounce"
+                END IF.
 
-								IF projectile IS NOT plural
-									THEN "ends up"
-									ELSE "end up"
-								END IF.
+                "harmlessly off"
 
-		  						IF floor HERE
-									THEN "on the floor"
-								ELSIF ground HERE
-									THEN "on the ground"
-		  						END IF.
-	
-		     						"nearby."
-		  						LOCATE projectile AT hero.
-						END IF.
+                SAY THE target. "and"
 
-					ELSE SAY THE target. "wouldn't probably appreciate that."
-						-- Throwing objects at actors is not disabled in the checks
-						-- as in some situations this might be desired, for example
-						-- when attacking enemies.
-		  		END IF.		
+                IF projectile IS NOT plural
+                  THEN "ends up"
+                  ELSE "end up"
+                END IF.
 
-	END VERB.
+                  IF floor HERE
+                  THEN "on the floor"
+                ELSIF ground HERE
+                  THEN "on the ground"
+                  END IF.
+
+                    "nearby."
+                  LOCATE projectile AT hero.
+            END IF.
+
+          ELSE SAY THE target. "wouldn't probably appreciate that."
+            -- Throwing objects at actors is not disabled in the checks
+            -- as in some situations this might be desired, for example
+            -- when attacking enemies.
+          END IF.
+
+  END VERB.
 END ADD TO.
 
 
@@ -7679,75 +7679,75 @@ END ADD TO.
 -- ==============================================================
 
 
------ THROW TO 	  
+----- THROW TO
 
 
 -- ==============================================================
 
 
 SYNTAX throw_to = throw (projectile) 'to' (recipient)
-    	WHERE projectile ISA OBJECT
-  		ELSE SAY illegal_parameter_obj OF my_game.
-  	AND recipient ISA ACTOR
-	   	ELSE SAY illegal_parameter2_there OF my_game. 
+      WHERE projectile ISA OBJECT
+      ELSE SAY illegal_parameter_obj OF my_game.
+    AND recipient ISA ACTOR
+      ELSE SAY illegal_parameter2_there OF my_game.
 
 
 ADD TO EVERY OBJECT
-	VERB throw_to
-    		WHEN projectile
-			CHECK my_game CAN throw_to
-				ELSE SAY restricted_response OF my_game.
-	    		AND projectile IS examinable
-				ELSE 
-					IF projectile IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game.
-					END IF.
-	    		AND projectile IS takeable
-		  		ELSE SAY check_obj_takeable OF my_game.
-	    		AND recipient IS examinable
-		  		ELSE SAY check_obj_suitable_at OF my_game.
-	    		AND projectile <> recipient
-				ELSE SAY check_obj_not_obj2_to OF my_game. 
-	    		AND recipient NOT IN hero
-	        		ELSE SAY check_obj2_not_in_hero1 OF my_game.
-	    		AND recipient <> hero
-		   		ELSE SAY check_obj2_not_hero1 OF my_game. 
-	    		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-	    		AND projectile IS reachable AND projectile IS NOT distant
-				ELSE
-					IF projectile IS NOT reachable
-						THEN  
-							IF projectile IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF projectile IS distant
-						THEN
-							IF projectile IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		AND recipient IS NOT distant
-		  		ELSE 
-					IF recipient IS NOT plural
-						THEN SAY check_obj2_not_distant_sg OF my_game. 
-						ELSE SAY check_obj2_not_distant_pl OF my_game. 
-					END IF.
-	    		DOES 
-				-- implicit taking:
-				IF projectile NOT DIRECTLY IN hero 
-					THEN LOCATE projectile IN hero.
-						SAY implicit_taking_message OF my_game.	
-				END IF.
-				-- end of implicit taking.
-				
-				"It wouldn't accomplish anything trying to throw"
-				SAY the projectile. "to" SAY THE recipient. "."
+  VERB throw_to
+        WHEN projectile
+      CHECK my_game CAN throw_to
+        ELSE SAY restricted_response OF my_game.
+          AND projectile IS examinable
+        ELSE
+          IF projectile IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+          AND projectile IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+          AND recipient IS examinable
+          ELSE SAY check_obj_suitable_at OF my_game.
+          AND projectile <> recipient
+        ELSE SAY check_obj_not_obj2_to OF my_game.
+          AND recipient NOT IN hero
+              ELSE SAY check_obj2_not_in_hero1 OF my_game.
+          AND recipient <> hero
+          ELSE SAY check_obj2_not_hero1 OF my_game.
+          AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+          AND projectile IS reachable AND projectile IS NOT distant
+        ELSE
+          IF projectile IS NOT reachable
+            THEN
+              IF projectile IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF projectile IS distant
+            THEN
+              IF projectile IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          AND recipient IS NOT distant
+          ELSE
+          IF recipient IS NOT plural
+            THEN SAY check_obj2_not_distant_sg OF my_game.
+            ELSE SAY check_obj2_not_distant_pl OF my_game.
+          END IF.
+          DOES
+        -- implicit taking:
+        IF projectile NOT DIRECTLY IN hero
+          THEN LOCATE projectile IN hero.
+            SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
 
-	END VERB.
+        "It wouldn't accomplish anything trying to throw"
+        SAY the projectile. "to" SAY THE recipient. "."
+
+  END VERB.
 END ADD TO.
 
 
@@ -7762,97 +7762,97 @@ END ADD TO.
 
 
 SYNTAX throw_in = throw (projectile) 'in' (cont)
-	WHERE projectile ISA OBJECT
-   		ELSE SAY illegal_parameter_obj OF my_game.
-	AND cont ISA OBJECT
-   		ELSE 
-			IF cont ISA ACTOR
-				THEN SAY illegal_parameter_act OF my_game.
-				ELSE SAY illegal_parameter2_there OF my_game.
-			END IF.  
-	AND cont ISA CONTAINER
-    		ELSE SAY illegal_parameter2_there OF my_game. 
+  WHERE projectile ISA OBJECT
+      ELSE SAY illegal_parameter_obj OF my_game.
+  AND cont ISA OBJECT
+      ELSE
+      IF cont ISA ACTOR
+        THEN SAY illegal_parameter_act OF my_game.
+        ELSE SAY illegal_parameter2_there OF my_game.
+      END IF.
+  AND cont ISA CONTAINER
+        ELSE SAY illegal_parameter2_there OF my_game.
 
 
 ADD TO EVERY OBJECT
-	VERB throw_in
-    		WHEN projectile
-			CHECK my_game CAN throw_in
-				ELSE SAY restricted_response OF my_game.
-          		AND projectile IS examinable
-		  		ELSE 
-					IF projectile IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-	    		AND projectile IS takeable
-		  		ELSE SAY check_obj_takeable OF my_game.
-	    		AND cont IS examinable
-		  		ELSE SAY check_obj2_suitable_there OF my_game.
-	    		AND projectile <> cont
-				ELSE SAY check_obj_not_obj2_in OF my_game. 
-	    		AND cont <> hero
-	        		ELSE SAY check_obj2_not_hero1 OF my_game. 
-			AND cont NOT IN hero
-				ELSE SAY check_obj2_not_in_hero1 OF my_game.
-	    		AND CURRENT LOCATION IS lit
-		  		ELSE SAY check_current_loc_lit OF my_game.
-	    		AND projectile NOT IN cont
-		  		ELSE  
-					IF projectile IS NOT plural
-						THEN SAY check_obj_not_in_cont_sg OF my_game.
-						ELSE SAY check_obj_not_in_cont_pl OF my_game.
-					END IF.
-	    		AND projectile IS reachable AND projectile IS NOT distant
-				ELSE
-					IF projectile IS NOT reachable
-						THEN  
-							IF projectile IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF projectile IS distant
-						THEN
-							IF projectile IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		AND cont IS NOT distant
-		  		ELSE  
-					IF cont IS NOT plural
-						THEN SAY check_obj2_not_distant_sg OF my_game. 
-						ELSE SAY check_obj2_not_distant_pl OF my_game. 
-					END IF.
-			AND projectile IN allowed OF cont
-				ELSE
-					IF projectile IS NOT plural
-						THEN SAY check_obj_allowed_in_sg OF my_game.
-						ELSE SAY check_obj_allowed_in_pl OF my_game.
-					END IF.
-	    		AND cont IS open
-		  		ELSE 
-					IF cont IS NOT plural
-						THEN SAY check_obj2_open_sg OF my_game.
-						ELSE SAY check_obj2_open_pl OF my_game.
-					END IF.
-	    		DOES
-				-- implicit taking:
-				IF projectile NOT DIRECTLY IN hero 
-					THEN LOCATE projectile IN hero.
-						SAY implicit_taking_message OF my_game.	
-				END IF.
-				-- end of implicit taking.
+  VERB throw_in
+        WHEN projectile
+      CHECK my_game CAN throw_in
+        ELSE SAY restricted_response OF my_game.
+              AND projectile IS examinable
+          ELSE
+          IF projectile IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+          AND projectile IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+          AND cont IS examinable
+          ELSE SAY check_obj2_suitable_there OF my_game.
+          AND projectile <> cont
+        ELSE SAY check_obj_not_obj2_in OF my_game.
+          AND cont <> hero
+              ELSE SAY check_obj2_not_hero1 OF my_game.
+      AND cont NOT IN hero
+        ELSE SAY check_obj2_not_in_hero1 OF my_game.
+          AND CURRENT LOCATION IS lit
+          ELSE SAY check_current_loc_lit OF my_game.
+          AND projectile NOT IN cont
+          ELSE
+          IF projectile IS NOT plural
+            THEN SAY check_obj_not_in_cont_sg OF my_game.
+            ELSE SAY check_obj_not_in_cont_pl OF my_game.
+          END IF.
+          AND projectile IS reachable AND projectile IS NOT distant
+        ELSE
+          IF projectile IS NOT reachable
+            THEN
+              IF projectile IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF projectile IS distant
+            THEN
+              IF projectile IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          AND cont IS NOT distant
+          ELSE
+          IF cont IS NOT plural
+            THEN SAY check_obj2_not_distant_sg OF my_game.
+            ELSE SAY check_obj2_not_distant_pl OF my_game.
+          END IF.
+      AND projectile IN allowed OF cont
+        ELSE
+          IF projectile IS NOT plural
+            THEN SAY check_obj_allowed_in_sg OF my_game.
+            ELSE SAY check_obj_allowed_in_pl OF my_game.
+          END IF.
+          AND cont IS open
+          ELSE
+          IF cont IS NOT plural
+            THEN SAY check_obj2_open_sg OF my_game.
+            ELSE SAY check_obj2_open_pl OF my_game.
+          END IF.
+          DOES
+        -- implicit taking:
+        IF projectile NOT DIRECTLY IN hero
+          THEN LOCATE projectile IN hero.
+            SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
 
-				"It wouldn't accomplish anything trying to throw"
-				SAY THE projectile. "into" SAY THE cont. "."	
+        "It wouldn't accomplish anything trying to throw"
+        SAY THE projectile. "into" SAY THE cont. "."
 
-				-- Throwing objects into containers, even when these objects are
-				-- in the 'allowed' set of the container, is not successful by
-				-- default; this is to avoid successful outcomes for commands like
-				-- 'throw plate into cupboard' etc. 
+        -- Throwing objects into containers, even when these objects are
+        -- in the 'allowed' set of the container, is not successful by
+        -- default; this is to avoid successful outcomes for commands like
+        -- 'throw plate into cupboard' etc.
 
-	END VERB.
+  END VERB.
 END ADD TO.
 
 
@@ -7866,30 +7866,30 @@ END ADD TO.
 -- ==============================================================
 
 
-SYNTAX tie = tie (obj) 
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+SYNTAX tie = tie (obj)
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB tie
-		CHECK my_game CAN tie
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.	
-		DOES 
-			"You must state where you want to tie" SAY THE obj. "."
-  	END VERB.
+  VERB tie
+    CHECK my_game CAN tie
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    DOES
+      "You must state where you want to tie" SAY THE obj. "."
+    END VERB.
 END ADD TO.
 
 
@@ -7904,73 +7904,73 @@ END ADD TO.
 
 
 SYNTAX tie_to = tie (obj) 'to' (target)
-	WHERE obj ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game.
-	AND target ISA THING
-		ELSE SAY illegal_parameter_obj OF my_game. 
+  WHERE obj ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+  AND target ISA THING
+    ELSE SAY illegal_parameter_obj OF my_game.
 
 
 
 ADD TO EVERY THING
-	VERB tie_to
-		WHEN obj
-			CHECK my_game CAN tie_to
-				ELSE SAY restricted_response OF my_game.
-			AND obj IS examinable
-		  		ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND target IS examinable
-		  		ELSE SAY check_obj2_suitable_there OF my_game.
-			AND obj <> target
-				ELSE SAY check_obj_not_obj2_to OF my_game.
-			AND obj IS takeable
-		  		ELSE SAY check_obj_takeable OF my_game. 
-			AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-			AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND target IS reachable AND target IS NOT distant
-				ELSE
-					IF target IS NOT reachable
-						THEN  
-							IF target IS NOT plural
-								THEN SAY check_obj2_reachable_sg OF my_game.
-								ELSE SAY check_obj2_reachable_pl OF my_game.
-							END IF.
-					ELSIF target IS distant
-						THEN
-							IF target IS NOT plural
-								THEN SAY check_obj2_not_distant_sg OF my_game. 
-								ELSE SAY check_obj2_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			DOES 
-				-- implicit taking:
-				IF obj NOT DIRECTLY IN hero 
-					THEN LOCATE obj IN hero.
-						SAY implicit_taking_message OF my_game.
-				END IF.	
-				-- end of implicit taking.
-								
-				"It's not possible to tie" SAY THE obj. "to" SAY THE target. "."	
+  VERB tie_to
+    WHEN obj
+      CHECK my_game CAN tie_to
+        ELSE SAY restricted_response OF my_game.
+      AND obj IS examinable
+          ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND target IS examinable
+          ELSE SAY check_obj2_suitable_there OF my_game.
+      AND obj <> target
+        ELSE SAY check_obj_not_obj2_to OF my_game.
+      AND obj IS takeable
+          ELSE SAY check_obj_takeable OF my_game.
+      AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND target IS reachable AND target IS NOT distant
+        ELSE
+          IF target IS NOT reachable
+            THEN
+              IF target IS NOT plural
+                THEN SAY check_obj2_reachable_sg OF my_game.
+                ELSE SAY check_obj2_reachable_pl OF my_game.
+              END IF.
+          ELSIF target IS distant
+            THEN
+              IF target IS NOT plural
+                THEN SAY check_obj2_not_distant_sg OF my_game.
+                ELSE SAY check_obj2_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      DOES
+        -- implicit taking:
+        IF obj NOT DIRECTLY IN hero
+          THEN LOCATE obj IN hero.
+            SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
 
-	END VERB.
+        "It's not possible to tie" SAY THE obj. "to" SAY THE target. "."
+
+  END VERB.
 END ADD TO.
 
 
@@ -7985,47 +7985,47 @@ END ADD TO.
 
 
 SYNTAX touch = touch (obj)
-	WHERE obj ISA THING
-	   	ELSE
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-    
+  WHERE obj ISA THING
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+
 
 ADD TO EVERY THING
-	VERB touch
-		CHECK my_game CAN touch
-				ELSE SAY restricted_response OF my_game.
-     		AND obj IS examinable
-          		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-	  	AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-	  	AND obj <> hero
-			ELSE SAY check_obj_not_hero3 OF my_game. 
-	  	AND obj IS inanimate
-			ELSE SAY check_obj_inanimate2 OF my_game. "."
-        	DOES
-	     		"You feel nothing unexpected."
+  VERB touch
+    CHECK my_game CAN touch
+        ELSE SAY restricted_response OF my_game.
+        AND obj IS examinable
+              ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+      AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+      AND obj <> hero
+      ELSE SAY check_obj_not_hero3 OF my_game.
+      AND obj IS inanimate
+      ELSE SAY check_obj_inanimate2 OF my_game. "."
+          DOES
+          "You feel nothing unexpected."
   END VERB.
 END ADD TO.
 
@@ -8044,65 +8044,65 @@ SYNONYMS feel = touch.
 
 
 SYNTAX touch_with = touch (obj) 'with' (instr)
-	WHERE obj ISA THING
-   		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND instr ISA OBJECT
-	    	ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter2_with_sg OF my_game. 
-				ELSE SAY illegal_parameter2_with_pl OF my_game. 
-			END IF.
+  WHERE obj ISA THING
+      ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND instr ISA OBJECT
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter2_with_sg OF my_game.
+        ELSE SAY illegal_parameter2_with_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY THING
-	VERB touch_with
-		WHEN obj
-			CHECK my_game CAN touch_with
-				ELSE SAY restricted_response OF my_game.
-	    		AND obj IS examinable
-	        		ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-	    		AND instr IS examinable
-		  		ELSE 
-					IF instr IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-				END IF.			
-	    		AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game. 
-	    		AND instr <> hero
-				ELSE SAY check_obj2_not_hero1 OF my_game.
-	    		AND instr IN hero
-		  		ELSE SAY check_obj2_in_hero OF my_game.
-	    		AND obj IS inanimate
-		  		ELSE SAY check_obj_inanimate2 OF my_game. 
-	    		AND CURRENT LOCATION IS lit
-		  		ELSE SAY check_current_loc_lit OF my_game.
-	    		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-	    		DOES
-	        		"You touch" SAY THE obj. "with" SAY THE instr. ". Nothing special happens."
-  	END VERB.
+  VERB touch_with
+    WHEN obj
+      CHECK my_game CAN touch_with
+        ELSE SAY restricted_response OF my_game.
+          AND obj IS examinable
+              ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+          AND instr IS examinable
+          ELSE
+          IF instr IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+        END IF.
+          AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+          AND instr <> hero
+        ELSE SAY check_obj2_not_hero1 OF my_game.
+          AND instr IN hero
+          ELSE SAY check_obj2_in_hero OF my_game.
+          AND obj IS inanimate
+          ELSE SAY check_obj_inanimate2 OF my_game.
+          AND CURRENT LOCATION IS lit
+          ELSE SAY check_current_loc_lit OF my_game.
+          AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+          DOES
+              "You touch" SAY THE obj. "with" SAY THE instr. ". Nothing special happens."
+    END VERB.
 END ADD TO.
 
 
@@ -8110,68 +8110,68 @@ END ADD TO.
 -- ==============================================================
 
 
------ TURN	(+ rotate)
+----- TURN  (+ rotate)
 
 
 -- ==============================================================
 
 
 SYNTAX turn = turn (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF my_game CAN NOT turn
-				THEN
-				  "The verb '$v' is not in your vocabulary."
-				ELSE
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF my_game CAN NOT turn
+        THEN
+          "The verb '$v' is not in your vocabulary."
+        ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+      END IF.
 
 
 
 
 ADD TO EVERY OBJECT
-  	VERB turn
-		CHECK my_game CAN turn
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS examinable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND obj IS movable
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game.
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
+    VERB turn
+    CHECK my_game CAN turn
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS examinable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND obj IS movable
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
 
-		DOES 
-			IF obj DIRECTLY IN hero
-				THEN "You turn" SAY THE obj. "in your hands, noticing nothing special."
-				ELSE "That wouldn't accomplish anything."
-			END IF.
-	END VERB.
+    DOES
+      IF obj DIRECTLY IN hero
+        THEN "You turn" SAY THE obj. "in your hands, noticing nothing special."
+        ELSE "That wouldn't accomplish anything."
+      END IF.
+  END VERB.
 END ADD TO.
 
 
@@ -8185,48 +8185,48 @@ END ADD TO.
 -- ==============================================================
 
 
------ Only devices and lightsources can be turned on and off. These classes are 
------ defined in 'classes.i' with proper checks for 'on' and 'NOT on', 'lit' and 'NOT lit'. 
------ Trying to turn on or off an ordinary object will default here to "That's not 
+----- Only devices and lightsources can be turned on and off. These classes are
+----- defined in 'classes.i' with proper checks for 'on' and 'NOT on', 'lit' and 'NOT lit'.
+----- Trying to turn on or off an ordinary object will default here to "That's not
 ----- something you can turn on".
 
 
 SYNTAX turn_on = turn 'on' (app)
-	WHERE app ISA OBJECT
-		ELSE 
-			IF app IS NOT plural
-				THEN SAY illegal_parameter_on_sg OF my_game. 
-				ELSE SAY illegal_parameter_on_pl OF my_game. 
-			END IF.
-					
-  	turn_on = switch 'on' (app).
+  WHERE app ISA OBJECT
+    ELSE
+      IF app IS NOT plural
+        THEN SAY illegal_parameter_on_sg OF my_game.
+        ELSE SAY illegal_parameter_on_pl OF my_game.
+      END IF.
 
-    	turn_on = turn (app) 'on'.
+    turn_on = switch 'on' (app).
 
-    	turn_on = switch (app) 'on'.
-		
+      turn_on = turn (app) 'on'.
+
+      turn_on = switch (app) 'on'.
+
 
 
 -- Note that 'switch' is not declared a synonym for 'turn'.
 -- This is because 'turn' has also other meanings, for example 'turn page' which is
--- not equal with 'switch page'. 
+-- not equal with 'switch page'.
 -- A separate 'switch' verb is declared in 'classes.i', classes 'device' and 'lightsource'.
 -- This verb merely covers cases where the player forgets (or doesn't bother) to type 'on' or 'off'.
 
 
 
 ADD TO EVERY OBJECT
-	VERB turn_on	
-	   	CHECK my_game CAN turn_on
-			ELSE SAY restricted_response OF my_game.
-		DOES
-			IF app IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			
-			"something you can $v on."
-  	END VERB.
+  VERB turn_on
+      CHECK my_game CAN turn_on
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      IF app IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+
+      "something you can $v on."
+    END VERB.
 END ADD TO.
 
 
@@ -8240,46 +8240,46 @@ END ADD TO.
 -- ==============================================================
 
 
------ Only devices and lightsources can be turned on and off. These classes 
------ are defined in 'classes.i' with proper checks for 'on' and 'NOT on', 
------ 'lit' and 'NOT lit'. 
+----- Only devices and lightsources can be turned on and off. These classes
+----- are defined in 'classes.i' with proper checks for 'on' and 'NOT on',
+----- 'lit' and 'NOT lit'.
 
 
 SYNTAX turn_off = turn off (app)
-	WHERE app ISA OBJECT
-		ELSE 
-			IF app IS NOT plural
-				THEN SAY illegal_parameter_off_sg OF my_game. 
-				ELSE SAY illegal_parameter_off_pl OF my_game. 
-			END IF.
+  WHERE app ISA OBJECT
+    ELSE
+      IF app IS NOT plural
+        THEN SAY illegal_parameter_off_sg OF my_game.
+        ELSE SAY illegal_parameter_off_pl OF my_game.
+      END IF.
 
-	turn_off = switch off (app).
-		
-    	turn_off = turn (app) off.
-		
-	turn_off = switch (app) off.
-		
+  turn_off = switch off (app).
+
+      turn_off = turn (app) off.
+
+  turn_off = switch (app) off.
+
 
 
 -- Note that 'switch' is not declared a synonym for 'turn'.
 -- This is because 'turn' has also other meanings, for example 'turn page' which is
--- not equal with 'switch page'. 
+-- not equal with 'switch page'.
 -- A separate 'switch' verb is declared in 'classes.i', classes 'device' and 'lightsource'.
 -- This verb merely covers cases where the player forgets to type 'on' or 'off'.
-    	
+
 
 ADD TO EVERY OBJECT
-	VERB turn_off
-		CHECK my_game CAN turn_off
-			ELSE SAY restricted_response OF my_game.
-		DOES
-			IF app IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
+  VERB turn_off
+    CHECK my_game CAN turn_off
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      IF app IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
 
-			"something you can $v off."
-  	END VERB.
+      "something you can $v off."
+    END VERB.
 END ADD TO.
 
 
@@ -8297,18 +8297,18 @@ SYNTAX undress = undress.
 
 
 VERB undress
-	CHECK my_game CAN undress
-		ELSE SAY restricted_response OF my_game.
-	AND CURRENT LOCATION IS lit
-		ELSE SAY check_current_loc_lit OF my_game.
-	DOES "You don't feel like undressing is a good idea right now."
-																						
-	   	-- To make it work, use the following lines instead:					
-	    	--IF COUNT DIRECTLY IN worn, ISA CLOTHING > 0 
-			--THEN EMPTY worn IN hero.
-				--"You remove all the items you were wearing."
-		    	--ELSE "You're not wearing anything you can remove."
-	    	-- END IF.
+  CHECK my_game CAN undress
+    ELSE SAY restricted_response OF my_game.
+  AND CURRENT LOCATION IS lit
+    ELSE SAY check_current_loc_lit OF my_game.
+  DOES "You don't feel like undressing is a good idea right now."
+
+      -- To make it work, use the following lines instead:
+        --IF COUNT DIRECTLY IN worn, ISA CLOTHING > 0
+      --THEN EMPTY worn IN hero.
+        --"You remove all the items you were wearing."
+          --ELSE "You're not wearing anything you can remove."
+        -- END IF.
 END VERB.
 
 
@@ -8323,55 +8323,55 @@ END VERB.
 
 
 SYNTAX unlock = unlock (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
 
 
 ADD TO EVERY OBJECT
-	VERB unlock
-		CHECK my_game CAN unlock
-			ELSE SAY restricted_response OF my_game.
-		AND obj IS lockable
-	    		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_suitable_sg OF my_game. 
-					ELSE SAY check_obj_suitable_pl OF my_game. 
-				END IF.
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
-		AND obj IS locked
-	    		ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_locked_sg OF my_game.
-					ELSE SAY check_obj_locked_pl OF my_game.
-				END IF.
-		DOES
-			IF matching_key OF obj IN hero
-				THEN MAKE obj NOT locked.
-					"(with" SAY THE matching_key OF obj. "$$)$n"
-					"You unlock" SAY THE obj. "."
-	    			ELSE "You don't have the key that unlocks" SAY THE obj. "."
-			END IF.
-	END VERB.
+  VERB unlock
+    CHECK my_game CAN unlock
+      ELSE SAY restricted_response OF my_game.
+    AND obj IS lockable
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_suitable_sg OF my_game.
+          ELSE SAY check_obj_suitable_pl OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
+    AND obj IS locked
+          ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_locked_sg OF my_game.
+          ELSE SAY check_obj_locked_pl OF my_game.
+        END IF.
+    DOES
+      IF matching_key OF obj IN hero
+        THEN MAKE obj NOT locked.
+          "(with" SAY THE matching_key OF obj. "$$)$n"
+          "You unlock" SAY THE obj. "."
+            ELSE "You don't have the key that unlocks" SAY THE obj. "."
+      END IF.
+  END VERB.
 END ADD TO.
 
 
@@ -8386,66 +8386,66 @@ END ADD TO.
 
 
 SYNTAX unlock_with = unlock (obj) 'with' (key)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	AND key ISA OBJECT
-   		ELSE SAY illegal_parameter_with_sg OF my_game. "."
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+  AND key ISA OBJECT
+      ELSE SAY illegal_parameter_with_sg OF my_game. "."
 
 
 ADD TO EVERY OBJECT
-	VERB unlock_with
-      	WHEN obj
-			CHECK my_game CAN unlock_with
-				ELSE SAY restricted_response OF my_game.
-	    		AND obj IS lockable
-	        		ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_suitable_sg OF my_game. 
-						ELSE SAY check_obj_suitable_pl OF my_game. 
-					END IF.
-			AND key IS examinable
-				ELSE
-					IF obj IS NOT plural
-						THEN SAY check_obj2_suitable_with_sg OF my_game. 
-						ELSE SAY check_obj2_suitable_with_pl OF my_game. 
-					END IF. 
-	    		AND key IN hero
-		  		ELSE SAY check_obj2_in_hero OF my_game.
-	    		AND obj <> key
-				ELSE SAY check_obj_not_obj2_with OF my_game. 
-	    		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-	    		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
-			AND obj IS locked
-				ELSE 
-					IF obj IS NOT plural
-						THEN SAY check_obj_locked_sg OF my_game.
-						ELSE SAY check_obj_locked_pl OF my_game.
-					END IF.
-			AND key = matching_key OF obj
-				ELSE SAY check_door_matching_key OF my_game.		
-	  		DOES
-				MAKE obj NOT locked.
-				"You unlock" SAY THE obj. "with" SAY THE key. "."
-  	END VERB.
+  VERB unlock_with
+        WHEN obj
+      CHECK my_game CAN unlock_with
+        ELSE SAY restricted_response OF my_game.
+          AND obj IS lockable
+              ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_suitable_sg OF my_game.
+            ELSE SAY check_obj_suitable_pl OF my_game.
+          END IF.
+      AND key IS examinable
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj2_suitable_with_sg OF my_game.
+            ELSE SAY check_obj2_suitable_with_pl OF my_game.
+          END IF.
+          AND key IN hero
+          ELSE SAY check_obj2_in_hero OF my_game.
+          AND obj <> key
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+          AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+          AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
+      AND obj IS locked
+        ELSE
+          IF obj IS NOT plural
+            THEN SAY check_obj_locked_sg OF my_game.
+            ELSE SAY check_obj_locked_pl OF my_game.
+          END IF.
+      AND key = matching_key OF obj
+        ELSE SAY check_door_matching_key OF my_game.
+        DOES
+        MAKE obj NOT locked.
+        "You unlock" SAY THE obj. "with" SAY THE key. "."
+    END VERB.
 END ADD TO.
 
 
@@ -8460,23 +8460,23 @@ END ADD TO.
 
 
 SYNTAX 'use' = 'use' (obj)
-	WHERE obj ISA OBJECT
-		ELSE SAY illegal_parameter_obj OF my_game.
-			
+  WHERE obj ISA OBJECT
+    ELSE SAY illegal_parameter_obj OF my_game.
+
 
 
 ADD TO EVERY OBJECT
-	VERB 'use'
-		CHECK my_game CAN 'use'
-			ELSE SAY restricted_response OF my_game.
-		DOES
-			"Please be more specific. How do you intend to use"
-		
-			IF obj IS NOT plural
-				THEN "it?" 
-				ELSE "them?"
-			END IF.
-  	END VERB.
+  VERB 'use'
+    CHECK my_game CAN 'use'
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      "Please be more specific. How do you intend to use"
+
+      IF obj IS NOT plural
+        THEN "it?"
+        ELSE "them?"
+      END IF.
+    END VERB.
 END ADD TO.
 
 
@@ -8491,22 +8491,22 @@ END ADD TO.
 
 
 SYNTAX use_with = 'use' (obj) 'with' (instr)
-	WHERE obj ISA OBJECT
-	   	ELSE SAY illegal_parameter_obj OF my_game.
-	AND instr ISA OBJECT
-	  	ELSE SAY illegal_parameter_obj OF my_game.
+  WHERE obj ISA OBJECT
+      ELSE SAY illegal_parameter_obj OF my_game.
+  AND instr ISA OBJECT
+      ELSE SAY illegal_parameter_obj OF my_game.
 
 
 ADD TO EVERY OBJECT
-	VERB use_with
-    		WHEN obj
-			CHECK my_game CAN use_with
-				ELSE SAY restricted_response OF my_game.
-			AND obj <> instr
-				ELSE SAY check_obj_not_obj2_with OF my_game. 
-			DOES 
-				"Please be more specific. How do you intend to use them together?"
-  	END VERB.
+  VERB use_with
+        WHEN obj
+      CHECK my_game CAN use_with
+        ELSE SAY restricted_response OF my_game.
+      AND obj <> instr
+        ELSE SAY check_obj_not_obj2_with OF my_game.
+      DOES
+        "Please be more specific. How do you intend to use them together?"
+    END VERB.
 END ADD TO.
 
 
@@ -8525,12 +8525,12 @@ SYNTAX verbose = verbose.
 
 
 VERB verbose
-	CHECK my_game CAN verbose
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		VISITS 0.
-		"Verbose mode is now on. Location descriptions will be 
-		always shown in full."
+  CHECK my_game CAN verbose
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    VISITS 0.
+    "Verbose mode is now on. Location descriptions will be
+    always shown in full."
 END VERB.
 
 
@@ -8548,15 +8548,15 @@ SYNTAX 'wait' = 'wait'.
 
 
 VERB 'wait'
-	CHECK my_game CAN 'wait'
-		ELSE SAY restricted_response OF my_game.
-	DOES
-		"Time passes..."
+  CHECK my_game CAN 'wait'
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "Time passes..."
 END VERB.
 
 
 SYNONYMS
-	z = 'wait'.
+  z = 'wait'.
 
 
 
@@ -8571,55 +8571,55 @@ SYNONYMS
 
 
 SYNTAX wear = wear (obj)
-	WHERE obj ISA OBJECT
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_sg OF my_game. 
-				ELSE SAY illegal_parameter_pl OF my_game. 
-			END IF.
-	 wear = put 'on' (obj).
-	 wear = put (obj) 'on'.
-	 wear = don (obj).
+  WHERE obj ISA OBJECT
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_sg OF my_game.
+        ELSE SAY illegal_parameter_pl OF my_game.
+      END IF.
+   wear = put 'on' (obj).
+   wear = put (obj) 'on'.
+   wear = don (obj).
 
 
 ADD TO EVERY OBJECT
-	VERB wear
-		CHECK my_game CAN wear
-				ELSE SAY restricted_response OF my_game.
-		AND obj NOT IN worn 
-			ELSE SAY check_obj_not_in_worn1 OF my_game.
-		AND obj IS takeable
-			ELSE 
-				IF THIS IS NOT plural
-					THEN SAY check_obj_takeable OF my_game. 
-					ELSE SAY check_obj_takeable OF my_game. 
-				END IF. 
-		AND CURRENT LOCATION IS lit
-			ELSE SAY check_current_loc_lit OF my_game.										
-		AND obj IS reachable AND obj IS NOT distant
-			ELSE
-				IF obj IS NOT reachable
-					THEN  
-						IF obj IS NOT plural
-							THEN SAY check_obj_reachable_sg OF my_game.
-							ELSE SAY check_obj_reachable_pl OF my_game.
-						END IF.
-				ELSIF obj IS distant
-					THEN
-						IF obj IS NOT plural
-							THEN SAY check_obj_not_distant_sg OF my_game. 
-							ELSE SAY check_obj_not_distant_pl OF my_game. 
-						END IF.
-				END IF.
+  VERB wear
+    CHECK my_game CAN wear
+        ELSE SAY restricted_response OF my_game.
+    AND obj NOT IN worn
+      ELSE SAY check_obj_not_in_worn1 OF my_game.
+    AND obj IS takeable
+      ELSE
+        IF THIS IS NOT plural
+          THEN SAY check_obj_takeable OF my_game.
+          ELSE SAY check_obj_takeable OF my_game.
+        END IF.
+    AND CURRENT LOCATION IS lit
+      ELSE SAY check_current_loc_lit OF my_game.
+    AND obj IS reachable AND obj IS NOT distant
+      ELSE
+        IF obj IS NOT reachable
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_reachable_sg OF my_game.
+              ELSE SAY check_obj_reachable_pl OF my_game.
+            END IF.
+        ELSIF obj IS distant
+          THEN
+            IF obj IS NOT plural
+              THEN SAY check_obj_not_distant_sg OF my_game.
+              ELSE SAY check_obj_not_distant_pl OF my_game.
+            END IF.
+        END IF.
 
-		DOES
-			IF obj IS NOT plural
-				THEN "That's not"
-				ELSE "Those are not"
-			END IF.
-			"something you can wear."
-			
-	END VERB.
+    DOES
+      IF obj IS NOT plural
+        THEN "That's not"
+        ELSE "Those are not"
+      END IF.
+      "something you can wear."
+
+  END VERB.
 END ADD TO.
 
 
@@ -8637,10 +8637,10 @@ SYNTAX what_am_i = 'what' am i.
 
 
 VERB what_am_i
-	CHECK my_game CAN what_am_i
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		"Maybe examining yourself might help."
+  CHECK my_game CAN what_am_i
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "Maybe examining yourself might help."
 END VERB.
 
 
@@ -8655,23 +8655,23 @@ END VERB.
 
 
 SYNTAX what_is = 'what' 'is' (obj)!
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_what_sg OF my_game.
-				ELSE SAY illegal_parameter_what_pl OF my_game.
-			END IF. 
-	 
-	what_is = 'what' 'are' (obj)!.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_what_sg OF my_game.
+        ELSE SAY illegal_parameter_what_pl OF my_game.
+      END IF.
+
+  what_is = 'what' 'are' (obj)!.
 
 
 ADD TO EVERY THING
-	VERB what_is
-		CHECK my_game CAN what_is
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-			"You'll have to find it out yourself."
-  	END VERB.
+  VERB what_is
+    CHECK my_game CAN what_is
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      "You'll have to find it out yourself."
+    END VERB.
 END ADD TO.
 
 
@@ -8689,10 +8689,10 @@ SYNTAX where_am_i = 'where' am i.
 
 
 VERB where_am_i
-	CHECK my_game CAN where_am_i
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		LOOK.
+  CHECK my_game CAN where_am_i
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    LOOK.
 END VERB.
 
 
@@ -8707,28 +8707,28 @@ END VERB.
 
 
 SYNTAX where_is = 'where' 'is' (obj)!
-	WHERE obj ISA THING
-		ELSE 
-			IF obj IS NOT plural
-				THEN SAY illegal_parameter_what_sg OF my_game.
-				ELSE SAY illegal_parameter_what_pl OF my_game.
-			END IF. 
-	
-	where_is = 'where' 'are' (obj)!.
+  WHERE obj ISA THING
+    ELSE
+      IF obj IS NOT plural
+        THEN SAY illegal_parameter_what_sg OF my_game.
+        ELSE SAY illegal_parameter_what_pl OF my_game.
+      END IF.
+
+  where_is = 'where' 'are' (obj)!.
 
 
 ADD TO EVERY THING
- 	VERB where_is 
-		CHECK my_game CAN where_is
-			ELSE SAY restricted_response OF my_game.
-		AND obj NOT AT hero
-			ELSE 
-				IF obj IS NOT plural
-					THEN SAY check_obj_not_at_hero_sg OF my_game. 
-					ELSE SAY check_obj_not_at_hero_pl OF my_game.
-				END IF.
-		DOES 
-			"You'll have to find it out yourself."
+  VERB where_is
+    CHECK my_game CAN where_is
+      ELSE SAY restricted_response OF my_game.
+    AND obj NOT AT hero
+      ELSE
+        IF obj IS NOT plural
+          THEN SAY check_obj_not_at_hero_sg OF my_game.
+          ELSE SAY check_obj_not_at_hero_pl OF my_game.
+        END IF.
+    DOES
+      "You'll have to find it out yourself."
   END VERB.
 END ADD TO.
 
@@ -8746,11 +8746,11 @@ END ADD TO.
 SYNTAX who_am_i = who am i.
 
 
-VERB who_am_i 
-	CHECK my_game CAN who_am_i
-		ELSE SAY restricted_response OF my_game.
-	DOES 
-		"Maybe examining yourself might help."
+VERB who_am_i
+  CHECK my_game CAN who_am_i
+    ELSE SAY restricted_response OF my_game.
+  DOES
+    "Maybe examining yourself might help."
 END VERB.
 
 
@@ -8765,23 +8765,23 @@ END VERB.
 
 
 SYNTAX who_is = 'who' 'is' (act)!
-	WHERE act ISA ACTOR
-		ELSE 
-			IF act IS NOT plural
-				THEN SAY illegal_parameter_who_sg OF my_game.
-				ELSE SAY illegal_parameter_who_pl OF my_game.
-			END IF. 
+  WHERE act ISA ACTOR
+    ELSE
+      IF act IS NOT plural
+        THEN SAY illegal_parameter_who_sg OF my_game.
+        ELSE SAY illegal_parameter_who_pl OF my_game.
+      END IF.
 
-	who_is = 'who' 'are' (act)!.
+  who_is = 'who' 'are' (act)!.
 
 
 ADD TO EVERY ACTOR
-	VERB who_is
-		CHECK my_game CAN who_is
-			ELSE SAY restricted_response OF my_game.
-		DOES 
-			"You'll have to find it out yourself."
-  	END VERB.
+  VERB who_is
+    CHECK my_game CAN who_is
+      ELSE SAY restricted_response OF my_game.
+    DOES
+      "You'll have to find it out yourself."
+    END VERB.
 END ADD TO.
 
 
@@ -8796,51 +8796,51 @@ END ADD TO.
 
 
 SYNTAX write = write (txt) 'on' (obj)
-		WHERE txt ISA STRING
-			ELSE SAY illegal_parameter_string OF my_game.
-		AND obj ISA OBJECT
-			ELSE SAY illegal_parameter2_there OF my_game.
-	
-	 write = write (txt) 'in' (obj).
+    WHERE txt ISA STRING
+      ELSE SAY illegal_parameter_string OF my_game.
+    AND obj ISA OBJECT
+      ELSE SAY illegal_parameter2_there OF my_game.
+
+   write = write (txt) 'in' (obj).
 
 
 ADD TO EVERY OBJECT
-	VERB write 
-     		WHEN obj 
-			CHECK my_game CAN write
-				ELSE SAY restricted_response OF my_game.
-        		AND obj IS writeable 
-				ELSE SAY check_obj_writeable OF my_game. 
-	  		AND CURRENT LOCATION IS lit
-				ELSE SAY check_current_loc_lit OF my_game.
-	  		AND obj IS reachable AND obj IS NOT distant
-				ELSE
-					IF obj IS NOT reachable
-						THEN  
-							IF obj IS NOT plural
-								THEN SAY check_obj_reachable_sg OF my_game.
-								ELSE SAY check_obj_reachable_pl OF my_game.
-							END IF.
-					ELSIF obj IS distant
-						THEN
-							IF obj IS NOT plural
-								THEN SAY check_obj_not_distant_sg OF my_game. 
-								ELSE SAY check_obj_not_distant_pl OF my_game. 
-							END IF.
-					END IF.
+  VERB write
+        WHEN obj
+      CHECK my_game CAN write
+        ELSE SAY restricted_response OF my_game.
+            AND obj IS writeable
+        ELSE SAY check_obj_writeable OF my_game.
+        AND CURRENT LOCATION IS lit
+        ELSE SAY check_current_loc_lit OF my_game.
+        AND obj IS reachable AND obj IS NOT distant
+        ELSE
+          IF obj IS NOT reachable
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_reachable_sg OF my_game.
+                ELSE SAY check_obj_reachable_pl OF my_game.
+              END IF.
+          ELSIF obj IS distant
+            THEN
+              IF obj IS NOT plural
+                THEN SAY check_obj_not_distant_sg OF my_game.
+                ELSE SAY check_obj_not_distant_pl OF my_game.
+              END IF.
+          END IF.
 
-	  		DOES 	
-				"You don't have anything to write with."
+        DOES
+        "You don't have anything to write with."
 
-				-- To make it work:
-		  		-- IF text OF obj = ""
-					-- THEN SET text OF obj TO txt.
-					-- ELSE SET text OF obj TO text OF obj + " " + txt. 
-		  		-- END IF.
+        -- To make it work:
+          -- IF text OF obj = ""
+          -- THEN SET text OF obj TO txt.
+          -- ELSE SET text OF obj TO text OF obj + " " + txt.
+          -- END IF.
 
-				-- "You write ""$$" SAY txt. "$$"" on" SAY THE obj. "."
-			   	-- MAKE obj readable.
-  	END VERB. 
+        -- "You write ""$$" SAY txt. "$$"" on" SAY THE obj. "."
+          -- MAKE obj readable.
+    END VERB.
 END ADD TO.
 
 
@@ -8849,38 +8849,38 @@ END ADD TO.
 
 
 SYNTAX write_error1 = write 'on' (obj)
-	WHERE obj ISA OBJECT
-		ELSE "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
-			to write something."
+  WHERE obj ISA OBJECT
+    ELSE "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
+      to write something."
 
 
 ADD TO EVERY OBJECT
-	VERB write_error1
-		DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
-			to write something."
-	END VERB.
+  VERB write_error1
+    DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
+      to write something."
+  END VERB.
 END ADD TO.
 
 
 SYNTAX write_error2 = write.
 
-VERB write_error2 
-	DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
-			to write something."
+VERB write_error2
+  DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
+      to write something."
 END VERB.
 
 
 SYNTAX write_error3 = write (txt)
-	WHERE txt ISA STRING
-		ELSE "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
-			to write something."
+  WHERE txt ISA STRING
+    ELSE "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
+      to write something."
 
 
 ADD TO EVERY STRING
-	VERB write_error3
-		DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
-			to write something."
-	END VERB.
+  VERB write_error3
+    DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
+      to write something."
+  END VERB.
 END ADD TO.
 
 
@@ -8897,10 +8897,10 @@ END ADD TO.
 SYNTAX yes = yes.
 
 
-VERB yes 
-	CHECK my_game CAN yes
-		ELSE SAY restricted_response OF my_game.
-	DOES "Really?"
+VERB yes
+  CHECK my_game CAN yes
+    ELSE SAY restricted_response OF my_game.
+  DOES "Really?"
 END VERB.
 
 

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -9,128 +9,128 @@
 ----- Verbs originally defined in this file are the following:
 
 
------ VERB        SYNONYMS                                        SYNTAX                              ARITY             OBJ
+----- VERB        SYNONYMS                                        SYNTAX                              ARITY   OBJ
 
 ----- about       (+ help, info)                                  about                               0
 ----- again       (+ g)                                           again                               0
 ----- answer      (+ reply)                                       answer (topic)                      1
 ----- ask         (+ enquire, inquire, interrogate)               ask (act) about (topic)             2
------ ask_for                                                     ask (act) for (obj)                 2                 x
+----- ask_for                                                     ask (act) for (obj)                 2       x
 ----- attack      (+ beat, fight, hit, punch)                     attack (target)                     1
 ----- attack_with                                                 attack (target) with (weapon)       2
------ bite        (+ chew)                                      bite (obj)                          1                 x
------ break       (+ destroy)                                     break (obj)                         1        x
------ break_with                                                  break (obj) with (instr)            2                 x
+----- bite        (+ chew)                                        bite (obj)                          1       x
+----- break       (+ destroy)                                     break (obj)                         1       x
+----- break_with                                                  break (obj) with (instr)            2       x
 ----- brief                                                       brief                               0
------ burn                                                        burn (obj)                          1                 x
------ burn_with                                                   burn (obj) with (instr)             2                 x
+----- burn                                                        burn (obj)                          1       x
+----- burn_with                                                   burn (obj) with (instr)             2       x
 ----- buy         (+ purchase)                                    buy (item)                          1
------ catch                                                       catch (obj)                         1                 x
------ clean       (+ polish, wipe)                                clean (obj)                         1                 x
------ climb                                                       climb (obj)                         1                 x
+----- catch                                                       catch (obj)                         1       x
+----- clean       (+ polish, wipe)                                clean (obj)                         1       x
+----- climb                                                       climb (obj)                         1       x
 ----- climb_on                                                    climb on (surface)                  1
------ climb_through                                               climb through (obj)                 1                 x
------ close       (+ shut)                                        close (obj)                         1                 x
------ close_with                                                  close (obj) with (instr)            2                 x
+----- climb_through                                               climb through (obj)                 1       x
+----- close       (+ shut)                                        close (obj)                         1       x
+----- close_with                                                  close (obj) with (instr)            2       x
 ----- consult                                                     consult (source) about (topic)      2
------ credits     (+ acknowledgments, author, copyright)          credits                             2
------ cut                                                         cut (obj)                           1                 x
------ cut_with                                                    cut (obj) with (instr)              2                 x
+----- credits     (+ acknowledgments, author, copyright)          credits                             0
+----- cut                                                         cut (obj)                           1       x
+----- cut_with                                                    cut (obj) with (instr)              2       x
 ----- dance                                                       dance                               0
------ dig                                                         dig (obj)                           1                 x
+----- dig                                                         dig (obj)                           1       x
 ----- dive                                                        dive                                0
 ----- dive_in                                                     dive in (liq)                       1
 ----- drink                                                       drink (liq)                         1
 ----- drive                                                       drive (vehicle)                     1
------ drop        (+ discard, dump, reject)                       drop (obj)                          1                 x
+----- drop        (+ discard, dump, reject)                       drop (obj)                          1       x
 ----- eat                                                         eat (food)                          1
------ empty                                                       empty (obj)                         1                 x
------ empty_in                                                    empty (obj) in (cont)               2                 x
------ empty_on                                                    empty (obj) on (surface)            2                 x
------ enter                                                       enter (obj)                         1
------ examine     (+ check, inspect, observe, x)                  examine (obj)                       1                 x
------ exit                                                        exit (obj)                          1
------ extinguish  (+ put out, quench)                             extinguish (obj)                    1                 x
+----- empty                                                       empty (obj)                         1       x
+----- empty_in                                                    empty (obj) in (cont)               2       x
+----- empty_on                                                    empty (obj) on (surface)            2       x
+----- enter                                                       enter (obj)                         1       x
+----- examine     (+ check, inspect, observe, x)                  examine (obj)                       1       x
+----- exit                                                        exit (obj)                          1       x
+----- extinguish  (+ put out, quench)                             extinguish (obj)                    1       x
 ----- fill                                                        fill (cont)                         1
------ fill_with                                                   fill (cont) with (substance)        1
------ find        (+ locate)                                      find (obj)                          1                 x
+----- fill_with                                                   fill (cont) with (substance)        2
+----- find        (+ locate)                                      find (obj)                          1       x
 ----- fire                                                        fire (weapon)                       1
------ fire_at                     fire (weapon) at (target)       1
------ fix     (+ mend, repair)              fix (obj)          1                 x
+----- fire_at                                                     fire (weapon) at (target)           2
+----- fix         (+ mend, repair)                                fix (obj)                           1       x
 ----- follow                                                      follow (act)                        1
------ free        (+ release)                                     free (obj)                          1                 x
+----- free        (+ release)                                     free (obj)                          1       x
 ----- get_up                                                      get up                              0
------ get_off                                                     get off (obj)                       1                 x
------ give                                                        give (obj) to (recipient)           1                 x
+----- get_off                                                     get off (obj)                       1       x
+----- give                                                        give (obj) to (recipient)           2       x
 ----- go_to                                                       go to (dest)                        1
 ----- hint        (+ hints)                                       hint                                0
------ i         (+ inv, inventory             inventory                           0
+----- i           (+ inv, inventory                               inventory                           0
 ----- jump                                                        jump                                0
 ----- jump_in                                                     jump in (cont)                      1
 ----- jump_on                                                     jump on (surface)                   1
 ----- kick                                                        kick (target)                       1
 ----- kill        (+ murder)                                      kill (victim)                       1
 ----- kill_with                                                   kill (victim) with (weapon)         2
------ kiss        (+ hug, embrace)                                kiss (obj)                          1                 x
------ knock
+----- kiss        (+ hug, embrace)                                kiss (obj)                          1       x
+----- knock (on)                                                  knock on (obj)                      1       x
 ----- lie_down                                                    lie down                            0
 ----- lie_in                                                      lie in (cont)                       1
 ----- lie_on                                                      lie on (surface)                    1
------ lift                                                        lift (obj)                          1                 x
------ light       (+ lit)                                         light (obj)                         1                 x
+----- lift                                                        lift (obj)                          1       x
+----- light       (+ lit)                                         light (obj)                         1       x
 ----- listen0                                                     listen                              0
------ listen                                                      listen to (obj)                     1                 x
------ lock                                                        lock (obj)                          1                 x
------ lock_with                                                   lock (obj) with (key)               2                 x
+----- listen                                                      listen to (obj)                     1       x
+----- lock                                                        lock (obj)                          1       x
+----- lock_with                                                   lock (obj) with (key)               2       x
 ----- look        (+ gaze, peek)                                  look                                0
------ look_at                                                     look at (obj)                       1                 x
+----- look_at                                                     look at (obj)                       1       x
 ----- look_behind                                                 look behind (bulk)                  1
 ----- look_in                                                     look in (cont)                      1
------ look_out_of                                                 look out of (obj)                   1                 x
+----- look_out_of                                                 look out of (obj)                   1       x
 ----- look_through                                                look through (bulk)                 1
 ----- look_under                                                  look under (bulk)                   1
 ----- look_up                                                     look up                             0
 ----- no                                                          no                                  0
 ----- notify (on, off)                                            notify. notify on. notify off       0
------ open                                                        open (obj)                          1                 x
------ open_with                                                   open (obj) with (instr)             2                 x
------ play                                                        play (obj)                          1                 x
------ play_with                                                   play with (obj)                     1                 x
------ pour        (= defined at the verb 'empty)                  pour (obj)                          1                 x
------ pour_in     (= defined at the verb 'emtpy_in')              pour (obj) in (cont)                2                 x
------ pour_on     (= defined at the verb 'empty_on')              pour (obj) on (surface)             2                 x
+----- open                                                        open (obj)                          1       x
+----- open_with                                                   open (obj) with (instr)             2       x
+----- play                                                        play (obj)                          1       x
+----- play_with                                                   play with (obj)                     1       x
+----- pour        (= defined at the verb 'empty)                  pour (obj)                          1       x
+----- pour_in     (= defined at the verb 'emtpy_in')              pour (obj) in (cont)                2       x
+----- pour_on     (= defined at the verb 'empty_on')              pour (obj) on (surface)             2       x
 ----- pray                                                        pray                                0
------ pry                                                         pry (obj)                           1                 x
------ pry_with                                                    pry (obj) with (instr)              2                 x
------ pull                                                        pull (obj)                          1                 x
------ push                                                        push (obj)                          1                 x
------ push_with                                                   push (obj) with (instr)             2                 x
------ put         (+ lay, place)                                  put (obj)                           1                 x
------ put_against                   put (obj) against (bulk))    2         x
------ put_behind                                                  put (obj) behind (bulk)             2                 x
------ put_down                                                    put down (obj)                      1                 x
------ put_in      (+ insert)                                      put (obj) in (cont)                 2                 x
------ put_near                                                    put (obj) near (bulk)               2                 x
------ put_on                                                      put (obj) on (surface)              2                 x
------ put_under                                                   put (obj) under (bulk)              2                 x
------ read                                                        read (obj)                          1                 x
------ remove                      remove (obj)           1         x
+----- pry                                                         pry (obj)                           1       x
+----- pry_with                                                    pry (obj) with (instr)              2       x
+----- pull                                                        pull (obj)                          1       x
+----- push                                                        push (obj)                          1       x
+----- push_with                                                   push (obj) with (instr)             2       x
+----- put         (+ lay, place)                                  put (obj)                           1       x
+----- put_against                                                 put (obj) against (bulk))           2       x
+----- put_behind                                                  put (obj) behind (bulk)             2       x
+----- put_down                                                    put down (obj)                      1       x
+----- put_in      (+ insert)                                      put (obj) in (cont)                 2       x
+----- put_near                                                    put (obj) near (bulk)               2       x
+----- put_on                                                      put (obj) on (surface)              2       x
+----- put_under                                                   put (obj) under (bulk)              2       x
+----- read                                                        read (obj)                          1       x
+----- remove                                                      remove (obj)                        1       x
 ----- restart                                                     restart                             0
 ----- restore                                                     restore                             0
------ rub                                                         rub (obj)                           1                 x
+----- rub                                                         rub (obj)                           1       x
 ----- save                                                        save                                0
 ----- say                                                         say (topic)                         1
 ----- say_to                                                      say (topic) to (act)                2
 ----- score                                                       score                               0
------ scratch                                                     scratch (obj)                       1                 x
+----- scratch                                                     scratch (obj)                       1       x
 ----- script                                                      script. script on. script off.      0
------ search                                                      search (obj)                        1                 x
+----- search                                                      search (obj)                        1       x
 ----- sell                                                        sell (item)                         1
------ shake                                                       shake (obj)                         1                 x
+----- shake                                                       shake (obj)                         1       x
 ----- shoot (at)                                                  shoot at (target)                   1
 ----- shoot_with                                                  shoot (target) with (weapon)        2
 ----- shout       (+ scream, yell)                                shout                               0
------ show        (+ reveal)                                      show (obj) to (act)                 2                 x
+----- show        (+ reveal)                                      show (obj) to (act)                 2       x
 ----- sing                                                        sing                                0
 ----- sip                                                         sip (liq)                           1
 ----- sit (down)                                                  sit.  sit down.                     0
@@ -138,20 +138,20 @@
 ----- sleep       (+ rest)                                        sleep                               0
 ----- smell0                                                      smell                               0
 ----- smell                                                       smell (odour)                       1
------ squeeze                                                     squeeze (obj)                       1                 x
+----- squeeze                                                     squeeze (obj)                       1       x
 ----- stand (up)                                                  stand.  stand up.                   0
 ----- stand_on                                                    stand on (surface)                  1
 ----- swim                                                        swim                                0
 ----- swim_in                                                     swim in (liq)                       1
------ switch                      switch (obj)              1       x
------ switch_on   (defined at the verb 'turn_on')       switch on (app)                     1
------ switch_off  (defined at the verb 'turn_off')        switch off (app)                    1
------ take        (+ carry, get, grab, hold, obtain)              take (obj)                          1                 x
------ take_from   (+ remove from)                                 take (obj) from (holder)            2                 x
+----- switch                                                      switch (obj)                        1       x
+----- switch_on   (defined at the verb 'turn_on')                 switch on (app)                     1
+----- switch_off  (defined at the verb 'turn_off')                switch off (app)                    1
+----- take        (+ carry, get, grab, hold, obtain)              take (obj)                          1       x
+----- take_from   (+ remove from)                                 take (obj) from (holder)            2       x
 ----- talk                                                        talk                                0
 ----- talk_to     (+ speak)                                       talk to (act)                       1
------ taste       (+ lick)                                        taste (obj)                         1                 x
------ tear        (+ rip)                                         tear (obj)                          1                 x
+----- taste       (+ lick)                                        taste (obj)                         1       x
+----- tear        (+ rip)                                         tear (obj)                          1       x
 ----- tell        (+ enlighten, inform)                           tell (act) about (topic)            2
 ----- think                                                       think                               0
 ----- think_about                                                 think about (topic)                 1
@@ -159,27 +159,27 @@
 ----- throw_at                                                    throw (projectile) at (target)      2
 ----- throw_in                                                    throw (projectile) in (cont)        2
 ----- throw_to                                                    throw (projectile) to (recipient)   2
------ tie                                                         tie (obj)                           1                 x
------ tie_to                                                      tie (obj) to (target)               2                 x
------ touch       (+ feel)                                        touch (obj)                         1                 x
------ turn        (+ rotate)                                      turn (obj)                          1                 x
+----- tie                                                         tie (obj)                           1       x
+----- tie_to                                                      tie (obj) to (target)               2       x
+----- touch       (+ feel)                                        touch (obj)                         1       x
+----- turn        (+ rotate)                                      turn (obj)                          1       x
 ----- turn_on                                                     turn on (app)                       1
 ----- turn_off                                                    turn off (app)                      1
------ undress                     undress               0
------ unlock                                                      unlock (obj)                        1                 x
------ unlock_with                                                 unlock (obj) with (key)             2                 x
------ use                                                         use (obj)                           1                 x
------ use_with                                                    use (obj) with (instr)              2                 x
+----- undress                                                     undress                             0
+----- unlock                                                      unlock (obj)                        1       x
+----- unlock_with                                                 unlock (obj) with (key)             2       x
+----- use                                                         use (obj)                           1       x
+----- use_with                                                    use (obj) with (instr)              2       x
 ----- verbose                                                     verbose                             0
 ----- wait        (+ z)                                           wait                                0
------ wear                        wear (obj)           1         x
+----- wear                                                        wear (obj)                          1       x
 ----- what_am_i                                                   what am i                           0
------ what_is                                                     what is (obj)                       1                 x
+----- what_is                                                     what is (obj)                       1       x
 ----- where_am_i                                                  where am i                          0
------ where_is                                                    where is (obj)                      1                 x
+----- where_is                                                    where is (obj)                      1       x
 ----- who_am_i                                                    who am i                            0
------ who_is                                                      who is (obj)                        1                 x
------ write                                                       write (txt) on (obj)                2                 x
+----- who_is                                                      who is (obj)                        1       x
+----- write                                                       write (txt) on (obj)                2       x
 ----- yes                                                         yes                                 0
 
 

--- a/mygame_import.i
+++ b/mygame_import.i
@@ -3,17 +3,17 @@
 -- An auxiliary game source file for ALAN Standard Library v2.1.
 
 
--- This file is not one of the library files and not necessary for running a game 
--- which uses the library. 
+-- This file is not one of the library files and not necessary for running a game
+-- which uses the library.
 
 -- This file lists all attributes of the my_game instance (declared
--- in the library file 'definitions.i') and all verb outcomes (declared in 'verbs.i'), 
+-- in the library file 'definitions.i') and all verb outcomes (declared in 'verbs.i'),
 -- for easy editing and modification.
 
 -- USAGE: if you need to edit/change a great number of pre-declared library messages
--- (verb outcomes, verb check messages, illegal parameter messages etc.) for your game, e.g. 
+-- (verb outcomes, verb check messages, illegal parameter messages etc.) for your game, e.g.
 -- when you are writing in another language or if you intend to use an unusual
--- person/tense in your game's narrative, please edit the default messages in this file. 
+-- person/tense in your game's narrative, please edit the default messages in this file.
 -- Then, import this file into your main source file, together with the five library files.
 -- The library files don't need to be edited (except if you wish to reword standard runtime
 -- messages found in  'messages.i').
@@ -22,53 +22,53 @@
 -- you import that instance to your game in this file.
 
 
--- NOTE 2: This file doesn't contain the responses for verb outcomes in 'lib_classes.i' nor 
--- some marginal messages for the behaviour of indoor and outdoor objects in 'lib_locations.i'.  
+-- NOTE 2: This file doesn't contain the responses for verb outcomes in 'lib_classes.i' nor
+-- some marginal messages for the behaviour of indoor and outdoor objects in 'lib_locations.i'.
 
 -- To change verb outcomes for classes predefined in 'lib_classes,i', add the change in this
 -- file at the applicable verb in the list of verbs further below, in the following way:
 
--- In this example, the author has changed the response for the verb 'look_through' for 
+-- In this example, the author has changed the response for the verb 'look_through' for
 -- the class WINDOW:
 
-	
-		-- VERB look_through
-			-- DOES ONLY
-				-- IF THIS ISA WINDOW
-					-- THEN "You see the garden outside the house."  
-						-- -- the above would be the default outcome for all windows in the game.
-					-- ELSE "You can't see through" SAY THE bulk. "."
-						-- -- this is the original default response defined by the library, 
-						-- -- and in the list of verbs further below.
-				-- END IF.
-		-- END VERB.
+
+    -- VERB look_through
+      -- DOES ONLY
+        -- IF THIS ISA WINDOW
+          -- THEN "You see the garden outside the house."
+            -- -- the above would be the default outcome for all windows in the game.
+          -- ELSE "You can't see through" SAY THE bulk. "."
+            -- -- this is the original default response defined by the library,
+            -- -- and in the list of verbs further below.
+        -- END IF.
+    -- END VERB.
 
 
--- Above, the author has added an IF clause to cater for both window objects and other objects. 
+-- Above, the author has added an IF clause to cater for both window objects and other objects.
 -- The 'lib_classes.i' file won't have to be edited.
 
-	
+
 -- (To change the verb outcome for any verb applying to a class you have created yourself:
 -- For example:
 
-	-- EVERY cat ISA ACTOR
+  -- EVERY cat ISA ACTOR
 
-           -- VERB examine 
-			-- DOES ONLY “It’s just an ordinary cat.”
-		-- END VERB.
+           -- VERB examine
+      -- DOES ONLY ?It?s just an ordinary cat.?
+    -- END VERB.
 
-	-- END EVERY. 	
+  -- END EVERY.
 
- 	-- etc.)
+  -- etc.)
 
 
 -- To add a check of your own to any library verb, just add the check to the verb definition in
 -- the list of verbs below, for example:
 
 -- VERB jump
---	CHECK strength OF hero > 5          -- your own check, added in this file and not in  
---		ELSE "You feel too weak."             -- the library files!
---	DOES "You jump on the spot, to no avail."
+--  CHECK strength OF hero > 5          -- your own check, added in this file and not in
+--    ELSE "You feel too weak."             -- the library files!
+--  DOES "You jump on the spot, to no avail."
 -- END VERB.
 
 
@@ -81,383 +81,383 @@
 THE my_game ISA DEFINITION_BLOCK
 
 
-	-- attributes for the game banner; edit these to suit your own game:
-	-- =================================================================
+  -- attributes for the game banner; edit these to suit your own game:
+  -- =================================================================
 
-	HAS title "My New Game".		
-    	HAS subtitle "".	 -- leaving this empty won't show the subtitle line in your game's banner  	
-    	HAS author "An ALAN Author".   	-- put your name/pseudonym here
-    	HAS year 0000.			-- change this to the current year		
-    	HAS version "1".	 -- setting this to 0 won't show the version line in your game's banner 				
-    	
+  HAS title "My New Game".
+      HAS subtitle "".   -- leaving this empty won't show the subtitle line in your game's banner
+      HAS author "An ALAN Author".    -- put your name/pseudonym here
+      HAS year 0000.      -- change this to the current year
+      HAS version "1".   -- setting this to 0 won't show the version line in your game's banner
 
-	-- messages for the hero:
-	-- ======================
 
-	-- The hero is not defined as an instance in the library; the game author
-	-- has all the freedom to define the hero as (s)he sees fit. However,
-	-- there are some messages for the hero defined in the library. These can be
-	-- easily overridden. Two of these messages are right here, the rest are
-	-- e.g. in verb checks.
+  -- messages for the hero:
+  -- ======================
 
-	HAS hero_worn_header "You are wearing".
-	HAS hero_worn_else "You are not wearing anything.".	
-
-	-- These messages are shown when you add "LIST worn." for example to the 'examine' verb.
+  -- The hero is not defined as an instance in the library; the game author
+  -- has all the freedom to define the hero as (s)he sees fit. However,
+  -- there are some messages for the hero defined in the library. These can be
+  -- easily overridden. Two of these messages are right here, the rest are
+  -- e.g. in verb checks.
 
+  HAS hero_worn_header "You are wearing".
+  HAS hero_worn_else "You are not wearing anything.".
 
-	-- description messages for dark locations:
-	-- =======================================
-
-	HAS dark_loc_desc "It is pitch black. You can't see anything at all.".
-
-	HAS light_goes_off "It is now pitch black.".
-		-- This message is shown when a light goes off and the location becomes dark.
-	
-
-	-- response for restricted actions:
-	-- ================================
+  -- These messages are shown when you add "LIST worn." for example to the 'examine' verb.
 
-	HAS restricted_response "You can't do that.".
-		-- This message is shown whenever the player used a verb that has been disabled
-		 -- by the "CAN NOT [verb]." or verbs_disabled attributes (see the library manual).
-
-	HAS restricted_level 0.
-		-- by default, all verbs work in the normal way
 
+  -- description messages for dark locations:
+  -- =======================================
 
-
-	-- all illegal parameter messages, typically found in the ELSE parts of SYNTAX structures and
-	-- the first two below being by far the most common.
-	-- ==========================================================================================
-
-
-	-- the general message for when a parameter is not suitable with the verb:
-	--------------------------------------------------------------------------
-
- 	HAS illegal_parameter_sg "That's not something you can $v.".				-- (numerous)
-	HAS illegal_parameter_pl "Those are not something you can $v.".
-
-
-	-- variations of the above message when a preposition is required after the verb:
-	---------------------------------------------------------------------------------
-
-	HAS illegal_parameter_about_sg "That's not something you can $v about.".		-- ask_about, tell_about, think_about
-	HAS illegal_parameter_about_pl "Those are not something you can $v about.".
-	HAS illegal_parameter_at "You can't $v anything at $+2.".					-- fire_at, throw_at
-	HAS illegal_parameter_for_sg "That's not something you can $v for.".			-- ask_for
-	HAS illegal_parameter_for_pl "Those are not something you can $v for.".
-	HAS illegal_parameter2_from_sg "That's not something you can take things from.".	-- take_from
-	HAS illegal_parameter2_from_pl "Those are not something you can take things from.".
-	HAS illegal_parameter_in_sg "That's not something you can $v in.".			-- dive_in, jump_in, lie_in, swim_in
-	HAS illegal_parameter_in_pl "Those are not something you can $v in.".
-	HAS illegal_parameter_on_sg "That's not something you can $v on.".			-- climb_on, jump_on, knock, lie_on, sit_on,
-																  -- stand_on, switch_on, turn_on
-	HAS illegal_parameter_on_pl "Those are not something you can $v on.".
-	HAS illegal_parameter_off_sg "That's not something you can $v off.".			-- get_off, switch_off, turn_off
-	HAS illegal_parameter_off_pl "Those are not something you can $v off.".
-	HAS illegal_parameter_to_sg "That's not something you can $v to.".			-- listen_to, talk_to
-	HAS illegal_parameter_to_pl "Those are not something you can $v to.".
-	HAS illegal_parameter2_to_sg "That's not something you can $v things to.".		-- give, show, tell, tie_to, throw_to
-	HAS illegal_parameter2_to_pl "Those are not something you can $v things to.".	
-	HAS illegal_parameter_with_sg "That's not something you can $v with.".		-- kill_with, shoot_with, play_with
-	HAS illegal_parameter_with_pl "Those are not something you can $v with.".	
-	HAS illegal_parameter2_with_sg "That's not something you can $v things with.".	-- attack_with, break_with, burn_with, close_with, 
-																 -- + cut_with, fill_with, lock_with, open_with, pry_with,
-																 -- + push_with, unlock_with
-	HAS illegal_parameter2_with_pl "Those are not something you can $v things with.".
-		
-
-	-- other illegal parameter messages:
-	------------------------------------ 
-
-
-	HAS illegal_parameter_act "That doesn't make sense.".							-- empty_in, pour_in, put_in, throw_in
-	
-	HAS illegal_parameter_consult_sg "That's not something you can find information		-- consult_about
-								about.".
-	HAS illegal_parameter_consult_pl "Those are not something you can find 			
-								information about.".
-
-	HAS illegal_parameter_examine_sg "That's not something you can examine.".			-- examine
-	HAS illegal_parameter_examine_pl "Those are not something you can examine.".
-
-	HAS illegal_parameter_go "You can't go there.".								-- go_to
-
-	HAS illegal_parameter_look_out_sg "That's not something you can look out of.".		-- look_out_of  
-	HAS illegal_parameter_look_out_pl "Those are not something you can look out of.".
-	HAS illegal_parameter_look_through "You can't look through $+1.".				-- look_through  
-
-	HAS illegal_parameter_obj "You can only $v objects.".							-- give, put, put_in, put_on, put_against,
-																	   -- + put_behind, put_near, put_under,
-																	   -- + throw_at, throw_in, throw_to, tie_to,
-																	   -- + use, use_with
-
-	HAS illegal_parameter_string "Please state inside double quotes ("""") what you want to $v.".	-- answer, say, say_to, write
-	
-	HAS illegal_parameter_talk_sg "That's not something you can talk to.".			-- ask, ask_for, say_to, tell
-	HAS illegal_parameter_talk_pl "Those are not something you can talk to.".
-
-	HAS illegal_parameter_there "It's not possible to $v there.".					-- look_behind, look_in, look_under 
-	HAS illegal_parameter2_there "It's not possible to $v anything there.".    		-- empty_in, empty_on, pour_in, pour_on, put_in,  
-															    		 -- + put_on, put_against, put_behind, put_near, 
-																	 -- + put_under, throw_in, throw_to, tie_to, write
-
-	HAS illegal_parameter_what_sg "That's not something I know about.".				-- what_is, where_is
-	HAS illegal_parameter_what_pl "Those are not something I know about.".			-- what_is, where_is
-	HAS illegal_parameter_who_sg "That's not somebody I know about.".				-- who_is
-	HAS illegal_parameter_who_pl "Those are not somebody I know about.".				-- who_is
-		
-	
-	-- verb check messages, found before DOES sections of verbs and used mainly in 'verbs.i':	
-	-- ======================================================================================
-
-
-	-- a) attribute checks
-	----------------------
-
-		
-	-- the general check message for when an instance cannot be used with the verb :
-	--------------------------------------------------------------------------------	
-		
-	HAS check_obj_suitable_sg "That's not something you can $v.".				-- (numerous)				
-	HAS check_obj_suitable_pl "Those are not something you can $v.".
-
-
-	-- variations of the above message, needed e.g. when a preposition is required after the verb:
-	----------------------------------------------------------------------------------------------
-
-	HAS check_obj_suitable_at "You can't $v anything at $+2.".					-- fire_at, throw_at, throw_to
-	HAS check_obj2_suitable_for_sg "That's not something you can $v for.".		-- ask_for
-	HAS check_obj2_suitable_for_pl "Those are not something you can $v for.".
-	HAS check_obj_suitable_off_sg "That's not something you can $v off.".			-- turn_off, switch_off
-	HAS check_obj_suitable_off_pl "Those are not something you can $v off.".
-	HAS check_obj_suitable_on_sg "That's not something you can $v on.".			-- knock, switch_on, turn_on
-	HAS check_obj_suitable_on_pl "Those are not something you can $v on."	.	
-	HAS check_obj_suitable_with_sg "That's not something you can $v with.".		-- play_with
-	HAS check_obj_suitable_with_pl "Those are not something you can $v with.".		
-	HAS check_obj2_suitable_with_sg "That's not something you can $v things with.".	  -- break_with, burn_with, close_with, cut_with, fill_with, 
-	HAS check_obj2_suitable_with_pl "Those are not something you can $v things with.".	 -- + lock_with, open_with, pry_with, push_with,
-																	 -- + touch_with, unlock_with
-
-	HAS check_obj_suitable_examine_sg "That's not something you can examine.".			-- examine
-	HAS check_obj_suitable_examine_pl "Those are not something you can examine.".		-- examine
-
-	HAS check_obj_suitable_look_out_sg "That's not something you can look out of.".		-- look_out_of
-	HAS check_obj_suitable_look_out_pl "Those are not something you can look out of.".			
-	HAS check_obj_suitable_look_through "You can't look through $+1.".				-- look_through
-
-
-	-- checks for open, closed and locked objects:
-	----------------------------------------------
-
-	HAS check_obj_not_open_sg "$+1 is already open.".					-- open, open_with
-	HAS check_obj_not_open_pl "$+1 are already open.".
-	HAS check_obj_open1_sg "$+1 is already closed.".					-- close, close_with
-	HAS check_obj_open1_pl "$+1 are already closed.".
-	HAS check_obj_open2_sg "You can't, since $+1 is closed.".				-- empty (in/on), look_in, pour (in/on)
-	HAS check_obj_open2_pl "You can't, since $+1 are closed.".
-	HAS check_obj2_open_sg "You can't, since $+2 is closed.".				-- empty_in, pour_in, put_in, throw_in
-	HAS check_obj2_open_pl "You can't, since $+2 are closed.".
-	HAS check_obj_locked_sg "$+1 is already unlocked.".					-- unlock, unlock_with
-	HAS check_obj_locked_pl "$+1 are already unlocked.".
-	HAS check_obj_not_locked_sg "$+1 is already locked.". 				-- lock, lock_with
-	HAS check_obj_not_locked_pl "$+1 are already locked.".
-	
-
-
-	-- checks for "not reachable" and "distant" objects:
-	----------------------------------------------------
-
-	HAS check_obj_reachable_sg "$+1 is out of your reach.".				-- (numerous)
-	HAS check_obj_reachable_pl "$+1 are out of your reach.".
-	HAS check_obj2_reachable_sg "$+2 is out of your reach.".				-- empty_in, fill_with, put_in, take_from, tie_to			
-	HAS check_obj2_reachable_pl "$+2 are out of your reach.".
-	HAS check_obj_reachable_ask "$+1 can't reach $+2.".					-- ask_for
-	HAS check_obj_not_distant_sg "$+1 is too far away.".					-- (numerous)
-	HAS check_obj_not_distant_pl "$+1 are too far away.".
-	HAS check_obj2_not_distant_sg "$+2 is too far away.".					-- empty_in, fill_with, pour_in, put_in, show, take_from,  																 -- + throw_at, throw_in, throw_to
-	HAS check_obj2_not_distant_pl "$+2 are too far away.".
-	
-
-	-- checks for the hero sitting or lying_down:
-	---------------------------------------------
-
-	HAS check_hero_not_sitting1 "It is difficult to $v while sitting down.".   		-- (with many intransitive verbs)
-	HAS check_hero_not_sitting2 "It is difficult to $v anything while sitting down.".	-- (with many transitive verbs)
-	HAS check_hero_not_sitting3 "It is difficult to $v anywhere while sitting down.".	-- (with many verbs of motion)
-	HAS check_hero_not_sitting4 "You're sitting down already.".					-- sit, sit_on
-	HAS check_hero_not_lying_down1 "It is difficult to $v while lying down.".			-- (with many intransitive verbs)
-	HAS check_hero_not_lying_down2 "It is difficult to $v anything while lying down.".	-- (with many transitive verbs)
-	HAS check_hero_not_lying_down3 "It is difficult to $v anywhere while lying down.".	-- (with many verbs of motion)
-	HAS check_hero_not_lying_down4 "You're lying down already.".					-- lie_down, lie_in
-
-
-	-- other attribute checks:
-	--------------------------
-
-	HAS check_act_can_talk_sg "That's not something you can talk to.".				-- ask, ask_for, say_to, tell
-	HAS check_act_can_talk_pl "Those are not something you can talk to.". 
-
-	HAS check_obj_allowed_in_sg "$+1 doesn't belong in $+2.".						-- empty_in, pour_in, put_in, throw_in
-    	HAS check_obj_allowed_in_pl "$+1 don't belong in $+2.". 							
-		
-	HAS check_obj_broken_sg "That doesn't need fixing.".  						-- fix					
-	HAS check_obj_broken_pl "Those don't need fixing.".
-
-	HAS check_obj_inanimate1 "$+1 wouldn't probably appreciate that.".				-- push, push_with, scratch, search
-	HAS check_obj_inanimate2 "You are not sure whether $+1 would appreciate that.".		-- rub, touch, touch_with
-	
-	HAS check_obj_movable "It's not possible to $v $+1.".							-- lift, pull, push, push_with, shake, take, take_from
-			
-	HAS check_obj_not_scenery_sg "$+1 is not important.".							-- examine, take, take_from
-	HAS check_obj_not_scenery_pl "$+1 are not important.".
-
-	HAS check_obj2_not_scenery_sg "$+1 is not important.".						-- ask_for, take_from
-	HAS check_obj2_not_scenery_pl "$+1 are not important.".
-	
-	HAS check_obj_suitable_there "It's not possible to $v there.".					-- look_behind, look_in, look_under
-	HAS check_obj2_suitable_there "It's not possible to $v anything there.".			-- throw_in, tie_to
-
-	HAS check_obj_takeable "You don't have $+1.".							-- (numerous; this check is in verbs with implicit taking)
-	HAS check_obj2_takeable1 "You don't have $+2.".								-- fill_with
-	HAS check_obj2_takeable2 "You can't have $+2.".								-- ask_for
-	
-	HAS check_obj_weight_sg "$+1 is too heavy to $v.".							-- lift, take, take_from
-	HAS check_obj_weight_pl "$+1 are too heavy to $v.".
-
-	HAS check_obj_writeable "Nothing can be written there.".						-- write
-
-
-	-- b) location and containment checks for actors and objects
-	------------------------------------------------------------
-
-
-	-- containment checks for actors other than the hero (checks for the hero are listed separately below):
-	-------------------------------------------------------------------------------------------------------
-	
-	HAS check_act_near_hero "You don't quite know where $+1 went.  					-- follow
-		You should state a direction where you want to go.".
-
-	HAS check_obj_in_act_sg "$+2 doesn't have $+1.".							-- take_from
-	HAS check_obj_in_act_pl "$+2 don't have $+1.".
-	HAS check_obj_not_in_act_sg "$+2 already has $+1.".							-- give
-	HAS check_obj_not_in_act_pl "$+2 already have $+1.". 
-
-
-	-- location and containment checks for the hero:
-	------------------------------------------------
-
-	HAS check_count_weapon_in_hero "You are not carrying any firearms.".				-- shoot
-
-	HAS check_obj_not_at_hero_sg "$+1 is right here.".  							-- find, follow, go_to, where_is
-	HAS check_obj_not_at_hero_pl "$+1 are right here.".
-	HAS check_obj_in_hero "You don't have the $+1.".							-- drop, fire, fire_at, put, show
-	HAS check_obj2_in_hero "You don't have the $+2.".							-- (numerous)
-	HAS check_obj_not_in_hero1 "It doesn't make sense to $v something you're holding.".  	-- attack, attack_with, kick, lift, shoot, shoot_with
-	HAS check_obj_not_in_hero2 "You already have $+1.".							-- take, take_from
-	HAS check_obj2_not_in_hero1 "You are carrying $+2.".   						-- throw_at, throw_in, throw_to
-	HAS check_obj2_not_in_hero2 "That would be futile.".							-- put_against, put_behind, put_near, put_under
-	HAS check_obj2_not_in_hero3 "You already have $+2.".							-- ask_for
-
-
-	-- checking whether an object is in a container or not:
-	-------------------------------------------------------
-
-	HAS check_cont_not_in_obj "That doesn't make sense.".							-- empty_in, pour_in, put_in
-	HAS check_obj_in_cont_sg "$+1 is not in $+2.".								-- take_from
-	HAS check_obj_in_cont_pl "$+1 are not in $+2.".
-	HAS check_obj_not_in_cont_sg "$+1 is in $+2 already.".						-- put_in, throw_in
-	HAS check_obj_not_in_cont_pl "$+1 are in $+2 already.".
-	HAS check_obj_not_in_cont2 "$+1 is already full of $+2.".						-- fill_with
-
-
-	-- checking whether an object is on a surface or not:
-	-----------------------------------------------------
-	
-	HAS check_obj_on_surface_sg "$+1 is not on $+2.".							-- take_from
-	HAS check_obj_on_surface_pl "$+1 are not on $+2.".
-	HAS check_obj_not_on_surface_sg "$+1 is already on $+2.".						-- put_on
-	HAS check_obj_not_on_surface_pl "$+1 are already on $+2.".
-	
-
-	-- checking whether an object is worn or not:
-	---------------------------------------------	
-
-	HAS check_obj_in_worn "You are not wearing $+1.".    							-- remove, take_off ('classes.i')
-	HAS check_obj_not_in_worn1 "You are already wearing $+1.".   					-- put_on, wear ('classes.i')
-    	HAS check_obj_not_in_worn2 "It doesn't make sense to $v something you're wearing.".	-- attack, attack_with, kick, shoot, shoot_with
-	HAS check_obj_not_in_worn3 "You'll have to take off $+1 first.".				-- drop
-    	
-
-	-- c) checking location states
-	------------------------------	
-
-    	HAS check_current_loc_lit "It is too dark to see.".						-- (numerous)
-
-
-	-- d) checks guarding against actions directed at the hero him-/herself
-	-----------------------------------------------------------------------
-
-	HAS check_obj_not_hero1 "It doesn't make sense to $v yourself.".			-- ask, ask_for, attack, attack_with, catch, follow
-																   -- kick, listen, pull, push, push_with, take,
-																   -- take_from, tell 
-	HAS check_obj_not_hero2 "There is no need to be that desperate.".  			-- fire_at, kill, kill_with, shoot, shoot_with
-	HAS check_obj_not_hero3 "That wouldn't accomplish anything.".				-- scratch, touch
-	HAS check_obj_not_hero4 "You're right here.".							-- find, go_to
-	HAS check_obj_not_hero5 "You don't need to be freed.".					-- free
-	HAS check_obj_not_hero6 "There is no time for that now.".								-- kiss, play_with, rub
-	HAS check_obj_not_hero7 "Turning your head, you notice nothing unusual behind yourself.".		-- look_behind 
-	HAS check_obj_not_hero8 "You notice nothing unusual under yourself.".						-- look_under
-	HAS check_obj2_not_hero1 "That doesn't make sense.".						-- say_to, show, take_from, touch_with, throw_at/in/to
-	HAS check_obj2_not_hero2 "That would be futile.".						-- put_against, put_behind, put_near, put_under
-	HAS check_obj2_not_hero3 "You can't $v things to yourself.".				-- give, tie_to
-
-
-	-- e) checks guarding against actions where an object is used with itself
-	-------------------------------------------------------------------------
-
-	HAS check_obj_not_obj2_at "It doesn't make sense to $v something at itself.".		-- fire_at, throw_at
-	HAS check_obj_not_obj2_from "It doesn't make sense to $v something from itself.".	-- take_from
-	HAS check_obj_not_obj2_in "It doesn't make sense to $v something into itself.".		-- empty_in, pour_in, put_in, throw_in
-	HAS check_obj_not_obj2_on "It doesn't make sense to $v something onto itself.".		-- empty_on, pour_on, put_on
-	HAS check_obj_not_obj2_to "It doesn't make sense to $v something to itself.".		-- give, show, throw_to, tie_to
-	HAS check_obj_not_obj2_with "It doesn't make sense to $v something with itself.".  	-- attack_with, break_with, burn_with, close_with, 																		   -- + cut_with, fill_with, lock_with, 
-																	   -- + open_with, push_with, pry_with, shoot_with,  
-																	   -- + touch_withm unlock_with, use_with
-	
-	HAS check_obj_not_obj2_put "That doesn't make sense."	.					-- put_against, put_behind, put_near, put_under
-
-	
-    	-- f) additional checks for classes:
-	------------------------------------
-
-	HAS check_clothing_sex "On second thoughts you decide $+1 won't really suit you.".			-- clothing: wear
-	HAS check_cont_not_supporter "You can't put $+1 inside $+2.".							-- supporter: put_in
-	HAS check_device_on_sg "$+1 is already off.". 										-- device: turn_off, switch_off
-	HAS check_device_on_pl "$+1 are already off.".
-	HAS check_device_not_on_sg "$+1 is already on.". 									-- device: turn_on, switch_on
-	HAS check_device_not_on_pl "$+1 are already on.".
-	HAS check_door_matching_key "You can't use $+2 to $v $+1.".							-- door: lock_with, unlock_with	
-	HAS check_lightsource_lit_sg "But $+1 is not lit.".									-- lightsource: extinguish, turn_off
-	HAS check_lightsource_lit_pl "But $+1 are not lit.".
-	HAS check_lightsource_not_lit_sg "$+1 is already lit.".								-- lightsource: light, turn_on
-	HAS check_lightsource_not_lit_pl "$+1 are already lit.".
-	HAS check_lightsource_switchable_sg "That's not something you can switch on and off."	.		-- lightsource: switch 
-	HAS check_lightsource_switchable_pl "Those are not something you can switch on and off.".
-	HAS check_liquid_vessel_not_cont "You can't carry $+1 around in your bare hands.".			-- liquid: take_from
-	HAS check_obj_not_broken "Nothing happens.".										-- device, lightsource: light, switch, turn_on
-
-
-	-- messages for implicit taking:
-	-- =============================
-
-    	HAS implicit_taking_message "(taking $+1 first)$n".	
-
-	-- The following verbs are preceded by implicit taking:
-			-- bite, drink, eat, empty, empty_in, empty_on, give, pour, pour_in, pour_on,  
-			-- put_in, put_on, throw, throw_at, throw_in, throw_to, tie_to.
-	-- In ditransitive verbs, only the first parameter (the direct object) is taken implicitly.
+  HAS dark_loc_desc "It is pitch black. You can't see anything at all.".
+
+  HAS light_goes_off "It is now pitch black.".
+    -- This message is shown when a light goes off and the location becomes dark.
+
+
+  -- response for restricted actions:
+  -- ================================
+
+  HAS restricted_response "You can't do that.".
+    -- This message is shown whenever the player used a verb that has been disabled
+     -- by the "CAN NOT [verb]." or verbs_disabled attributes (see the library manual).
+
+  HAS restricted_level 0.
+    -- by default, all verbs work in the normal way
+
+
+
+  -- all illegal parameter messages, typically found in the ELSE parts of SYNTAX structures and
+  -- the first two below being by far the most common.
+  -- ==========================================================================================
+
+
+  -- the general message for when a parameter is not suitable with the verb:
+  --------------------------------------------------------------------------
+
+  HAS illegal_parameter_sg "That's not something you can $v.".        -- (numerous)
+  HAS illegal_parameter_pl "Those are not something you can $v.".
+
+
+  -- variations of the above message when a preposition is required after the verb:
+  ---------------------------------------------------------------------------------
+
+  HAS illegal_parameter_about_sg "That's not something you can $v about.".    -- ask_about, tell_about, think_about
+  HAS illegal_parameter_about_pl "Those are not something you can $v about.".
+  HAS illegal_parameter_at "You can't $v anything at $+2.".         -- fire_at, throw_at
+  HAS illegal_parameter_for_sg "That's not something you can $v for.".      -- ask_for
+  HAS illegal_parameter_for_pl "Those are not something you can $v for.".
+  HAS illegal_parameter2_from_sg "That's not something you can take things from.".  -- take_from
+  HAS illegal_parameter2_from_pl "Those are not something you can take things from.".
+  HAS illegal_parameter_in_sg "That's not something you can $v in.".      -- dive_in, jump_in, lie_in, swim_in
+  HAS illegal_parameter_in_pl "Those are not something you can $v in.".
+  HAS illegal_parameter_on_sg "That's not something you can $v on.".      -- climb_on, jump_on, knock, lie_on, sit_on,
+                                  -- stand_on, switch_on, turn_on
+  HAS illegal_parameter_on_pl "Those are not something you can $v on.".
+  HAS illegal_parameter_off_sg "That's not something you can $v off.".      -- get_off, switch_off, turn_off
+  HAS illegal_parameter_off_pl "Those are not something you can $v off.".
+  HAS illegal_parameter_to_sg "That's not something you can $v to.".      -- listen_to, talk_to
+  HAS illegal_parameter_to_pl "Those are not something you can $v to.".
+  HAS illegal_parameter2_to_sg "That's not something you can $v things to.".    -- give, show, tell, tie_to, throw_to
+  HAS illegal_parameter2_to_pl "Those are not something you can $v things to.".
+  HAS illegal_parameter_with_sg "That's not something you can $v with.".    -- kill_with, shoot_with, play_with
+  HAS illegal_parameter_with_pl "Those are not something you can $v with.".
+  HAS illegal_parameter2_with_sg "That's not something you can $v things with.".  -- attack_with, break_with, burn_with, close_with,
+                                 -- + cut_with, fill_with, lock_with, open_with, pry_with,
+                                 -- + push_with, unlock_with
+  HAS illegal_parameter2_with_pl "Those are not something you can $v things with.".
+
+
+  -- other illegal parameter messages:
+  ------------------------------------
+
+
+  HAS illegal_parameter_act "That doesn't make sense.".             -- empty_in, pour_in, put_in, throw_in
+
+  HAS illegal_parameter_consult_sg "That's not something you can find information   -- consult_about
+                about.".
+  HAS illegal_parameter_consult_pl "Those are not something you can find
+                information about.".
+
+  HAS illegal_parameter_examine_sg "That's not something you can examine.".     -- examine
+  HAS illegal_parameter_examine_pl "Those are not something you can examine.".
+
+  HAS illegal_parameter_go "You can't go there.".               -- go_to
+
+  HAS illegal_parameter_look_out_sg "That's not something you can look out of.".    -- look_out_of
+  HAS illegal_parameter_look_out_pl "Those are not something you can look out of.".
+  HAS illegal_parameter_look_through "You can't look through $+1.".       -- look_through
+
+  HAS illegal_parameter_obj "You can only $v objects.".             -- give, put, put_in, put_on, put_against,
+                                     -- + put_behind, put_near, put_under,
+                                     -- + throw_at, throw_in, throw_to, tie_to,
+                                     -- + use, use_with
+
+  HAS illegal_parameter_string "Please state inside double quotes ("""") what you want to $v.". -- answer, say, say_to, write
+
+  HAS illegal_parameter_talk_sg "That's not something you can talk to.".      -- ask, ask_for, say_to, tell
+  HAS illegal_parameter_talk_pl "Those are not something you can talk to.".
+
+  HAS illegal_parameter_there "It's not possible to $v there.".         -- look_behind, look_in, look_under
+  HAS illegal_parameter2_there "It's not possible to $v anything there.".       -- empty_in, empty_on, pour_in, pour_on, put_in,
+                                       -- + put_on, put_against, put_behind, put_near,
+                                   -- + put_under, throw_in, throw_to, tie_to, write
+
+  HAS illegal_parameter_what_sg "That's not something I know about.".       -- what_is, where_is
+  HAS illegal_parameter_what_pl "Those are not something I know about.".      -- what_is, where_is
+  HAS illegal_parameter_who_sg "That's not somebody I know about.".       -- who_is
+  HAS illegal_parameter_who_pl "Those are not somebody I know about.".        -- who_is
+
+
+  -- verb check messages, found before DOES sections of verbs and used mainly in 'verbs.i':
+  -- ======================================================================================
+
+
+  -- a) attribute checks
+  ----------------------
+
+
+  -- the general check message for when an instance cannot be used with the verb :
+  --------------------------------------------------------------------------------
+
+  HAS check_obj_suitable_sg "That's not something you can $v.".       -- (numerous)
+  HAS check_obj_suitable_pl "Those are not something you can $v.".
+
+
+  -- variations of the above message, needed e.g. when a preposition is required after the verb:
+  ----------------------------------------------------------------------------------------------
+
+  HAS check_obj_suitable_at "You can't $v anything at $+2.".          -- fire_at, throw_at, throw_to
+  HAS check_obj2_suitable_for_sg "That's not something you can $v for.".    -- ask_for
+  HAS check_obj2_suitable_for_pl "Those are not something you can $v for.".
+  HAS check_obj_suitable_off_sg "That's not something you can $v off.".     -- turn_off, switch_off
+  HAS check_obj_suitable_off_pl "Those are not something you can $v off.".
+  HAS check_obj_suitable_on_sg "That's not something you can $v on.".     -- knock, switch_on, turn_on
+  HAS check_obj_suitable_on_pl "Those are not something you can $v on." .
+  HAS check_obj_suitable_with_sg "That's not something you can $v with.".   -- play_with
+  HAS check_obj_suitable_with_pl "Those are not something you can $v with.".
+  HAS check_obj2_suitable_with_sg "That's not something you can $v things with.".   -- break_with, burn_with, close_with, cut_with, fill_with,
+  HAS check_obj2_suitable_with_pl "Those are not something you can $v things with.".   -- + lock_with, open_with, pry_with, push_with,
+                                   -- + touch_with, unlock_with
+
+  HAS check_obj_suitable_examine_sg "That's not something you can examine.".      -- examine
+  HAS check_obj_suitable_examine_pl "Those are not something you can examine.".   -- examine
+
+  HAS check_obj_suitable_look_out_sg "That's not something you can look out of.".   -- look_out_of
+  HAS check_obj_suitable_look_out_pl "Those are not something you can look out of.".
+  HAS check_obj_suitable_look_through "You can't look through $+1.".        -- look_through
+
+
+  -- checks for open, closed and locked objects:
+  ----------------------------------------------
+
+  HAS check_obj_not_open_sg "$+1 is already open.".         -- open, open_with
+  HAS check_obj_not_open_pl "$+1 are already open.".
+  HAS check_obj_open1_sg "$+1 is already closed.".          -- close, close_with
+  HAS check_obj_open1_pl "$+1 are already closed.".
+  HAS check_obj_open2_sg "You can't, since $+1 is closed.".       -- empty (in/on), look_in, pour (in/on)
+  HAS check_obj_open2_pl "You can't, since $+1 are closed.".
+  HAS check_obj2_open_sg "You can't, since $+2 is closed.".       -- empty_in, pour_in, put_in, throw_in
+  HAS check_obj2_open_pl "You can't, since $+2 are closed.".
+  HAS check_obj_locked_sg "$+1 is already unlocked.".         -- unlock, unlock_with
+  HAS check_obj_locked_pl "$+1 are already unlocked.".
+  HAS check_obj_not_locked_sg "$+1 is already locked.".         -- lock, lock_with
+  HAS check_obj_not_locked_pl "$+1 are already locked.".
+
+
+
+  -- checks for "not reachable" and "distant" objects:
+  ----------------------------------------------------
+
+  HAS check_obj_reachable_sg "$+1 is out of your reach.".       -- (numerous)
+  HAS check_obj_reachable_pl "$+1 are out of your reach.".
+  HAS check_obj2_reachable_sg "$+2 is out of your reach.".        -- empty_in, fill_with, put_in, take_from, tie_to
+  HAS check_obj2_reachable_pl "$+2 are out of your reach.".
+  HAS check_obj_reachable_ask "$+1 can't reach $+2.".         -- ask_for
+  HAS check_obj_not_distant_sg "$+1 is too far away.".          -- (numerous)
+  HAS check_obj_not_distant_pl "$+1 are too far away.".
+  HAS check_obj2_not_distant_sg "$+2 is too far away.".         -- empty_in, fill_with, pour_in, put_in, show, take_from,                                  -- + throw_at, throw_in, throw_to
+  HAS check_obj2_not_distant_pl "$+2 are too far away.".
+
+
+  -- checks for the hero sitting or lying_down:
+  ---------------------------------------------
+
+  HAS check_hero_not_sitting1 "It is difficult to $v while sitting down.".      -- (with many intransitive verbs)
+  HAS check_hero_not_sitting2 "It is difficult to $v anything while sitting down.". -- (with many transitive verbs)
+  HAS check_hero_not_sitting3 "It is difficult to $v anywhere while sitting down.". -- (with many verbs of motion)
+  HAS check_hero_not_sitting4 "You're sitting down already.".         -- sit, sit_on
+  HAS check_hero_not_lying_down1 "It is difficult to $v while lying down.".     -- (with many intransitive verbs)
+  HAS check_hero_not_lying_down2 "It is difficult to $v anything while lying down.".  -- (with many transitive verbs)
+  HAS check_hero_not_lying_down3 "It is difficult to $v anywhere while lying down.".  -- (with many verbs of motion)
+  HAS check_hero_not_lying_down4 "You're lying down already.".          -- lie_down, lie_in
+
+
+  -- other attribute checks:
+  --------------------------
+
+  HAS check_act_can_talk_sg "That's not something you can talk to.".        -- ask, ask_for, say_to, tell
+  HAS check_act_can_talk_pl "Those are not something you can talk to.".
+
+  HAS check_obj_allowed_in_sg "$+1 doesn't belong in $+2.".           -- empty_in, pour_in, put_in, throw_in
+      HAS check_obj_allowed_in_pl "$+1 don't belong in $+2.".
+
+  HAS check_obj_broken_sg "That doesn't need fixing.".              -- fix
+  HAS check_obj_broken_pl "Those don't need fixing.".
+
+  HAS check_obj_inanimate1 "$+1 wouldn't probably appreciate that.".        -- push, push_with, scratch, search
+  HAS check_obj_inanimate2 "You are not sure whether $+1 would appreciate that.".   -- rub, touch, touch_with
+
+  HAS check_obj_movable "It's not possible to $v $+1.".             -- lift, pull, push, push_with, shake, take, take_from
+
+  HAS check_obj_not_scenery_sg "$+1 is not important.".             -- examine, take, take_from
+  HAS check_obj_not_scenery_pl "$+1 are not important.".
+
+  HAS check_obj2_not_scenery_sg "$+1 is not important.".            -- ask_for, take_from
+  HAS check_obj2_not_scenery_pl "$+1 are not important.".
+
+  HAS check_obj_suitable_there "It's not possible to $v there.".          -- look_behind, look_in, look_under
+  HAS check_obj2_suitable_there "It's not possible to $v anything there.".      -- throw_in, tie_to
+
+  HAS check_obj_takeable "You don't have $+1.".             -- (numerous; this check is in verbs with implicit taking)
+  HAS check_obj2_takeable1 "You don't have $+2.".               -- fill_with
+  HAS check_obj2_takeable2 "You can't have $+2.".               -- ask_for
+
+  HAS check_obj_weight_sg "$+1 is too heavy to $v.".              -- lift, take, take_from
+  HAS check_obj_weight_pl "$+1 are too heavy to $v.".
+
+  HAS check_obj_writeable "Nothing can be written there.".            -- write
+
+
+  -- b) location and containment checks for actors and objects
+  ------------------------------------------------------------
+
+
+  -- containment checks for actors other than the hero (checks for the hero are listed separately below):
+  -------------------------------------------------------------------------------------------------------
+
+  HAS check_act_near_hero "You don't quite know where $+1 went.           -- follow
+    You should state a direction where you want to go.".
+
+  HAS check_obj_in_act_sg "$+2 doesn't have $+1.".              -- take_from
+  HAS check_obj_in_act_pl "$+2 don't have $+1.".
+  HAS check_obj_not_in_act_sg "$+2 already has $+1.".             -- give
+  HAS check_obj_not_in_act_pl "$+2 already have $+1.".
+
+
+  -- location and containment checks for the hero:
+  ------------------------------------------------
+
+  HAS check_count_weapon_in_hero "You are not carrying any firearms.".        -- shoot
+
+  HAS check_obj_not_at_hero_sg "$+1 is right here.".                -- find, follow, go_to, where_is
+  HAS check_obj_not_at_hero_pl "$+1 are right here.".
+  HAS check_obj_in_hero "You don't have the $+1.".              -- drop, fire, fire_at, put, show
+  HAS check_obj2_in_hero "You don't have the $+2.".             -- (numerous)
+  HAS check_obj_not_in_hero1 "It doesn't make sense to $v something you're holding.".   -- attack, attack_with, kick, lift, shoot, shoot_with
+  HAS check_obj_not_in_hero2 "You already have $+1.".             -- take, take_from
+  HAS check_obj2_not_in_hero1 "You are carrying $+2.".              -- throw_at, throw_in, throw_to
+  HAS check_obj2_not_in_hero2 "That would be futile.".              -- put_against, put_behind, put_near, put_under
+  HAS check_obj2_not_in_hero3 "You already have $+2.".              -- ask_for
+
+
+  -- checking whether an object is in a container or not:
+  -------------------------------------------------------
+
+  HAS check_cont_not_in_obj "That doesn't make sense.".             -- empty_in, pour_in, put_in
+  HAS check_obj_in_cont_sg "$+1 is not in $+2.".                -- take_from
+  HAS check_obj_in_cont_pl "$+1 are not in $+2.".
+  HAS check_obj_not_in_cont_sg "$+1 is in $+2 already.".            -- put_in, throw_in
+  HAS check_obj_not_in_cont_pl "$+1 are in $+2 already.".
+  HAS check_obj_not_in_cont2 "$+1 is already full of $+2.".           -- fill_with
+
+
+  -- checking whether an object is on a surface or not:
+  -----------------------------------------------------
+
+  HAS check_obj_on_surface_sg "$+1 is not on $+2.".             -- take_from
+  HAS check_obj_on_surface_pl "$+1 are not on $+2.".
+  HAS check_obj_not_on_surface_sg "$+1 is already on $+2.".           -- put_on
+  HAS check_obj_not_on_surface_pl "$+1 are already on $+2.".
+
+
+  -- checking whether an object is worn or not:
+  ---------------------------------------------
+
+  HAS check_obj_in_worn "You are not wearing $+1.".                 -- remove, take_off ('classes.i')
+  HAS check_obj_not_in_worn1 "You are already wearing $+1.".            -- put_on, wear ('classes.i')
+      HAS check_obj_not_in_worn2 "It doesn't make sense to $v something you're wearing.". -- attack, attack_with, kick, shoot, shoot_with
+  HAS check_obj_not_in_worn3 "You'll have to take off $+1 first.".        -- drop
+
+
+  -- c) checking location states
+  ------------------------------
+
+      HAS check_current_loc_lit "It is too dark to see.".           -- (numerous)
+
+
+  -- d) checks guarding against actions directed at the hero him-/herself
+  -----------------------------------------------------------------------
+
+  HAS check_obj_not_hero1 "It doesn't make sense to $v yourself.".      -- ask, ask_for, attack, attack_with, catch, follow
+                                   -- kick, listen, pull, push, push_with, take,
+                                   -- take_from, tell
+  HAS check_obj_not_hero2 "There is no need to be that desperate.".       -- fire_at, kill, kill_with, shoot, shoot_with
+  HAS check_obj_not_hero3 "That wouldn't accomplish anything.".       -- scratch, touch
+  HAS check_obj_not_hero4 "You're right here.".             -- find, go_to
+  HAS check_obj_not_hero5 "You don't need to be freed.".          -- free
+  HAS check_obj_not_hero6 "There is no time for that now.".               -- kiss, play_with, rub
+  HAS check_obj_not_hero7 "Turning your head, you notice nothing unusual behind yourself.".   -- look_behind
+  HAS check_obj_not_hero8 "You notice nothing unusual under yourself.".           -- look_under
+  HAS check_obj2_not_hero1 "That doesn't make sense.".            -- say_to, show, take_from, touch_with, throw_at/in/to
+  HAS check_obj2_not_hero2 "That would be futile.".           -- put_against, put_behind, put_near, put_under
+  HAS check_obj2_not_hero3 "You can't $v things to yourself.".        -- give, tie_to
+
+
+  -- e) checks guarding against actions where an object is used with itself
+  -------------------------------------------------------------------------
+
+  HAS check_obj_not_obj2_at "It doesn't make sense to $v something at itself.".   -- fire_at, throw_at
+  HAS check_obj_not_obj2_from "It doesn't make sense to $v something from itself.". -- take_from
+  HAS check_obj_not_obj2_in "It doesn't make sense to $v something into itself.".   -- empty_in, pour_in, put_in, throw_in
+  HAS check_obj_not_obj2_on "It doesn't make sense to $v something onto itself.".   -- empty_on, pour_on, put_on
+  HAS check_obj_not_obj2_to "It doesn't make sense to $v something to itself.".   -- give, show, throw_to, tie_to
+  HAS check_obj_not_obj2_with "It doesn't make sense to $v something with itself.".   -- attack_with, break_with, burn_with, close_with,                                       -- + cut_with, fill_with, lock_with,
+                                     -- + open_with, push_with, pry_with, shoot_with,
+                                     -- + touch_withm unlock_with, use_with
+
+  HAS check_obj_not_obj2_put "That doesn't make sense." .         -- put_against, put_behind, put_near, put_under
+
+
+      -- f) additional checks for classes:
+  ------------------------------------
+
+  HAS check_clothing_sex "On second thoughts you decide $+1 won't really suit you.".      -- clothing: wear
+  HAS check_cont_not_supporter "You can't put $+1 inside $+2.".             -- supporter: put_in
+  HAS check_device_on_sg "$+1 is already off.".                     -- device: turn_off, switch_off
+  HAS check_device_on_pl "$+1 are already off.".
+  HAS check_device_not_on_sg "$+1 is already on.".                  -- device: turn_on, switch_on
+  HAS check_device_not_on_pl "$+1 are already on.".
+  HAS check_door_matching_key "You can't use $+2 to $v $+1.".             -- door: lock_with, unlock_with
+  HAS check_lightsource_lit_sg "But $+1 is not lit.".                 -- lightsource: extinguish, turn_off
+  HAS check_lightsource_lit_pl "But $+1 are not lit.".
+  HAS check_lightsource_not_lit_sg "$+1 is already lit.".               -- lightsource: light, turn_on
+  HAS check_lightsource_not_lit_pl "$+1 are already lit.".
+  HAS check_lightsource_switchable_sg "That's not something you can switch on and off." .   -- lightsource: switch
+  HAS check_lightsource_switchable_pl "Those are not something you can switch on and off.".
+  HAS check_liquid_vessel_not_cont "You can't carry $+1 around in your bare hands.".      -- liquid: take_from
+  HAS check_obj_not_broken "Nothing happens.".                    -- device, lightsource: light, switch, turn_on
+
+
+  -- messages for implicit taking:
+  -- =============================
+
+      HAS implicit_taking_message "(taking $+1 first)$n".
+
+  -- The following verbs are preceded by implicit taking:
+      -- bite, drink, eat, empty, empty_in, empty_on, give, pour, pour_in, pour_on,
+      -- put_in, put_on, throw, throw_at, throw_in, throw_to, tie_to.
+  -- In ditransitive verbs, only the first parameter (the direct object) is taken implicitly.
 
 
 
@@ -470,1033 +470,1033 @@ THE my_game ISA DEFINITION_BLOCK
 -- You can also add checks of your own to the verbs here, before the "DOES ONLY" section.
 
 
- 
+
 VERB 'about'
-	DOES ONLY
-		"[This is a text adventure, also called interactive fiction, which means that what
-		goes on in the story depends on what you type at the prompt. Commands you can type 
-		are for example GO NORTH (or NORTH or just N), WEST, SOUTHEAST, UP, IN etc for 
-		moving around, but you can try many other things too, like TAKE LAMP, DROP EVERYTHING, 
-		EAT APPLE, EXAMINE BIRD or FOLLOW OLD MAN, to name just a few. LOOK (L) describes your 
-		surroundings, and INVENTORY (I) lists what you are carrying. You can SAVE your game and 
-		RESTORE it later on. 
-		$pType CREDITS to see information about the author and the copyright issues.
-		$pTo stop playing and end the program, type QUIT.]$p"
+  DOES ONLY
+    "[This is a text adventure, also called interactive fiction, which means that what
+    goes on in the story depends on what you type at the prompt. Commands you can type
+    are for example GO NORTH (or NORTH or just N), WEST, SOUTHEAST, UP, IN etc for
+    moving around, but you can try many other things too, like TAKE LAMP, DROP EVERYTHING,
+    EAT APPLE, EXAMINE BIRD or FOLLOW OLD MAN, to name just a few. LOOK (L) describes your
+    surroundings, and INVENTORY (I) lists what you are carrying. You can SAVE your game and
+    RESTORE it later on.
+    $pType CREDITS to see information about the author and the copyright issues.
+    $pTo stop playing and end the program, type QUIT.]$p"
 END VERB.
 
 
 
 VERB 'again'
-	DOES ONLY
-		"[The AGAIN command is not supported in this game. As a workaround, try using
-		 the 'up' and 'down' arrow keys to scroll through your previous commands.]" 
+  DOES ONLY
+    "[The AGAIN command is not supported in this game. As a workaround, try using
+     the 'up' and 'down' arrow keys to scroll through your previous commands.]"
 END VERB.
 
 
 
 VERB answer
-	DOES ONLY
-		"What was the question?"
+  DOES ONLY
+    "What was the question?"
 END VERB.
 
 
 
 VERB ask
-	WHEN act
-		DOES ONLY "There is no reply."
+  WHEN act
+    DOES ONLY "There is no reply."
 END VERB.
 
 
 
 VERB ask_for
-	DOES ONLY
-		MAKE act compliant.		
-		-- see 'classes.i' -> ACTOR.
-		-- It is only possible to get something from an NPC
-		-- if the NPC is 'compliant'.
-		LOCATE obj IN hero.
-		SAY THE act. "gives" SAY THE obj. "to you."
-		MAKE act NOT compliant.
+  DOES ONLY
+    MAKE act compliant.
+    -- see 'classes.i' -> ACTOR.
+    -- It is only possible to get something from an NPC
+    -- if the NPC is 'compliant'.
+    LOCATE obj IN hero.
+    SAY THE act. "gives" SAY THE obj. "to you."
+    MAKE act NOT compliant.
 END VERB.
 
 
 
 VERB attack
-	DOES ONLY
-		"Resorting to brute force is not the solution here."
+  DOES ONLY
+    "Resorting to brute force is not the solution here."
 END VERB.
 
 
 
 VERB attack_with
-	WHEN target
-		DOES ONLY
-			"Resorting to brute force is not the solution here."
+  WHEN target
+    DOES ONLY
+      "Resorting to brute force is not the solution here."
 END VERB.
 
 
 
 VERB bite
-	DOES ONLY
-		IF obj IN hero
-			THEN "You take a bite of" SAY THE obj. "$$." 
-				IF obj IS NOT plural
-					THEN "It tastes nothing out of the ordinary."
-					ELSE "They taste nothing out of the ordinary."
-				END IF.
-		END IF.
+  DOES ONLY
+    IF obj IN hero
+      THEN "You take a bite of" SAY THE obj. "$$."
+        IF obj IS NOT plural
+          THEN "It tastes nothing out of the ordinary."
+          ELSE "They taste nothing out of the ordinary."
+        END IF.
+    END IF.
 END VERB.
 
 
 
 VERB break
-	DOES ONLY
-		"Resorting to brute force is not the solution here."
+  DOES ONLY
+    "Resorting to brute force is not the solution here."
 END VERB.
 
 
 
 VERB break_with
-	DOES ONLY		
-		"Trying to break" SAY THE obj. "with" SAY THE instr. 
-		"wouldn't accomplish anything."
+  DOES ONLY
+    "Trying to break" SAY THE obj. "with" SAY THE instr.
+    "wouldn't accomplish anything."
 END VERB.
 
 
 
 VERB 'brief'
-	DOES ONLY
-		Visits 1000.
-		"Brief mode is now on. Location descriptions will only be shown
-		the first time you visit."
+  DOES ONLY
+    Visits 1000.
+    "Brief mode is now on. Location descriptions will only be shown
+    the first time you visit."
 END VERB.
 
 
 
 VERB burn
-	DOES ONLY
-		"You must state what you want to burn" SAY THE obj. "with."
+  DOES ONLY
+    "You must state what you want to burn" SAY THE obj. "with."
 END VERB.
 
 
 
 VERB burn_with
-	DOES ONLY
-		"You can't burn" SAY THE obj. "with" SAY THE instr. "."
+  DOES ONLY
+    "You can't burn" SAY THE obj. "with" SAY THE instr. "."
 END VERB.
 
 
 
 VERB buy
-	DOES ONLY
-		IF item IS NOT plural
-			THEN "That's not" 
-			ELSE "Those are not"
-		END IF. 
-			
-		"for sale."
+  DOES ONLY
+    IF item IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+
+    "for sale."
 END VERB.
 
 
 
 VERB catch
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That doesn't" 
-			ELSE "Those don't"
-		END IF.
-		"need to be caught."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That doesn't"
+      ELSE "Those don't"
+    END IF.
+    "need to be caught."
 END VERB.
 
 
 
 VERB clean
-	DOES ONLY
-		"Nothing would be achieved by that."
+  DOES ONLY
+    "Nothing would be achieved by that."
 END VERB.
 
 
 
 VERB climb
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not" 
-			ELSE "Those are not"
-		END IF.	
-		"something you can climb."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can climb."
 END VERB.
 
 
 
 VERB climb_on
-	DOES ONLY
-		IF surface IS NOT plural
-			THEN "That's not" 
-			ELSE "Those are not"
-		END IF.
-		"something you can climb on."
+  DOES ONLY
+    IF surface IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can climb on."
 END VERB.
 
 
 
 VERB climb_through
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not" 
-			ELSE "Those are not"
-		END IF.
-		"something you can climb through."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can climb through."
 END VERB.
 
 
 
 VERB close
-	DOES ONLY
-	    	MAKE obj NOT open.
-	    	"You close the" SAY THE obj. "."
+  DOES ONLY
+        MAKE obj NOT open.
+        "You close the" SAY THE obj. "."
 END VERB.
 
 
 
 VERB close_with
-	DOES ONLY
-	    	"You can't $v" SAY THE obj. "with" SAY THE instr. "."
+  DOES ONLY
+        "You can't $v" SAY THE obj. "with" SAY THE instr. "."
 END VERB.
 
 
 
 VERB consult
-	DOES ONLY
-		"You find nothing useful about" SAY THE topic. "in" SAY THE source. "."
+  DOES ONLY
+    "You find nothing useful about" SAY THE topic. "in" SAY THE source. "."
 END VERB.
 
 
 
 VERB credits
-	DOES ONLY
-		"The author retains the copyright to this game.
-		$pThis game was written using the ALAN Adventure Language. ALAN is 
-		an interactive fiction authoring system by Thomas Nilsson.
-		$nE-mail address: thomas@alanif.se $pFurther information 
-		about the ALAN system can be obtained from
-		the World Wide Web Internet site
-		$ihttp://www.alanif.se$p"
+  DOES ONLY
+    "The author retains the copyright to this game.
+    $pThis game was written using the ALAN Adventure Language. ALAN is
+    an interactive fiction authoring system by Thomas Nilsson.
+    $nE-mail address: thomas@alanif.se $pFurther information
+    about the ALAN system can be obtained from
+    the World Wide Web Internet site
+    $ihttp://www.alanif.se$p"
 END VERB.
 
 
 
 VERB cut
-	DOES ONLY
-		"You need to specify what you want to cut" SAY THE obj. "with."
+  DOES ONLY
+    "You need to specify what you want to cut" SAY THE obj. "with."
 END VERB.
 
 
 
 VERB cut_with
-	DOES ONLY
-		"You can't cut" SAY THE obj. "with" SAY THE instr. "."
+  DOES ONLY
+    "You can't cut" SAY THE obj. "with" SAY THE instr. "."
 END VERB.
 
 
 
 VERB dance
-	DOES ONLY
-    		"How about a waltz?"
+  DOES ONLY
+        "How about a waltz?"
 END VERB.
 
 
 
 VERB dig
-	DOES ONLY
-		"There is nothing suitable to dig here."
+  DOES ONLY
+    "There is nothing suitable to dig here."
 END VERB.
 
 
 
 VERB dive
-	DOES ONLY 
-		"There is no water suitable for swimming here."
+  DOES ONLY
+    "There is no water suitable for swimming here."
 END VERB.
 
 
 
 VERB dive_in
-	DOES ONLY
-		IF liq IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can dive in."
+  DOES ONLY
+    IF liq IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can dive in."
 END VERB.
 
 
 
 VERB drink
-	DOES ONLY
-		IF vessel OF liq = null_vessel		
-			-- here, if the liquid is in no container, e.g.
-			-- the hero takes a sip of water from a river,
-			-- the action is allowed to succeed so that the hero 
-			-- drinks some of the liquid:
+  DOES ONLY
+    IF vessel OF liq = null_vessel
+      -- here, if the liquid is in no container, e.g.
+      -- the hero takes a sip of water from a river,
+      -- the action is allowed to succeed so that the hero
+      -- drinks some of the liquid:
 
-			THEN "You drink a bit of" SAY THE liq. "."
-			ELSE 
-				-- = if the liquid is in a container:
+      THEN "You drink a bit of" SAY THE liq. "."
+      ELSE
+        -- = if the liquid is in a container:
 
-				-- implicit taking:
-				IF vessel OF liq NOT DIRECTLY IN hero
-					THEN 
-						IF vessel OF liq IS NOT takeable
-							THEN "You can't carry" SAY THE liq. "around in your bare hands."
-								-- the action stops here if the container is not takeable.
-							ELSE
-								LOCATE vessel OF liq IN hero.
-								SAY implicit_taking_message OF my_game. 
-						END IF.		
-				END IF.
-				-- end of implicit taking.
-		
-				IF liq IN hero 		
-				-- i.e. if the implicit taking was successful
-					THEN
-						"You drink all of" SAY THE liq. "."
-						LOCATE liq AT nowhere.
-				END IF.
-		END IF.
+        -- implicit taking:
+        IF vessel OF liq NOT DIRECTLY IN hero
+          THEN
+            IF vessel OF liq IS NOT takeable
+              THEN "You can't carry" SAY THE liq. "around in your bare hands."
+                -- the action stops here if the container is not takeable.
+              ELSE
+                LOCATE vessel OF liq IN hero.
+                SAY implicit_taking_message OF my_game.
+            END IF.
+        END IF.
+        -- end of implicit taking.
+
+        IF liq IN hero
+        -- i.e. if the implicit taking was successful
+          THEN
+            "You drink all of" SAY THE liq. "."
+            LOCATE liq AT nowhere.
+        END IF.
+    END IF.
 
 END VERB.
 
 
 
-VERB drive 
-	DOES ONLY
-		IF vehicle IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can drive."
+VERB drive
+  DOES ONLY
+    IF vehicle IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can drive."
 END VERB.
 
 
 
 VERB drop
-	DOES ONLY
-      	LOCATE obj HERE.
-      	"Dropped."
+  DOES ONLY
+        LOCATE obj HERE.
+        "Dropped."
 END VERB.
 
 
 
 VERB eat
-	DOES ONLY
-		-- implicit taking:
-		IF food NOT DIRECTLY IN hero 
-			THEN LOCATE food IN hero.
-				SAY implicit_taking_message OF my_game.	
-		END IF.
-		-- end of implicit taking.
-			
-		"You eat all of" SAY THE food. "."
-		LOCATE food AT nowhere.
+  DOES ONLY
+    -- implicit taking:
+    IF food NOT DIRECTLY IN hero
+      THEN LOCATE food IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
+
+    "You eat all of" SAY THE food. "."
+    LOCATE food AT nowhere.
 END VERB.
 
 
 
 VERB 'empty'
-	DOES ONLY 
-		-- implicit taking:
-		IF obj NOT DIRECTLY IN hero 
-			THEN LOCATE obj IN hero.
-				SAY implicit_taking_message OF my_game.
-		END IF.									
-		-- end of implicit taking.
+  DOES ONLY
+    -- implicit taking:
+    IF obj NOT DIRECTLY IN hero
+      THEN LOCATE obj IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
 
-		IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
-			THEN "There is nothing in" SAY THE obj. "."
-			ELSE
-				"You $v the contents of" SAY THE obj.
-					IF floor HERE
-						THEN "on the floor."
-						ELSE "on the ground."
-					END IF.
-				EMPTY obj AT hero.
-		END IF.
+    IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
+      THEN "There is nothing in" SAY THE obj. "."
+      ELSE
+        "You $v the contents of" SAY THE obj.
+          IF floor HERE
+            THEN "on the floor."
+            ELSE "on the ground."
+          END IF.
+        EMPTY obj AT hero.
+    END IF.
 END VERB.
 
 
 
 VERB empty_in, pour_in
-	DOES ONLY
-		-- implicit taking:
-		IF obj NOT DIRECTLY IN hero 
-			THEN LOCATE obj IN hero.
-				SAY implicit_taking_message OF my_game.
-		END IF.									
-		-- end of implicit taking.
+  DOES ONLY
+    -- implicit taking:
+    IF obj NOT DIRECTLY IN hero
+      THEN LOCATE obj IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
 
-		IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
-			THEN "There is nothing in" SAY THE obj. "."
-			ELSE 
-				EMPTY obj IN cont.
-				"You $v the contents of" SAY THE obj.
-				"in" SAY THE cont. "."
-		END IF.
-END VERB.	
-		
+    IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
+      THEN "There is nothing in" SAY THE obj. "."
+      ELSE
+        EMPTY obj IN cont.
+        "You $v the contents of" SAY THE obj.
+        "in" SAY THE cont. "."
+    END IF.
+END VERB.
+
 
 
 VERB empty_on, pour_on
-	DOES ONLY 
-		-- implicit taking:
-		IF obj NOT DIRECTLY IN hero 
-			THEN LOCATE obj IN hero.
-				SAY implicit_taking_message OF my_game.
-		END IF.									
-		-- end of implicit taking.
+  DOES ONLY
+    -- implicit taking:
+    IF obj NOT DIRECTLY IN hero
+      THEN LOCATE obj IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
 
-		IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
-			THEN "There is nothing in" SAY THE obj. "."
-			ELSE 
-				IF surface = floor OR surface = ground
-					THEN EMPTY obj AT hero.
-					ELSE EMPTY obj IN surface.
-				END IF.
-				"You $v the contents of" SAY THE obj.
-				"on" SAY THE surface. "."
-		END IF.
+    IF COUNT ISA OBJECT, DIRECTLY IN obj = 0
+      THEN "There is nothing in" SAY THE obj. "."
+      ELSE
+        IF surface = floor OR surface = ground
+          THEN EMPTY obj AT hero.
+          ELSE EMPTY obj IN surface.
+        END IF.
+        "You $v the contents of" SAY THE obj.
+        "on" SAY THE surface. "."
+    END IF.
 END VERB.
 
 
 
 VERB enter
-	 DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can enter."
+   DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can enter."
 END VERB.
 
 
 
 VERB examine
-	DOES ONLY
-		IF obj IS readable			
-			-- for readable objects, 'examine' behaves just as 'read'
-			THEN 
-				IF text OF obj = ""
-					THEN "There is nothing written on" SAY THE obj. "."
-					ELSE "You read" SAY THE obj. "."
-						IF obj IS NOT plural
-							THEN "It says"
-							ELSE "They say"
-						END IF.  
-						"""$$" SAY text OF obj. "$$""."
-				END IF.
-      		ELSE 
-				IF obj = hero
-					THEN "You notice nothing unusual about yourself."
-					ELSE "You notice nothing unusual about" SAY THE obj. "."
-				END IF. 
-		END IF.
+  DOES ONLY
+    IF obj IS readable
+      -- for readable objects, 'examine' behaves just as 'read'
+      THEN
+        IF text OF obj = ""
+          THEN "There is nothing written on" SAY THE obj. "."
+          ELSE "You read" SAY THE obj. "."
+            IF obj IS NOT plural
+              THEN "It says"
+              ELSE "They say"
+            END IF.
+            """$$" SAY text OF obj. "$$""."
+        END IF.
+          ELSE
+        IF obj = hero
+          THEN "You notice nothing unusual about yourself."
+          ELSE "You notice nothing unusual about" SAY THE obj. "."
+        END IF.
+    END IF.
 END VERB.
 
 
 
 VERB 'exit'
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.		
-		"something you can exit."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can exit."
 END VERB.
 
 
 
 VERB extinguish
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"on fire."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "on fire."
 END VERB.
 
 
 
 VERB fill
-	DOES ONLY
-		"You have to say what you want to fill" SAY THE cont. "with."
+  DOES ONLY
+    "You have to say what you want to fill" SAY THE cont. "with."
 END VERB.
 
 
 
 VERB fill_with
-	DOES ONLY	
-		"You can't fill" SAY THE cont. "with" SAY THE substance. "."
-		-- allow the action at individual substances only
+  DOES ONLY
+    "You can't fill" SAY THE cont. "with" SAY THE substance. "."
+    -- allow the action at individual substances only
 END VERB.
 
 
 
 VERB find
-	DOES ONLY
-		"You'll have to $v it yourself."
+  DOES ONLY
+    "You'll have to $v it yourself."
 END VERB.
 
 
 
 VERB fire
-	DOES ONLY
-		"You fire" SAY THE weapon. "into the air."
+  DOES ONLY
+    "You fire" SAY THE weapon. "into the air."
 END VERB.
 
 
 
 VERB fire_at
-	DOES ONLY
-		"Resorting to violence is not the solution here."
+  DOES ONLY
+    "Resorting to violence is not the solution here."
 END VERB.
 
 
 
 VERB fix
-	DOES ONLY
-		"Please be more specific. How do you intend to fix it?"
+  DOES ONLY
+    "Please be more specific. How do you intend to fix it?"
 END VERB.
 
 
 
 VERB follow
-	DOES ONLY 
-		LOCATE hero AT act.
-		"You follow" SAY THE act. "."		
+  DOES ONLY
+    LOCATE hero AT act.
+    "You follow" SAY THE act. "."
 END VERB.
 
 
 
 VERB free
-	DOES ONLY 
-		IF obj IS NOT plural
-			THEN "That doesn't need to be $vd."
-			ELSE "Those don't need to be $vd."
-		END IF.
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That doesn't need to be $vd."
+      ELSE "Those don't need to be $vd."
+    END IF.
 END VERB.
 
 
 
 VERB get_off
-	DOES ONLY
-		IF hero IS sitting OR hero IS lying_down
-			THEN "You get off" SAY THE surface. "."
-				MAKE hero NOT lying_down.
-				MAKE hero NOT sitting.
-			ELSE "You're standing up already."
-		END IF.
+  DOES ONLY
+    IF hero IS sitting OR hero IS lying_down
+      THEN "You get off" SAY THE surface. "."
+        MAKE hero NOT lying_down.
+        MAKE hero NOT sitting.
+      ELSE "You're standing up already."
+    END IF.
 END VERB.
 
 
 
 VERB get_up
-	DOES ONLY
-		IF hero IS sitting 
-			THEN "You stand up."
-				MAKE hero NOT sitting.
-				MAKE hero NOT lying_down.
-		ELSIF hero IS lying_down
-			THEN "You get up."
-				MAKE hero NOT lying_down.
-				MAKE hero NOT sitting.
-		ELSE "You're standing up already."
-		END IF.
+  DOES ONLY
+    IF hero IS sitting
+      THEN "You stand up."
+        MAKE hero NOT sitting.
+        MAKE hero NOT lying_down.
+    ELSIF hero IS lying_down
+      THEN "You get up."
+        MAKE hero NOT lying_down.
+        MAKE hero NOT sitting.
+    ELSE "You're standing up already."
+    END IF.
 END VERB.
 
 
 
 VERB give
-	DOES ONLY
-		-- implicit taking:
-		IF obj NOT DIRECTLY IN hero
-			THEN  SAY implicit_taking_message OF my_game.
-				LOCATE obj IN hero.
-		END IF.
-		-- end of implicit taking.
+  DOES ONLY
+    -- implicit taking:
+    IF obj NOT DIRECTLY IN hero
+      THEN  SAY implicit_taking_message OF my_game.
+        LOCATE obj IN hero.
+    END IF.
+    -- end of implicit taking.
 
-		LOCATE obj IN recipient.	
-		"You give" SAY THE obj. "to" SAY THE recipient. "."
+    LOCATE obj IN recipient.
+    "You give" SAY THE obj. "to" SAY THE recipient. "."
 END VERB.
 
 
 
 VERB go_to
-	DOES ONLY
-		"You can't see" SAY THE dest. "anywhere nearby. You must state a
-		direction where you want to go."
+  DOES ONLY
+    "You can't see" SAY THE dest. "anywhere nearby. You must state a
+    direction where you want to go."
 END VERB.
 
 
 
 VERB hint
-	DOES ONLY
-		"Unfortunately hints are not available in this game."
+  DOES ONLY
+    "Unfortunately hints are not available in this game."
 END VERB.
 
 
 
 VERB i
-	DOES ONLY
-		LIST hero.
+  DOES ONLY
+    LIST hero.
 
-		-- if the hero in your game carries any containers you want the contents of 
-		-- to be listed after 'inventory', you should manually add the listing right here
+    -- if the hero in your game carries any containers you want the contents of
+    -- to be listed after 'inventory', you should manually add the listing right here
             -- according to the following example:
-		-- 
-		-- IF bag IN hero
-		--     THEN LIST bag.
-		-- END IF.
-		--
-		-- This way, 'inventory' will yield e.g. "You are carrying a bag. The bag contains a book."
-		-- If you leave the above addition out, the outcome will be just "You are carrying a bag.", with
-		-- no comment on what is inside the bag.
-		
-		IF COUNT DIRECTLY IN worn > 0		-- See the file 'classes.i', subclass 'clothing'.
-			THEN LIST worn. 		-- This code will list what the hero is wearing.
-		END IF.
-	
+    --
+    -- IF bag IN hero
+    --     THEN LIST bag.
+    -- END IF.
+    --
+    -- This way, 'inventory' will yield e.g. "You are carrying a bag. The bag contains a book."
+    -- If you leave the above addition out, the outcome will be just "You are carrying a bag.", with
+    -- no comment on what is inside the bag.
+
+    IF COUNT DIRECTLY IN worn > 0   -- See the file 'classes.i', subclass 'clothing'.
+      THEN LIST worn.     -- This code will list what the hero is wearing.
+    END IF.
+
 END VERB.
 
 
 
 VERB jump
-	DOES ONLY
-		"You jump on the spot, to no avail."
+  DOES ONLY
+    "You jump on the spot, to no avail."
 END VERB.
 
 
 
 VERB jump_in
-	DOES
-		IF cont IS NOT plural
-			THEN "That's not something you can jump into."
-			ELSE "Those are not something you can jump into."
-		END IF.
+  DOES
+    IF cont IS NOT plural
+      THEN "That's not something you can jump into."
+      ELSE "Those are not something you can jump into."
+    END IF.
 END VERB.
 
 
 
 VERB jump_on
-	DOES ONLY
-		IF surface IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can jump onto."	
+  DOES ONLY
+    IF surface IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can jump onto."
 END VERB.
 
 
 
 VERB kick
-	DOES ONLY
-		"Resorting to brute force is not the solution here."
+  DOES ONLY
+    "Resorting to brute force is not the solution here."
 END VERB.
 
 
 
 VERB kill
-	DOES ONLY
-		"You have to state what you want to kill" SAY THE victim. "with."
+  DOES ONLY
+    "You have to state what you want to kill" SAY THE victim. "with."
 END VERB.
 
 
 
 VERB kill_with
    WHEN victim
-	DOES ONLY
-		"That would be needlessly brutal."
+  DOES ONLY
+    "That would be needlessly brutal."
 END VERB.
 
 
 
 VERB kiss
-	DOES ONLY
-		IF obj ISA ACTOR
-			THEN SAY THE obj. "avoids your advances."
-			ELSE "Nothing would be achieved by that."
-		END IF.
+  DOES ONLY
+    IF obj ISA ACTOR
+      THEN SAY THE obj. "avoids your advances."
+      ELSE "Nothing would be achieved by that."
+    END IF.
 END VERB.
 
 
 
 VERB knock
-	DOES ONLY
-		"You knock on" SAY THE obj. "$$. Nothing happens."
+  DOES ONLY
+    "You knock on" SAY THE obj. "$$. Nothing happens."
 END VERB.
 
 
 
 VERB lie_down
-	DOES ONLY
-		"There's no need to lie down right now."
-		-- If you need this to work, insert the following lines instead of the above:
-			-- DOES "You lie down."
-			-- MAKE hero lying_down.
-			-- MAKE hero NOT sitting_down.
+  DOES ONLY
+    "There's no need to lie down right now."
+    -- If you need this to work, insert the following lines instead of the above:
+      -- DOES "You lie down."
+      -- MAKE hero lying_down.
+      -- MAKE hero NOT sitting_down.
 END VERB.
 
 
 
 VERB lie_in
-	DOES ONLY
-		"There's no need to lie down in" SAY THE cont. "."
-		-- If you need this to work, make a nested location
-		-- (e.g. THE in_bed ISA LOCATION AT bedroom; etc.)
-		-- Remember to: MAKE hero lying_down.
-		-- Presently, an actor cannot be located inside a container object. 
+  DOES ONLY
+    "There's no need to lie down in" SAY THE cont. "."
+    -- If you need this to work, make a nested location
+    -- (e.g. THE in_bed ISA LOCATION AT bedroom; etc.)
+    -- Remember to: MAKE hero lying_down.
+    -- Presently, an actor cannot be located inside a container object.
 END VERB.
 
 
 
 VERB lie_on
-	DOES ONLY
-		"There's no need to lie down on" SAY THE surface. "."
-		-- If you need this to work, make a nested location
-		-- (e.g. THE on_bed ISA LOCATION AT bedroom; etc.)
-		-- Remember to: MAKE hero lying_down.
-		-- Presently, an actor cannot be located inside a container object
-		-- or on a supporter.
+  DOES ONLY
+    "There's no need to lie down on" SAY THE surface. "."
+    -- If you need this to work, make a nested location
+    -- (e.g. THE on_bed ISA LOCATION AT bedroom; etc.)
+    -- Remember to: MAKE hero lying_down.
+    -- Presently, an actor cannot be located inside a container object
+    -- or on a supporter.
 END VERB.
 
 
 
 VERB lift
-	DOES ONLY
-		"That wouldn't accomplish anything."	
+  DOES ONLY
+    "That wouldn't accomplish anything."
 END VERB.
 
 
 
 VERB light
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can $v."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can $v."
 END VERB.
 
 
 
 VERB listen0
-	DOES ONLY
-		"You hear nothing unusual."
+  DOES ONLY
+    "You hear nothing unusual."
 END VERB.
 
 
 
 VERB listen
-	DOES ONLY
-		IF obj AT hero
-			THEN "You hear nothing unusual."
-		ELSIF obj NEAR hero
-			THEN "You can't hear" SAY THE obj. "very well from here."
-			ELSE "You can't hear anything."
-		END IF.
+  DOES ONLY
+    IF obj AT hero
+      THEN "You hear nothing unusual."
+    ELSIF obj NEAR hero
+      THEN "You can't hear" SAY THE obj. "very well from here."
+      ELSE "You can't hear anything."
+    END IF.
 END VERB.
 
 
 
 VERB lock
-	DOES ONLY
-		IF matching_key OF obj IN hero
-			THEN MAKE obj locked.
-				"(with" SAY THE matching_key OF obj. "$$)$n"
-				"You" 
+  DOES ONLY
+    IF matching_key OF obj IN hero
+      THEN MAKE obj locked.
+        "(with" SAY THE matching_key OF obj. "$$)$n"
+        "You"
 
-				IF obj IS open
-					THEN "close and"
-						MAKE obj NOT open.
-		 		END IF.
+        IF obj IS open
+          THEN "close and"
+            MAKE obj NOT open.
+        END IF.
 
-				"lock" SAY THE obj. "."
-	    		ELSE	"You have to state what you want to lock" SAY THE obj. "with."
-		END IF.
+        "lock" SAY THE obj. "."
+          ELSE  "You have to state what you want to lock" SAY THE obj. "with."
+    END IF.
 END VERB.
 
 
 
 VERB lock_with
-	 DOES ONLY
-		MAKE obj locked. "You"
-		 		
-			IF obj IS open
-				THEN "close and"
-					MAKE obj NOT open.
-			END IF.
+   DOES ONLY
+    MAKE obj locked. "You"
 
-		 "lock" SAY THE obj. "with" SAY THE key. "."
+      IF obj IS open
+        THEN "close and"
+          MAKE obj NOT open.
+      END IF.
+
+     "lock" SAY THE obj. "with" SAY THE key. "."
 END VERB.
 
 
 
 VERB 'look'
-	DOES ONLY
-		INCREASE described OF CURRENT LOCATION. 		
-		-- see 'locations.i', attribute 'described'.
-		LOOK.
+  DOES ONLY
+    INCREASE described OF CURRENT LOCATION.
+    -- see 'locations.i', attribute 'described'.
+    LOOK.
 END VERB.
 
 
 
 VERB look_behind
-	DOES ONLY
-		IF bulk IN hero
-			THEN "You turn" SAY THE bulk. "in your hands but notice nothing unusual about it."
-			ELSE "You notice nothing unusual behind" SAY THE bulk. "."
-		END IF.
+  DOES ONLY
+    IF bulk IN hero
+      THEN "You turn" SAY THE bulk. "in your hands but notice nothing unusual about it."
+      ELSE "You notice nothing unusual behind" SAY THE bulk. "."
+    END IF.
 END VERB.
 
 
 
 VERB look_in
-	DOES ONLY 
-		LIST cont.
+  DOES ONLY
+    LIST cont.
 END VERB.
 
 
 
 VERB look_out_of
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can look out of."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can look out of."
 END VERB.
 
 
 
 VERB look_through
-	DOES ONLY
-		"You can't see through" SAY THE bulk. "."
+  DOES ONLY
+    "You can't see through" SAY THE bulk. "."
 END VERB.
 
 
 
 VERB look_under
-	DOES ONLY
-		"You notice nothing unusual under" SAY THE bulk. "."
+  DOES ONLY
+    "You notice nothing unusual under" SAY THE bulk. "."
 END VERB.
 
 
 
 VERB look_up
-	DOES ONLY
-		"Looking up, you see nothing unusual."
+  DOES ONLY
+    "Looking up, you see nothing unusual."
 END VERB.
 
 
 
 VERB 'no'
-	DOES ONLY 
-		"Really?"
+  DOES ONLY
+    "Really?"
 END VERB.
 
 
 
 VERB pray
-	DOES ONLY 
-		"Your prayers don't seem to help right now."
+  DOES ONLY
+    "Your prayers don't seem to help right now."
 END VERB.
 
 
 
 VERB pry
-	DOES ONLY 
-		"You must state what you want to pry" SAY THE obj. "with."
+  DOES ONLY
+    "You must state what you want to pry" SAY THE obj. "with."
 END VERB.
 
 
 
 VERB pry_with
-	DOES ONLY 
-		"That doesn't work."
+  DOES ONLY
+    "That doesn't work."
 END VERB.
 
 
 
-VERB pull 
-	DOES ONLY 
-		"That wouldn't accomplish anything."
+VERB pull
+  DOES ONLY
+    "That wouldn't accomplish anything."
 END VERB.
 
 
 
 VERB push
-	DOES ONLY 
-		"You give" SAY THE obj. "a little push. Nothing happens."
+  DOES ONLY
+    "You give" SAY THE obj. "a little push. Nothing happens."
 END VERB.
 
 
 
 VERB push_with
-	DOES ONLY 
-		"That wouldn't accomplish anything."
-END VERB. 
+  DOES ONLY
+    "That wouldn't accomplish anything."
+END VERB.
 
 
 
 VERB put
-	DOES ONLY
-		"You must state where you want to put" 
-			IF obj IS NOT plural
-				THEN "it."
-				ELSE "them."
-			END IF.
+  DOES ONLY
+    "You must state where you want to put"
+      IF obj IS NOT plural
+        THEN "it."
+        ELSE "them."
+      END IF.
 END VERB.
 
 
 
 VERB put_in
-	DOES ONLY 
-		LOCATE obj IN cont.
-		"You put" SAY THE obj. "into" SAY THE cont. "."	
+  DOES ONLY
+    LOCATE obj IN cont.
+    "You put" SAY THE obj. "into" SAY THE cont. "."
 END VERB.
 
 
 
 VERB put_against, put_behind, put_near, put_under
-	DOES ONLY 
-		"That wouldn't accomplish anything."
+  DOES ONLY
+    "That wouldn't accomplish anything."
 END VERB.
 
 
 
 VERB put_on
-	DOES ONLY
-		IF obj IN hero
-			THEN
-				IF surface = floor OR surface = ground
-					THEN LOCATE obj AT hero.
-						"You put" SAY THE obj. "on" SAY THE surface. "."
-					ELSE LOCATE obj IN surface.
-						"You put" SAY THE obj. "on" SAY THE surface. "."
-					END IF.	
-			END IF.
+  DOES ONLY
+    IF obj IN hero
+      THEN
+        IF surface = floor OR surface = ground
+          THEN LOCATE obj AT hero.
+            "You put" SAY THE obj. "on" SAY THE surface. "."
+          ELSE LOCATE obj IN surface.
+            "You put" SAY THE obj. "on" SAY THE surface. "."
+          END IF.
+      END IF.
 END VERB.
 
 
 
 VERB 'quit'
-	DOES ONLY
-		QUIT.
+  DOES ONLY
+    QUIT.
 END VERB.
 
 
 
 VERB read
-	DOES ONLY
-		IF text OF obj = ""
-			THEN "There's nothing written on" SAY THE obj. "."
-			ELSE "You read" SAY THE obj. "." 
-				IF obj IS NOT plural
-					THEN "It says"
-					ELSE "They say"
-				END IF.
-				"""$$" SAY text OF obj. "$$""." 
-		END IF.
+  DOES ONLY
+    IF text OF obj = ""
+      THEN "There's nothing written on" SAY THE obj. "."
+      ELSE "You read" SAY THE obj. "."
+        IF obj IS NOT plural
+          THEN "It says"
+          ELSE "They say"
+        END IF.
+        """$$" SAY text OF obj. "$$""."
+    END IF.
 END VERB.
 
 
 
 VERB remove
-	DOES ONLY
-		IF obj IS NOT plural
-			THEN "That's"
-			ELSE "Those are"
-		END IF. 
-			
-		"not something you can remove since you're not wearing"
-					
-		IF obj IS NOT plural
-			THEN "it."
-			ELSE "them."
-		END IF. 
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's"
+      ELSE "Those are"
+    END IF.
+
+    "not something you can remove since you're not wearing"
+
+    IF obj IS NOT plural
+      THEN "it."
+      ELSE "them."
+    END IF.
 END VERB.
 
 
 
 VERB 'restart'
-	DOES ONLY
-		RESTART.
+  DOES ONLY
+    RESTART.
 END VERB.
 
 
 
 VERB 'restore'
-	DOES ONLY
-		RESTORE.
+  DOES ONLY
+    RESTORE.
 END VERB.
 
 
 
-VERB rub 
-	DOES ONLY 
-		"Nothing would be achieved by that."
+VERB rub
+  DOES ONLY
+    "Nothing would be achieved by that."
 END VERB.
 
 
 
 VERB 'save'
-	DOES ONLY
-		SAVE.
+  DOES ONLY
+    SAVE.
 END VERB.
 
 
 
 VERB 'say'
-    	DOES ONLY 
-		"Nothing happens."
+      DOES ONLY
+    "Nothing happens."
 END VERB.
 
 
 
 VERB say_to
-	DOES ONLY
-		SAY THE act. 
-			IF act IS NOT plural
-		 		THEN "doesn't look"
-				ELSE "don't look"
-			END IF.
-			"interested."
+  DOES ONLY
+    SAY THE act.
+      IF act IS NOT plural
+        THEN "doesn't look"
+        ELSE "don't look"
+      END IF.
+      "interested."
 END VERB.
 
 
 
 VERB 'score'
-	DOES ONLY
-		SCORE.
-		-- (or, if you wish to disable the score, use the following kind of 
-			-- line instead of the above:
-		-- "There is no score in this game.")
+  DOES ONLY
+    SCORE.
+    -- (or, if you wish to disable the score, use the following kind of
+      -- line instead of the above:
+    -- "There is no score in this game.")
 END VERB.
 
 
 
 VERB scratch
-	DOES ONLY 
-		"Nothing would be achieved by that."
+  DOES ONLY
+    "Nothing would be achieved by that."
 END VERB.
 
 
 
-VERB 'script' 
-	DOES ONLY
-		"You can turn transcripting on and off using the 'script on/off' command within the game. 
-		The transcript will be available in a file with a name starting with the game name.
-		$pIn a GUI version you can also find this in the drop-down menu in the interpreter. 
-		$pIn a command line version you can start your game with the '-s' switch to get a transcript 
-		of the whole game."
+VERB 'script'
+  DOES ONLY
+    "You can turn transcripting on and off using the 'script on/off' command within the game.
+    The transcript will be available in a file with a name starting with the game name.
+    $pIn a GUI version you can also find this in the drop-down menu in the interpreter.
+    $pIn a command line version you can start your game with the '-s' switch to get a transcript
+    of the whole game."
 END VERB.
 
 
@@ -1518,211 +1518,211 @@ END VERB.
 
 
 VERB search
-	DOES ONLY 
-		"You find nothing of interest."
+  DOES ONLY
+    "You find nothing of interest."
 END VERB.
 
 
 
 VERB sell
-	DOES ONLY 
-		"There's nobody here who would be interested in buying" SAY THE item. "."
+  DOES ONLY
+    "There's nobody here who would be interested in buying" SAY THE item. "."
 END VERB.
 
 
 
 VERB shake
-	DOES ONLY 
-		IF obj IN hero
-			THEN "You shake" SAY THE obj. "cautiously in your hands. Nothing happens."
-			ELSE "There is no reason to start shaking" SAY THE obj. "."
-		END IF.
+  DOES ONLY
+    IF obj IN hero
+      THEN "You shake" SAY THE obj. "cautiously in your hands. Nothing happens."
+      ELSE "There is no reason to start shaking" SAY THE obj. "."
+    END IF.
 END VERB.
 
 
 
 VERB shoot
-	DOES ONLY 
-		"Resorting to violence is not the solution here."
+  DOES ONLY
+    "Resorting to violence is not the solution here."
 END VERB.
 
 
 
 VERB shoot_with
-	DOES ONLY 
-		"Resorting to violence is not the solution here."
+  DOES ONLY
+    "Resorting to violence is not the solution here."
 END VERB.
 
 
 
 VERB shout
-  	DOES ONLY
-    		"Nothing results from your $ving."
+    DOES ONLY
+        "Nothing results from your $ving."
 END VERB.
 
 
 
-VERB 'show'		
-	DOES ONLY
-		SAY THE act. 
-			
-			IF act IS NOT plural
-				THEN "is"
-				ELSE "are"
-			END IF.
+VERB 'show'
+  DOES ONLY
+    SAY THE act.
 
-			"not especially interested."
+      IF act IS NOT plural
+        THEN "is"
+        ELSE "are"
+      END IF.
+
+      "not especially interested."
 END VERB.
 
 
 
 VERB sing
-  	DOES ONLY
-    		"You $v a little tune."
+    DOES ONLY
+        "You $v a little tune."
 END VERB.
 
 
 
 VERB sip
-	DOES ONLY	
-		IF vessel OF liq = null_vessel		
-			-- here, if the liquid is in no container, e.g.
-			-- the hero takes a sip of water from a river,
-			-- the action is allowed to succeed.
-			THEN "You take a sip of" SAY THE liq. "."
-			ELSE 
-				-- implicit taking:
-				IF vessel OF liq NOT DIRECTLY IN hero
-					THEN 
-						IF vessel OF liq IS NOT takeable
-							THEN "You can't carry" SAY THE liq. "around in your bare hands."
-								-- the action stops here if the container is not takeable.
-							ELSE LOCATE vessel OF liq IN hero.
-								"(taking" SAY THE vessel OF liq. "first)$n"
-						END IF.
-				END IF.
-				-- end of implicit taking.
-		END IF.		
+  DOES ONLY
+    IF vessel OF liq = null_vessel
+      -- here, if the liquid is in no container, e.g.
+      -- the hero takes a sip of water from a river,
+      -- the action is allowed to succeed.
+      THEN "You take a sip of" SAY THE liq. "."
+      ELSE
+        -- implicit taking:
+        IF vessel OF liq NOT DIRECTLY IN hero
+          THEN
+            IF vessel OF liq IS NOT takeable
+              THEN "You can't carry" SAY THE liq. "around in your bare hands."
+                -- the action stops here if the container is not takeable.
+              ELSE LOCATE vessel OF liq IN hero.
+                "(taking" SAY THE vessel OF liq. "first)$n"
+            END IF.
+        END IF.
+        -- end of implicit taking.
+    END IF.
 
-		IF liq IN hero		-- i.e. if the implicit taking was successful
-		 	THEN 
-				IF vessel OF liq IS NOT open
-					THEN "You can't, since" SAY THE vessel OF liq. "is closed."
-					ELSE "You take a sip of" SAY THE liq. "."
-				END IF.
-		END IF.
-			
+    IF liq IN hero    -- i.e. if the implicit taking was successful
+      THEN
+        IF vessel OF liq IS NOT open
+          THEN "You can't, since" SAY THE vessel OF liq. "is closed."
+          ELSE "You take a sip of" SAY THE liq. "."
+        END IF.
+    END IF.
+
 END VERB.
 
 
 
-VERB sit 
-	DOES ONLY
-		"You feel no urge to sit down at present."
-		-- (or, if you wish to make it work, use the following instead of the above:
-		-- IF hero IS lying_down
-		--	THEN "You sit up."
-		--		MAKE hero NOT lying_down.
-		-- 	ELSE "You sit down."
-		-- END IF.
-		-- MAKE hero sitting.
+VERB sit
+  DOES ONLY
+    "You feel no urge to sit down at present."
+    -- (or, if you wish to make it work, use the following instead of the above:
+    -- IF hero IS lying_down
+    --  THEN "You sit up."
+    --    MAKE hero NOT lying_down.
+    --  ELSE "You sit down."
+    -- END IF.
+    -- MAKE hero sitting.
 END VERB.
 
 
 
 VERB sit_on
-	DOES ONLY
-		"You feel no urge to sit down at present."
+  DOES ONLY
+    "You feel no urge to sit down at present."
 
-		-- (or, to make it work, use the following instead of the above:)
-		-- IF hero lying_down 
-		-- 	THEN "You get up and sit down on" SAY THE surface. "."
-		--		MAKE hero NOT lying_down.
-		--	ELSE "You sit down on" SAY THE surface. "."
-		-- END IF.
-		-- MAKE hero sitting.
+    -- (or, to make it work, use the following instead of the above:)
+    -- IF hero lying_down
+    --  THEN "You get up and sit down on" SAY THE surface. "."
+    --    MAKE hero NOT lying_down.
+    --  ELSE "You sit down on" SAY THE surface. "."
+    -- END IF.
+    -- MAKE hero sitting.
 END VERB.
 
 
 
 VERB sleep
-	DOES ONLY
-		"There's no need to $v right now."
+  DOES ONLY
+    "There's no need to $v right now."
 END VERB.
 
 
 
 VERB smell0
     DOES ONLY
-		"You smell nothing unusual."
+    "You smell nothing unusual."
 END VERB.
 
 
 
 VERB smell
-	DOES ONLY
-	    	"You smell nothing unusual."	
+  DOES ONLY
+        "You smell nothing unusual."
 END VERB.
 
 
 
 VERB squeeze
-	DOES ONLY
-	    	"Trying to squeeze" SAY THE obj. "wouldn't accomplish anything."		
+  DOES ONLY
+        "Trying to squeeze" SAY THE obj. "wouldn't accomplish anything."
 END VERB.
 
 
 
-VERB stand 
-	DOES ONLY
-		IF hero IS sitting OR hero IS lying_down
-			THEN "You get up."
-				MAKE hero NOT sitting.
-				MAKE hero NOT lying_down.
-			ELSE "You're standing up already."
-		END IF.
+VERB stand
+  DOES ONLY
+    IF hero IS sitting OR hero IS lying_down
+      THEN "You get up."
+        MAKE hero NOT sitting.
+        MAKE hero NOT lying_down.
+      ELSE "You're standing up already."
+    END IF.
 END VERB.
 
 
 
 VERB stand_on
-	DOES ONLY
-		"You feel no urge to stand on" SAY THE surface. "."
-		-- or, to make it work, use the following instead of the above:
-		-- "You get on" SAY THE surface. "."
-		-- (Make an attribute for the hero to check that he's on the surface.
-		-- It is not possible to actually locate him on the surface (unless
-		-- you implement a nested location.)	
-		-- MAKE hero NOT sitting. MAKE hero NOT lying_down.
+  DOES ONLY
+    "You feel no urge to stand on" SAY THE surface. "."
+    -- or, to make it work, use the following instead of the above:
+    -- "You get on" SAY THE surface. "."
+    -- (Make an attribute for the hero to check that he's on the surface.
+    -- It is not possible to actually locate him on the surface (unless
+    -- you implement a nested location.)
+    -- MAKE hero NOT sitting. MAKE hero NOT lying_down.
 END VERB.
 
 
 
-VERB swim 
-	DOES ONLY
-		"There is no water suitable for swimming here."
+VERB swim
+  DOES ONLY
+    "There is no water suitable for swimming here."
 END VERB.
 
 
 
 VERB swim_in
-	DOES ONLY
-		IF liq IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"something you can swim in."
+  DOES ONLY
+    IF liq IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "something you can swim in."
 END VERB.
 
 
 
 VERB switch
-	DOES ONLY
-		IF app IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-		"not something you can switch."
+  DOES ONLY
+    IF app IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+    "not something you can switch."
 END VERB.
 
 
@@ -1736,187 +1736,187 @@ END VERB.
 
 
 VERB take
-		DOES ONLY
-			IF obj ISA ACTOR
-				THEN SAY THE obj. "would probably object to that."
-			-- actors are not prohibited from being taken in the checks; this is to
-			-- allow for example a dog to be picked up, or a bird to be taken out of
-			-- a cage, etc.
-			
+    DOES ONLY
+      IF obj ISA ACTOR
+        THEN SAY THE obj. "would probably object to that."
+      -- actors are not prohibited from being taken in the checks; this is to
+      -- allow for example a dog to be picked up, or a bird to be taken out of
+      -- a cage, etc.
 
-			ELSIF obj ISA OBJECT
-				THEN IF obj DIRECTLY IN worn
-						THEN LOCATE obj IN hero.
-							"You take off" SAY THE obj. "and carry it in your hands."
-						ELSE LOCATE obj IN hero.
-							"Taken."
-					END IF.
-			END IF.
 
-				-- Objects held by NPCs cannot be taken by the hero by default.
-				-- The hero must *ask for* the object to obtain it.
-							
+      ELSIF obj ISA OBJECT
+        THEN IF obj DIRECTLY IN worn
+            THEN LOCATE obj IN hero.
+              "You take off" SAY THE obj. "and carry it in your hands."
+            ELSE LOCATE obj IN hero.
+              "Taken."
+          END IF.
+      END IF.
+
+        -- Objects held by NPCs cannot be taken by the hero by default.
+        -- The hero must *ask for* the object to obtain it.
+
 END VERB.
 
 
 
 VERB take_from
-	WHEN obj
-			DOES ONLY 
-				IF obj ISA ACTOR
-					THEN SAY THE obj. "would probably object to that."
-						-- actors are not prohibited from being taken in the checks; this is to
-						-- allow for example a dog to be picked up, or a bird to be taken out of
-						-- a cage, etc.
-				ELSIF obj ISA OBJECT
-					THEN 
-						LOCATE obj IN hero.
-	    					"You take" SAY THE obj. "from" SAY THE holder. "."
-				END IF.
-	
-					-- Objects held by NPCs cannot be taken by the hero by default.
-					-- The hero must *ask for* the object to obtain it.
-				
-					
+  WHEN obj
+      DOES ONLY
+        IF obj ISA ACTOR
+          THEN SAY THE obj. "would probably object to that."
+            -- actors are not prohibited from being taken in the checks; this is to
+            -- allow for example a dog to be picked up, or a bird to be taken out of
+            -- a cage, etc.
+        ELSIF obj ISA OBJECT
+          THEN
+            LOCATE obj IN hero.
+                "You take" SAY THE obj. "from" SAY THE holder. "."
+        END IF.
+
+          -- Objects held by NPCs cannot be taken by the hero by default.
+          -- The hero must *ask for* the object to obtain it.
+
+
 END VERB.
 
 
 
 VERB talk
-	DOES ONLY
-		"To talk to somebody, you can ASK PERSON ABOUT THING
-		or TELL PERSON ABOUT THING."
+  DOES ONLY
+    "To talk to somebody, you can ASK PERSON ABOUT THING
+    or TELL PERSON ABOUT THING."
 END VERB.
 
 
 
 VERB talk_to
-	DOES ONLY
-		"To talk to somebody, you can ASK PERSON ABOUT THING or
-		TELL PERSON ABOUT THING."	
+  DOES ONLY
+    "To talk to somebody, you can ASK PERSON ABOUT THING or
+    TELL PERSON ABOUT THING."
 END VERB.
 
 
 
 VERB taste
-	DOES ONLY
-		"You taste nothing unexpected."
+  DOES ONLY
+    "You taste nothing unexpected."
 END VERB.
 
 
 
 VERB tear
-	DOES ONLY
-		"Trying to $v" SAY THE obj. "would be futile."
+  DOES ONLY
+    "Trying to $v" SAY THE obj. "would be futile."
 END VERB.
 
 
 
 VERB tell
-	WHEN act
-		DOES ONLY
-			SAY THE act. 
+  WHEN act
+    DOES ONLY
+      SAY THE act.
 
-			IF act IS NOT plural
-				THEN "doesn't"
-				ELSE "don't"
-			END IF.
+      IF act IS NOT plural
+        THEN "doesn't"
+        ELSE "don't"
+      END IF.
 
-			"look interested."
+      "look interested."
 END VERB.
 
 
 
-VERB think 
-	DOES ONLY
-		"Nothing helpful comes to your mind."
+VERB think
+  DOES ONLY
+    "Nothing helpful comes to your mind."
 END VERB.
 
 
 
 VERB think_about
-	DOES ONLY
-		"Nothing helpful comes to your mind."
+  DOES ONLY
+    "Nothing helpful comes to your mind."
 END VERB.
 
 
 
 VERB throw
-	DOES ONLY
-		-- implicit taking:
-		IF projectile NOT DIRECTLY IN hero 
-			THEN LOCATE projectile IN hero.
-				SAY implicit_taking_message OF my_game.
-		END IF.
-		-- end of implicit taking.			
-				
-		"You can't throw very far;" SAY THE projectile. 
-			
-		IF projectile IS NOT plural
-			THEN "ends up"
-			ELSE "end up"
-		END IF.
-						
-		IF floor HERE
-			THEN "on the floor"
-		ELSIF ground HERE 
-			THEN "on the ground"
-		END IF.
-		
-		"nearby."
-	    	LOCATE projectile AT hero.
-			
+  DOES ONLY
+    -- implicit taking:
+    IF projectile NOT DIRECTLY IN hero
+      THEN LOCATE projectile IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
+
+    "You can't throw very far;" SAY THE projectile.
+
+    IF projectile IS NOT plural
+      THEN "ends up"
+      ELSE "end up"
+    END IF.
+
+    IF floor HERE
+      THEN "on the floor"
+    ELSIF ground HERE
+      THEN "on the ground"
+    END IF.
+
+    "nearby."
+        LOCATE projectile AT hero.
+
 END VERB.
 
 
 VERB throw_at
-	WHEN projectile
-		DOES ONLY
-				-- implicit taking: 
-				IF projectile NOT DIRECTLY IN hero 
-					THEN LOCATE projectile IN hero.
-					SAY implicit_taking_message OF my_game.
-				END IF.
-				-- end of implicit taking.
-      	  				
-				IF target IS inanimate
-					THEN 
-						IF target NOT DIRECTLY AT hero		
-							-- e.g. the target is inside a box
-							THEN "It wouldn't accomplish anything trying to throw
-								 something at" SAY THE target. "."
-							ELSE 
-								SAY THE projectile.
- 
-								IF projectile IS NOT plural
-									THEN "bounces"
-									ELSE "bounce"
-								END IF.
+  WHEN projectile
+    DOES ONLY
+        -- implicit taking:
+        IF projectile NOT DIRECTLY IN hero
+          THEN LOCATE projectile IN hero.
+          SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
 
-								"harmlessly off" 
+        IF target IS inanimate
+          THEN
+            IF target NOT DIRECTLY AT hero
+              -- e.g. the target is inside a box
+              THEN "It wouldn't accomplish anything trying to throw
+                 something at" SAY THE target. "."
+              ELSE
+                SAY THE projectile.
 
-								SAY THE target. "and"
+                IF projectile IS NOT plural
+                  THEN "bounces"
+                  ELSE "bounce"
+                END IF.
 
-								IF projectile IS NOT plural
-									THEN "ends up"
-									ELSE "end up"
-								END IF.
+                "harmlessly off"
 
-		  						IF floor HERE
-									THEN "on the floor"
-								ELSIF ground HERE
-									THEN "on the ground"
-		  						END IF.
-	
-		     						"nearby."
-		  						LOCATE projectile AT hero.
-						END IF.
+                SAY THE target. "and"
 
-					ELSE SAY THE target. "wouldn't probably appreciate that."
-						-- Throwing objects at actors is not disabled in the checks
-						-- as in some situations this might be desired, e.g.
-						-- when attacking enemies.
-		  		END IF.		
+                IF projectile IS NOT plural
+                  THEN "ends up"
+                  ELSE "end up"
+                END IF.
+
+                  IF floor HERE
+                  THEN "on the floor"
+                ELSIF ground HERE
+                  THEN "on the ground"
+                  END IF.
+
+                    "nearby."
+                  LOCATE projectile AT hero.
+            END IF.
+
+          ELSE SAY THE target. "wouldn't probably appreciate that."
+            -- Throwing objects at actors is not disabled in the checks
+            -- as in some situations this might be desired, e.g.
+            -- when attacking enemies.
+          END IF.
 
 END VERB.
 
@@ -1924,16 +1924,16 @@ END VERB.
 
 VERB throw_to
    WHEN projectile
-	DOES ONLY 
-		-- implicit taking:
-		IF projectile NOT DIRECTLY IN hero 
-			THEN LOCATE projectile IN hero.
-				SAY implicit_taking_message OF my_game.	
-		END IF.
-		-- end of implicit taking.
-				
-		"It wouldn't accomplish anything trying to throw"
-		SAY the projectile. "to" SAY THE recipient. "."
+  DOES ONLY
+    -- implicit taking:
+    IF projectile NOT DIRECTLY IN hero
+      THEN LOCATE projectile IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
+
+    "It wouldn't accomplish anything trying to throw"
+    SAY the projectile. "to" SAY THE recipient. "."
 
 END VERB.
 
@@ -1941,232 +1941,232 @@ END VERB.
 
 VERB throw_in
    WHEN projectile
-	DOES ONLY
-		-- implicit taking:
-		IF projectile NOT DIRECTLY IN hero 
-			THEN LOCATE projectile IN hero.
-				SAY implicit_taking_message OF my_game.	
-		END IF.
-		-- end of implicit taking.
+  DOES ONLY
+    -- implicit taking:
+    IF projectile NOT DIRECTLY IN hero
+      THEN LOCATE projectile IN hero.
+        SAY implicit_taking_message OF my_game.
+    END IF.
+    -- end of implicit taking.
 
-		"It wouldn't accomplish anything trying to throw"
-		SAY THE projectile. "into" SAY THE cont. "."	
+    "It wouldn't accomplish anything trying to throw"
+    SAY THE projectile. "into" SAY THE cont. "."
 
 
-		-- Throwing objects into containers, even when these objects are
-		-- in the 'allowed' set of the container, is not successful by
-		-- default; this is to avoid successful outcomes for commands like
-		-- 'throw plate into cupboard' etc. 
-	
+    -- Throwing objects into containers, even when these objects are
+    -- in the 'allowed' set of the container, is not successful by
+    -- default; this is to avoid successful outcomes for commands like
+    -- 'throw plate into cupboard' etc.
+
 END VERB.
 
 
 
 VERB tie
-	DOES ONLY 
-		"You must state where you want to tie" SAY THE obj. "."
+  DOES ONLY
+    "You must state where you want to tie" SAY THE obj. "."
 END VERB.
 
 
 
 VERB tie_to
-	WHEN obj
-		DOES ONLY
-				-- implicit taking:
-				IF obj NOT DIRECTLY IN hero 
-					THEN LOCATE obj IN hero.
-						SAY implicit_taking_message OF my_game.
-				END IF.	
-				-- end of implicit taking.
-								
-				"It's not possible to tie" SAY THE obj. "to" SAY THE target. "."	
+  WHEN obj
+    DOES ONLY
+        -- implicit taking:
+        IF obj NOT DIRECTLY IN hero
+          THEN LOCATE obj IN hero.
+            SAY implicit_taking_message OF my_game.
+        END IF.
+        -- end of implicit taking.
+
+        "It's not possible to tie" SAY THE obj. "to" SAY THE target. "."
 
 END VERB.
 
 
 
 VERB touch
-	DOES ONLY
-	     	"You feel nothing unexpected."
+  DOES ONLY
+        "You feel nothing unexpected."
 END VERB.
 
 
 
 VERB touch_with
-  	WHEN obj
-		DOES ONLY
-	        	"You touch" SAY THE obj. "with" SAY THE instr. ". Nothing special happens."
+    WHEN obj
+    DOES ONLY
+            "You touch" SAY THE obj. "with" SAY THE instr. ". Nothing special happens."
 END VERB.
 
 
 
 VERB turn
-	DOES ONLY 
-		IF obj DIRECTLY IN hero
-			THEN "You turn" SAY THE obj. "in your hands, noticing nothing special."
-			ELSE "That wouldn't accomplish anything."
-		END IF.
+  DOES ONLY
+    IF obj DIRECTLY IN hero
+      THEN "You turn" SAY THE obj. "in your hands, noticing nothing special."
+      ELSE "That wouldn't accomplish anything."
+    END IF.
 END VERB.
 
 
 
-VERB turn_on	
-	DOES ONLY
-		IF app IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
-			
-		"something you can $v on."
+VERB turn_on
+  DOES ONLY
+    IF app IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
+
+    "something you can $v on."
 END VERB.
 
 
 
 VERB turn_off
-	DOES ONLY
-		IF app IS NOT plural
-			THEN "That's not"
-			ELSE "Those are not"
-		END IF.
+  DOES ONLY
+    IF app IS NOT plural
+      THEN "That's not"
+      ELSE "Those are not"
+    END IF.
 
-		"something you can $v off."
+    "something you can $v off."
 END VERB.
 
 
 
 VERB undress
-	DOES ONLY 
-		"You don't feel like undressing is a good idea right now."
-																						
-	   	-- To make it work, use the following lines instead:					
-	    	--IF COUNT DIRECTLY IN worn, ISA CLOTHING > 0 
-			--THEN EMPTY worn IN hero.
-				--"You remove all the items you were wearing."
-		    	--ELSE "You're not wearing anything you can remove."
-	    	-- END IF.
+  DOES ONLY
+    "You don't feel like undressing is a good idea right now."
+
+      -- To make it work, use the following lines instead:
+        --IF COUNT DIRECTLY IN worn, ISA CLOTHING > 0
+      --THEN EMPTY worn IN hero.
+        --"You remove all the items you were wearing."
+          --ELSE "You're not wearing anything you can remove."
+        -- END IF.
 END VERB.
 
 
 
 VERB unlock
-	DOES ONLY
-		IF matching_key OF obj IN hero
-			THEN MAKE obj NOT locked.
-				"(with" SAY THE matching_key OF obj. "$$)$n"
-				"You unlock" SAY THE obj. "."
-	    		ELSE "You don't have the key that unlocks" SAY THE obj. "."
-		END IF.
+  DOES ONLY
+    IF matching_key OF obj IN hero
+      THEN MAKE obj NOT locked.
+        "(with" SAY THE matching_key OF obj. "$$)$n"
+        "You unlock" SAY THE obj. "."
+          ELSE "You don't have the key that unlocks" SAY THE obj. "."
+    END IF.
 END VERB.
 
 
 
 VERB unlock_with
    WHEN obj
-	DOES ONLY
-		MAKE obj NOT locked.
-		"You unlock" SAY THE obj. "with" SAY THE key. "."
+  DOES ONLY
+    MAKE obj NOT locked.
+    "You unlock" SAY THE obj. "with" SAY THE key. "."
 END VERB.
 
 
 
 VERB 'use'
-	DOES ONLY
-		"Please be more specific. How do you intend to use"		
-		IF obj IS NOT plural
-			THEN "it?" 
-			ELSE "them?"
-		END IF.
+  DOES ONLY
+    "Please be more specific. How do you intend to use"
+    IF obj IS NOT plural
+      THEN "it?"
+      ELSE "them?"
+    END IF.
 END VERB.
 
 
 
 VERB use_with
    WHEN obj
-	DOES ONLY
-		"Please be more specific. How do you intend to use them together?"
+  DOES ONLY
+    "Please be more specific. How do you intend to use them together?"
 END VERB.
 
 
 
 VERB 'verbose'
-	DOES ONLY
-		VISITS 0.
-		"Verbose mode is now on. Location descriptions will be 
-		always shown in full."
+  DOES ONLY
+    VISITS 0.
+    "Verbose mode is now on. Location descriptions will be
+    always shown in full."
 END VERB.
 
 
 
 VERB 'wait'
-	DOES ONLY
-		"Time passes..."
+  DOES ONLY
+    "Time passes..."
 END VERB.
 
 
 
 VERB wear
-	DOES ONLY
-		IF obj IS NOT plural 
-			THEN "That's"
-			ELSE "Those are"
-		END IF.
-		"not something you can wear."
+  DOES ONLY
+    IF obj IS NOT plural
+      THEN "That's"
+      ELSE "Those are"
+    END IF.
+    "not something you can wear."
 END VERB.
 
 
 
 VERB what_am_i
-	DOES ONLY
-		"Maybe examining yourself might help."
+  DOES ONLY
+    "Maybe examining yourself might help."
 END VERB.
 
 
 
 VERB what_is
-	DOES ONLY
-		"You'll have to find it out yourself."
+  DOES ONLY
+    "You'll have to find it out yourself."
 END VERB.
 
 
 
 VERB where_am_i
-	DOES ONLY
-		LOOK.
+  DOES ONLY
+    LOOK.
 END VERB.
 
 
 
 VERB where_is
-	DOES ONLY
-		"You'll have to find it out yourself."
+  DOES ONLY
+    "You'll have to find it out yourself."
 END VERB.
 
 
 
-VERB who_am_i 
-	DOES ONLY
-		"Maybe examining yourself might help."
+VERB who_am_i
+  DOES ONLY
+    "Maybe examining yourself might help."
 END VERB.
 
 
 
 VERB who_is
-	DOES ONLY
-		"You'll have to find it out yourself."
+  DOES ONLY
+    "You'll have to find it out yourself."
 END VERB.
 
 
 
 VERB write
-	DOES 	ONLY
-		"You don't have anything to write with."
+  DOES  ONLY
+    "You don't have anything to write with."
 END VERB.
 
 
 
-VERB yes 
-	DOES ONLY 
-		"Really?"
+VERB yes
+  DOES ONLY
+    "Really?"
 END VERB.
 
 

--- a/newgame.alan
+++ b/newgame.alan
@@ -1,6 +1,6 @@
 -- newgame.alan
 
--- A basic barebones source code file using the ALAN library v2.1 
+-- A basic barebones source code file using the ALAN library v2.1
 -- that can be used as a starting point for a new game
 
 
@@ -8,15 +8,15 @@ IMPORT 'library.i'.
 
 
 
-THE my_game ISA DEFINITION_BLOCK         
-    -- (needed obligatorily in every new game!) 
-    
+THE my_game ISA DEFINITION_BLOCK
+    -- (needed obligatorily in every new game!)
+
     -- the following can be edited:
-    HAS title "A New Game".		
-    HAS subtitle "".			     	
-    HAS author "An ALAN Author".   	
-    HAS year 2018.				
-    HAS version "1".					
+    HAS title "A New Game".
+    HAS subtitle "".
+    HAS author "An ALAN Author".
+    HAS year 2018.
+    HAS version "1".
 
 END THE.
 

--- a/testgame.alan
+++ b/testgame.alan
@@ -6,276 +6,276 @@ IMPORT 'library.i'.
 
 THE my_game ISA DEFINITION_BLOCK
 
-	VERB attack
-		DOES ONLY "No."
-	END VERB.
+  VERB attack
+    DOES ONLY "No."
+  END VERB.
 
 END THE.
 
 
 
 
-THE sunny_room ISA ROOM  	-- all ROOMS automatically have a floor, walls and a ceiling
-	NAME sunny 'room'
-	DESCRIPTION "You are in a spacious room filled with bright sunlight entering through 
-			the window and through an open doorway to the west leading to a small balcony. 
-			A white door leads north. There is a staircase to the south."
+THE sunny_room ISA ROOM   -- all ROOMS automatically have a floor, walls and a ceiling
+  NAME sunny 'room'
+  DESCRIPTION "You are in a spacious room filled with bright sunlight entering through
+      the window and through an open doorway to the west leading to a small balcony.
+      A white door leads north. There is a staircase to the south."
 
-	EXIT north TO closet	
-		CHECK door1_s IS open
-			ELSE "You can't, since the door is closed."
-	END EXIT.
+  EXIT north TO closet
+    CHECK door1_s IS open
+      ELSE "You can't, since the door is closed."
+  END EXIT.
 
-	EXIT west TO balcony.
-	
-	EXIT south TO nowhere
-		CHECK "The staircase just leads out of here. Stay here to keep experimenting,
-			otherwise type QUIT to quit."
-	END EXIT.
+  EXIT west TO balcony.
+
+  EXIT south TO nowhere
+    CHECK "The staircase just leads out of here. Stay here to keep experimenting,
+      otherwise type QUIT to quit."
+  END EXIT.
 
 
 END THE.
 
 THE sunny_room_object ISA OBJECT AT sunny_room
-	-- We cannot examine locations, only objects and actors.
+  -- We cannot examine locations, only objects and actors.
      -- That's why, if the player types 'x room', we account for that situation
-	-- by making a sunny_room object that can be examined.
-	NAME sunny 'room'
-	DESCRIPTION ""
+  -- by making a sunny_room object that can be examined.
+  NAME sunny 'room'
+  DESCRIPTION ""
 
-	VERB examine 
-		DOES ONLY LOOK. 
-	END VERB.
+  VERB examine
+    DOES ONLY LOOK.
+  END VERB.
 
 END THE.
 
 
 
 THE table ISA SUPPORTER    -- you can place things on a supporter
-	AT sunny_room
-	IS NOT takeable.
-	HAS components {drawer1, drawer2}.
+  AT sunny_room
+  IS NOT takeable.
+  HAS components {drawer1, drawer2}.
 
-	VERB examine
-		DOES AFTER
-			FOR EACH c IN components OF THIS 
-				DO
-				"The table has" SAY AN c. "." 
-					IF c IS open
-						THEN LIST c.
-						ELSE SAY THE c. "is closed."
-					END IF.
-			END FOR.
-	END VERB.
+  VERB examine
+    DOES AFTER
+      FOR EACH c IN components OF THIS
+        DO
+        "The table has" SAY AN c. "."
+          IF c IS open
+            THEN LIST c.
+            ELSE SAY THE c. "is closed."
+          END IF.
+      END FOR.
+  END VERB.
 
 END THE.
 
 
 THE drawer1 ISA LISTED_CONTAINER
-	AT sunny_room
-	OPAQUE CONTAINER 
-	NAME top drawer
-	IS closeable. IS closed.
-	DESCRIPTION ""
+  AT sunny_room
+  OPAQUE CONTAINER
+  NAME top drawer
+  IS closeable. IS closed.
+  DESCRIPTION ""
 END THE.
 
 
 THE drawer2 ISA LISTED_CONTAINER
-	AT sunny_room
-	OPAQUE CONTAINER
-	NAME bottom drawer
-	IS closeable. IS closed.
-	DESCRIPTION ""
+  AT sunny_room
+  OPAQUE CONTAINER
+  NAME bottom drawer
+  IS closeable. IS closed.
+  DESCRIPTION ""
 END THE.
 
 
 
 THE pearls ISA OBJECT
-	In table.
-	IS plural.
-	PRONOUN 'them'
+  In table.
+  IS plural.
+  PRONOUN 'them'
 
-	VERB examine
-		DOES BEFORE
-			"This is an object with a plural name. Experiment with different commands to see
-			the responses and how they differ as compared with objects with a singular name.$p"
-	END VERB.
+  VERB examine
+    DOES BEFORE
+      "This is an object with a plural name. Experiment with different commands to see
+      the responses and how they differ as compared with objects with a singular name.$p"
+  END VERB.
 
 
 END THE.
 
 
 THE box ISA LISTED_CONTAINER
-	AT sunny_room
-	IS NOT takeable.
+  AT sunny_room
+  IS NOT takeable.
 
-	VERB examine
-		DOES BEFORE "This is a listed container defined in the library. The contents should be
-			listed after both 'examine', 'look in' and 'look'."
-	END VERB.
+  VERB examine
+    DOES BEFORE "This is a listed container defined in the library. The contents should be
+      listed after both 'examine', 'look in' and 'look'."
+  END VERB.
 
 END THE.
 
-	
+
 
 THE door1_s ISA DOOR
-	AT sunny_room
-	NAME white 'door' 
-	HAS otherside door1_n.
-	IS lockable. IS locked. 
-	HAS matching_key silver_key.
-	DESCRIPTION ""
+  AT sunny_room
+  NAME white 'door'
+  HAS otherside door1_n.
+  IS lockable. IS locked.
+  HAS matching_key silver_key.
+  DESCRIPTION ""
 END THE.
 
 
 THE silver_key ISA OBJECT IN table
-	NAME silver key
+  NAME silver key
 END THE.
 
 
 THE window1 ISA WINDOW
-	AT sunny_room
-	NAME 'window'
-	DESCRIPTION ""
+  AT sunny_room
+  NAME 'window'
+  DESCRIPTION ""
 END THE.
 
 
 THE flower ISA OBJECT
-	IS scenery.
-	IN table		-- Note the 'in' here; however, the flower will be described 
-				-- to be *on* the table.
+  IS scenery.
+  IN table    -- Note the 'in' here; however, the flower will be described
+        -- to be *on* the table.
 
-END THE.    
+END THE.
 
 
 
 THE note ISA OBJECT
-	IN table
-	IS writeable.
-	IS readable.
-	
-
-	VERB examine
-		DOES ONLY "You can try writing something on the note."
-	END VERB.
+  IN table
+  IS writeable.
+  IS readable.
 
 
-	VERB write
-		WHEN obj
-		DOES ONLY 
-			IF pen NOT IN hero
-				THEN "(taking the pen first)$n"
-					LOCATE pen IN hero.
-			END IF.
-			
-		  		IF text OF obj = ""
-					THEN SET text OF obj TO txt.
-					ELSE SET text OF obj TO text OF obj + " " + txt. 
-		  		END IF.
-
-				"You write ""$$" SAY txt. "$$"" on" SAY THE obj. "."
-			   	MAKE obj readable.
-	END VERB.
+  VERB examine
+    DOES ONLY "You can try writing something on the note."
+  END VERB.
 
 
-	VERB burn
-		CHECK match IS lit
-			ELSE "How?"
-		DOES ONLY "You burn the note to ashes."
-				LOCATE note AT nowhere.
-	END VERB.
+  VERB write
+    WHEN obj
+    DOES ONLY
+      IF pen NOT IN hero
+        THEN "(taking the pen first)$n"
+          LOCATE pen IN hero.
+      END IF.
+
+          IF text OF obj = ""
+          THEN SET text OF obj TO txt.
+          ELSE SET text OF obj TO text OF obj + " " + txt.
+          END IF.
+
+        "You write ""$$" SAY txt. "$$"" on" SAY THE obj. "."
+          MAKE obj readable.
+  END VERB.
 
 
-	VERB burn_with
-		WHEN obj
-		CHECK instr = match
-			ELSE "That's not possible."
-		DOES ONLY "You burn the note to ashes."
-				LOCATE note AT nowhere.
-	END VERB.
-			
+  VERB burn
+    CHECK match IS lit
+      ELSE "How?"
+    DOES ONLY "You burn the note to ashes."
+        LOCATE note AT nowhere.
+  END VERB.
+
+
+  VERB burn_with
+    WHEN obj
+    CHECK instr = match
+      ELSE "That's not possible."
+    DOES ONLY "You burn the note to ashes."
+        LOCATE note AT nowhere.
+  END VERB.
+
 
 END THE.
 
 
 THE pen ISA OBJECT
-	IN table
+  IN table
 END THE.
 
 
 THE bottle ISA LISTED_CONTAINER
-	IN box
-	VERB examine
-		DOES ONLY LIST THIS.
-	END VERB.
+  IN box
+  VERB examine
+    DOES ONLY LIST THIS.
+  END VERB.
 END THE.
 
 
 THE juice ISA LIQUID
-	IN bottle
-	IS drinkable.
-	ARTICLE "some"
+  IN bottle
+  IS drinkable.
+  ARTICLE "some"
 END THE.
 
 
-THE match ISA LIGHTSOURCE 
-	IN box
-	IS natural.
+THE match ISA LIGHTSOURCE
+  IN box
+  IS natural.
 END THE.
 
 
 THE flashlight ISA LIGHTSOURCE
-	IN box
-	IS NOT natural.
+  IN box
+  IS NOT natural.
 END THE.
 
 
 THE waterpistol ISA WEAPON
-	IN box
-	IS fireable.
+  IN box
+  IS fireable.
 END THE.
 
 
 THE blue_ball ISA OBJECT
-	IN box
-	NAME blue ball NAME blue
-	VERB take
-		DOES SCORE 1.
-	END VERB.
+  IN box
+  NAME blue ball NAME blue
+  VERB take
+    DOES SCORE 1.
+  END VERB.
 END THE.
 
 
 THE red_ball ISA OBJECT
-	AT sunny_room
-	NAME red ball NAME red
-	VERB take
-		DOES SCORE 1.
-	END VERB.
+  AT sunny_room
+  NAME red ball NAME red
+  VERB take
+    DOES SCORE 1.
+  END VERB.
 END THE.
 
 
-THE yellow_ball ISA OBJECT 
-	AT sunny_room
-	NAME yellow ball NAME yellow
-	VERB take
-		DOES SCORE 1.
-	END VERB.
+THE yellow_ball ISA OBJECT
+  AT sunny_room
+  NAME yellow ball NAME yellow
+  VERB take
+    DOES SCORE 1.
+  END VERB.
 END THE.
 
 
 THE felix ISA PERSON
-	AT sunny_room
-	NAME felix NAME himself NAME butler
-	IS named.
-	IS wearing {tuxedo}.
-	MENTIONED "Felix"	
-	PRONOUN 'him'
-	DESCRIPTION "$pFelix, your grumpy butler, is standing off to one side."
+  AT sunny_room
+  NAME felix NAME himself NAME butler
+  IS named.
+  IS wearing {tuxedo}.
+  MENTIONED "Felix"
+  PRONOUN 'him'
+  DESCRIPTION "$pFelix, your grumpy butler, is standing off to one side."
 
-	VERB examine 
-		DOES ONLY "Felix is your grumpy butler. You could try talking to him, or asking him
-			for various things." LIST felix.
-	END VERB.
+  VERB examine
+    DOES ONLY "Felix is your grumpy butler. You could try talking to him, or asking him
+      for various things." LIST felix.
+  END VERB.
 
 END THE.
 
@@ -283,34 +283,34 @@ END THE.
 
 
 
-THE tuxedo ISA CLOTHING 
-	IS NOT takeable.
+THE tuxedo ISA CLOTHING
+  IS NOT takeable.
 END THE.
 
 
 THE dog ISA ACTOR
-	AT sunny_room
-	DESCRIPTION "$pA dog is here, looking at you with faithful eyes." 		
-	
-	VERB examine
-		DOES ONLY "Give the blue ball to the dog and he will follow you." LIST dog.
-	END VERB.
+  AT sunny_room
+  DESCRIPTION "$pA dog is here, looking at you with faithful eyes."
+
+  VERB examine
+    DOES ONLY "Give the blue ball to the dog and he will follow you." LIST dog.
+  END VERB.
 
 END THE.
 
 
-THE balcony ISA LOCATION 
+THE balcony ISA LOCATION
 
-	DESCRIPTION "You're standing on a small balcony overlooking a garden. The sky is clear. 
-			 In the distance you see a mountain. 
-			 The room is back to the east."
-	
-	IF visited OF balcony = 1
-		THEN "$pHaving never been on this balcony before, you pause to take in the magnificent view."
-		ELSE "$pEven if you've been here before, the magnificent view never ceases to amaze you."
-	END IF.
+  DESCRIPTION "You're standing on a small balcony overlooking a garden. The sky is clear.
+       In the distance you see a mountain.
+       The room is back to the east."
 
-	EXIT east TO sunny_room.	
+  IF visited OF balcony = 1
+    THEN "$pHaving never been on this balcony before, you pause to take in the magnificent view."
+    ELSE "$pEven if you've been here before, the magnificent view never ceases to amaze you."
+  END IF.
+
+  EXIT east TO sunny_room.
 
 END THE.
 
@@ -319,10 +319,10 @@ END THE.
 
 
 THE balcony_object ISA OBJECT AT balcony
-	NAME balcony
-	IS NOT takeable.
-	IS NOT movable.
-	DESCRIPTION ""
+  NAME balcony
+  IS NOT takeable.
+  IS NOT movable.
+  DESCRIPTION ""
 END THE.
 
 -- we cannot declare the balcony either as a room or as a site, because we need here both the floor
@@ -330,88 +330,88 @@ END THE.
 -- as a normal location above, and here we add to it its own floor and sky objects:
 
 THE balcony_floor ISA OBJECT AT balcony
-	NAME floor
-	IS NOT takeable.
-	IS NOT movable.
-	DESCRIPTION ""
+  NAME floor
+  IS NOT takeable.
+  IS NOT movable.
+  DESCRIPTION ""
 END THE.
 
 
 THE balcony_sky ISA OBJECT AT balcony
-	NAME sky
-	IS distant.
-	DESCRIPTION ""
+  NAME sky
+  IS distant.
+  DESCRIPTION ""
 END THE.
 
 
 THE mountain ISA OBJECT
-	AT balcony
-	IS distant.
-	DESCRIPTION ""
-	VERB examine
-		DOES ONLY "Majestic."
-	END VERB.
+  AT balcony
+  IS distant.
+  DESCRIPTION ""
+  VERB examine
+    DOES ONLY "Majestic."
+  END VERB.
 END THE.
 
 
 THE garden ISA OBJECT
-	AT balcony
-	IS distant.
-	NAME garden NAME flowers
-	DESCRIPTION "The garden is green and full of blossoming flowers."
+  AT balcony
+  IS distant.
+  NAME garden NAME flowers
+  DESCRIPTION "The garden is green and full of blossoming flowers."
 END THE.
 
 
 
 THE closet ISA LOCATION
-	
-	DESCRIPTION "This is a closet."
 
-	EXIT south TO sunny_room	
-		CHECK door1_n IS open
-			ELSE "You can't, since the door is closed."
-	END EXIT.
+  DESCRIPTION "This is a closet."
+
+  EXIT south TO sunny_room
+    CHECK door1_n IS open
+      ELSE "You can't, since the door is closed."
+  END EXIT.
 
 END THE.
 
 
 THE door1_n ISA DOOR AT closet
-	NAME white 'door' 
-	
+  NAME white 'door'
+
 END THE.
 
 
 THE shirt ISA CLOTHING
-	AT closet
-	IS topcover 8.
+  AT closet
+  IS topcover 8.
 END THE.
 
 
 THE jacket ISA CLOTHING
-	AT closet
-	IS topcover 32.
+  AT closet
+  IS topcover 32.
 END THE.
 
 
 THE wallet ISA LISTED_CONTAINER
-	IS openable. IS NOT open.
-	IN jacket
+  IS openable. IS NOT open.
+  IN jacket
 END THE.
 
 
 WHEN blue_ball IN dog AND dog IS NOT following
-	=> MAKE dog following.
+  => MAKE dog following.
 
 
 
 
 
-   
+
 
 START AT sunny_room.
 DESCRIBE banner.
 "$pThis is a" STYLE alert. "testgame" STYLE normal. "for the new ALAN library. Experiment with
- manipulating various objects and moving around. 
+ manipulating various objects and moving around.
 Taking any ball will increase your score."
 
 


### PR DESCRIPTION
StdLib Sources Cleanup
These are just some cleanup operations on the Library source files.

Mainly, they deal with whitespace problems due to mixture of tabs and spaces. All tabs are converted to two-spaces, so the code will show up consistently in all editors, and then I've adjusted alignement of comments after the changes.

I've also removed trailing whitespace ad line ends (for cleaner diff operations).

I've readjusted alignment in the Verbs Table, and fixed a couple of verbs' arity, obj or syntax.

I've also readjusted the Clothing Table so it shows properly aligned columns,
and I've taken the liberty of converting it to an Ascii Art table (which IMO is easier to consult).

All changes are cosmetic: since they deal only with comments they don't affect the libary version. Still, once the library is officialy tagged as release `v2.1` on the repo, it might be a cleaner approach to make any changes to a development branch.
