### PR TITLE
Make Banner a LOCATION

### DIFF
--- a/lib_classes.i
+++ b/lib_classes.i
@@ -2072,31 +2072,22 @@ ADD TO EVERY ACTOR
     IF THIS = hero
       THEN "You are carrying"
       ELSE
-
-        IF THIS IS NOT named
-          THEN SAY THE THIS.
-          ELSE SAY THIS.
-        END IF.
-
+        SAY THE THIS.
         IF THIS IS NOT plural
-          THEN "is carrying"
-          ELSE "are carrying"
-        END IF.
+          THEN "is"
+          ELSE "are"
+        END IF. "carrying"
     END IF.
 
   ELSE
     IF THIS = hero
       THEN "You are empty-handed."
       ELSE
-        IF THIS IS NOT named
-          THEN SAY THE THIS.
-          ELSE SAY THIS.
-        END IF.
-
+        SAY THE THIS.
         IF THIS IS NOT plural
-          THEN "is not carrying anything."
-          ELSE "are not carrying anything."
-        END IF.
+          THEN "is"
+          ELSE "are"
+        END IF. "not carrying anything."
 
     END IF.
 
@@ -2104,11 +2095,7 @@ ADD TO EVERY ACTOR
     CHECK THIS IS compliant
       ELSE
         "That seems to belong to"
-        IF THIS IS NOT named
-          THEN SAY THE THIS.
-          ELSE SAY THIS.
-        END IF.
-        "."
+        SAY THE THIS. "."
 
 
 
@@ -2205,29 +2192,21 @@ EVERY person ISA ACTOR
     HEADER
       SAY THE THIS.
       IF THIS IS NOT plural
-        THEN "is carrying"
-        ELSE "are carrying"
-      END IF.
+        THEN "is"
+        ELSE "are"
+      END IF. "carrying"
     ELSE
 
-      IF THIS IS NOT named
-        THEN SAY THE THIS.
-        ELSE SAY THIS.
-      END IF.
-
+      SAY THE THIS.
       IF THIS IS NOT plural
-        THEN "is empty-handed."
-        ELSE "are empty-handed."
-      END IF.
+        THEN "is"
+        ELSE "are"
+      END IF. "empty-handed."
 
     EXTRACT
       CHECK THIS IS compliant
         ELSE "That seems to belong to"
-          IF THIS IS NOT named
-            THEN SAY THE THIS.
-            ELSE SAY THIS.
-          END IF.
-          "."
+        SAY THE THIS. "."
 
 END EVERY.
 

--- a/lib_definitions.i
+++ b/lib_definitions.i
@@ -1626,7 +1626,7 @@ END EVENT.
 -- ===========
 
 
-THE banner ISA DEFINITION_BLOCK
+THE banner ISA LOCATION
 
     DESCRIPTION
 

--- a/tests/RUNTESTS.bat
+++ b/tests/RUNTESTS.bat
@@ -1,4 +1,4 @@
-:: "RUNTESTS.bat" v2.0.1 (2018/08/24) MIT License
+:: "RUNTESTS.bat" v2.0.2 (2018/08/24) MIT License
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::                                                                            ::
 ::                      ALAN STANDARD LIBRARY TEST SUITE                      ::
@@ -173,16 +173,16 @@ IF NOT EXIST %_SCRIPT% (
     ECHO %RESET_COLORS%%RED%
     ECHO Matching script "%YELLOW%%_SCRIPT%%RED%" not found.
 ) ELSE (
-    :: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    :: NOTE: The code doesn't actually check that ARun returned without error,
-    ::       or that the log was actually created. Should improve this!
-    :: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    REM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    REM NOTE: The code doesn't actually check that ARun returned without error,
+    REM       or that the log was actually created. Should improve this!
+    REM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     SET /A _SCRIPTSCNT=%_SCRIPTSCNT% +1
     CALL arun.exe -r %_ADVFILE% < %_SCRIPT% > %_LOG%
     ECHO %BG_GREEN%
-    ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ECHO -----------------------------
     ECHO  TRANSCRIPT SAVED TO DISK^^!^^!^^! 
-    ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ECHO -----------------------------
     ECHO %RESET_COLORS%%GREEN%
     ECHO Test transcript saved to "%YELLOW%%_LOG%%GREEN%".
 )


### PR DESCRIPTION
Tweaked `lib_definitions.i` to make `banner` an instance of `LOCATION` instead
of `DEFINITION_BLOCK` (smaller footprint in compiled games.)
(Resolves AnssiR66/AlanStdLib#8).