### PR TITLE
Remove `look_at`

### DIFF
--- a/lib_classes.i
+++ b/lib_classes.i
@@ -285,7 +285,7 @@ EVERY clothing ISA OBJECT
             THEN LIST THIS.
           END IF.
       END IF.
-  END VERB.
+  END VERB examine.
 
 
 
@@ -464,7 +464,7 @@ EVERY clothing ISA OBJECT
       "You put on" SAY THE THIS. "."
     END IF.
 
-END VERB.
+END VERB wear.
 
 
 
@@ -579,7 +579,7 @@ VERB remove
       EXCLUDE THIS FROM wearing OF hero.
       MAKE THIS NOT donned.
   END IF.
-END VERB.
+END VERB remove.
 
 
 END EVERY.
@@ -795,7 +795,7 @@ EVERY device ISA OBJECT
         THEN "currently on."
         ELSE "currently off."
       END IF.
-  END VERB.
+  END VERB examine.
 
 
   VERB turn_on
@@ -827,7 +827,7 @@ EVERY device ISA OBJECT
     DOES ONLY
       "You turn on" SAY THE THIS. "."
       MAKE THIS 'on'.
-  END VERB.
+  END VERB turn_on.
 
 
   VERB turn_off
@@ -857,7 +857,7 @@ EVERY device ISA OBJECT
     DOES ONLY
       "You turn off" SAY THE THIS. "."
       MAKE THIS NOT 'on'.
-  END VERB.
+  END VERB turn_off.
 
 
 -- The following verb switches a device off if the device is on, and vice versa.
@@ -890,7 +890,7 @@ EVERY device ISA OBJECT
         ELSE "You switch on" SAY THE THIS. "."
           MAKE THIS 'on'.
       END IF.
-  END VERB.
+  END VERB switch.
 
 END EVERY.
 
@@ -1002,7 +1002,7 @@ EVERY door ISA OBJECT
         THEN "currently closed."
         ELSE "currently open."
       END IF.
-  END VERB.
+  END VERB examine.
 
 
 
@@ -1016,7 +1016,7 @@ EVERY door ISA OBJECT
             ELSE "$$s."
           END IF.
       END IF.
-  END VERB.
+  END VERB knock.
 
 
 
@@ -1034,7 +1034,7 @@ EVERY door ISA OBJECT
             ELSE "$$s."
           END IF.
       END IF.
-  END VERB.
+  END VERB look_behind.
 
 
 
@@ -1053,7 +1053,7 @@ EVERY door ISA OBJECT
             ELSE "."
           END IF.
       END IF.
-  END VERB.
+  END VERB look_under.
 
 
 
@@ -1062,7 +1062,7 @@ EVERY door ISA OBJECT
       IF otherside OF THIS <> null_door
         THEN MAKE otherside OF THIS NOT open.
       END IF.
-  END VERB.
+  END VERB close.
 
 
   VERB lock
@@ -1071,7 +1071,7 @@ EVERY door ISA OBJECT
         THEN MAKE otherside OF THIS NOT open.
           MAKE otherside OF THIS locked.
       END IF.
-  END VERB.
+  END VERB lock.
 
 
   VERB open
@@ -1080,7 +1080,7 @@ EVERY door ISA OBJECT
         THEN MAKE otherside OF THIS open.
           MAKE otherside OF THIS NOT locked.
       END IF.
-  END VERB.
+  END VERB open.
 
 
   VERB unlock
@@ -1088,7 +1088,7 @@ EVERY door ISA OBJECT
       IF otherside OF THIS <> null_door
         THEN MAKE otherside OF THIS NOT locked.
       END IF.
-  END VERB.
+  END VERB unlock.
 
 
 END EVERY.
@@ -1156,7 +1156,7 @@ EVERY lightsource ISA OBJECT
               "currently off."
           END IF.
       END IF.
-  END VERB.
+  END VERB examine.
 
 
   VERB light
@@ -1175,7 +1175,7 @@ EVERY lightsource ISA OBJECT
         ELSE "You turn on" SAY THE THIS. "."
           MAKE THIS lit.
       END IF.
-  END VERB.
+  END VERB light.
 
 
   VERB extinguish
@@ -1187,7 +1187,7 @@ EVERY lightsource ISA OBJECT
         END IF.
     DOES ONLY "You extinguish" SAY THE THIS. "."
       MAKE THIS NOT lit.
-  END VERB.
+  END VERB extinguish.
 
 
   VERB turn_on
@@ -1209,7 +1209,7 @@ EVERY lightsource ISA OBJECT
       "You turn on" SAY THE THIS. "."
       MAKE THIS lit.
 
-  END VERB.
+  END VERB turn_on.
 
 
   VERB turn_off
@@ -1230,7 +1230,7 @@ EVERY lightsource ISA OBJECT
       "You turn off" SAY THE THIS. "."
       MAKE THIS NOT lit.
 
-  END VERB.
+  END VERB turn_off.
 
 
 -- The following verb switches a NOT natural lightsource on if it is off, and vice versa
@@ -1259,7 +1259,7 @@ EVERY lightsource ISA OBJECT
         ELSE "You switch on" SAY THE THIS. "."
           MAKE THIS lit.
       END IF.
-  END VERB.
+  END VERB switch.
 
 
 END EVERY.
@@ -1364,7 +1364,7 @@ EVERY liquid ISA OBJECT
           END IF.
         ELSE "You notice nothing unusual about" SAY THE THIS. "."
       END IF.
-  END VERB.
+  END VERB examine.
 
 
   VERB look_in
@@ -1384,7 +1384,7 @@ EVERY liquid ISA OBJECT
           END IF.
         ELSE "You see nothing special in" SAY THE THIS. "."
       END IF.
-  END VERB.
+  END VERB look_in.
 
 
   VERB take
@@ -1396,7 +1396,7 @@ EVERY liquid ISA OBJECT
         ELSE LOCATE vessel OF THIS IN hero.
           "($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nTaken."
       END IF.
-  END VERB.
+  END VERB take.
 
 
   VERB take_from
@@ -1411,7 +1411,7 @@ EVERY liquid ISA OBJECT
         ELSE LOCATE vessel OF THIS IN hero.
           "($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nTaken."
       END IF.
-  END VERB.
+  END VERB take_from.
 
 
   VERB drop
@@ -1419,14 +1419,14 @@ EVERY liquid ISA OBJECT
       LOCATE vessel OF THIS AT hero.
       "($$" SAY THE vessel OF THIS. "of" SAY THIS. "$$)$nDropped."
 
-  END VERB.
+  END VERB drop.
 
 
   VERB ask_for
     DOES ONLY
       LOCATE vessel OF THIS IN hero.
       SAY THE act. "gives" SAY THE vessel OF THIS. "of" SAY THIS. "to you."
-  END VERB.
+  END VERB ask_for.
 
 
   VERB give
@@ -1453,7 +1453,7 @@ EVERY liquid ISA OBJECT
       -- there is no 'ELSE' statement in this last IF -clause, as the 'IF THIS NOT
       -- IN hero' clause above it takes care of the 'ELSE' alternative.
 
-  END VERB.
+  END VERB give.
 
 
   VERB pour
@@ -1484,7 +1484,7 @@ EVERY liquid ISA OBJECT
           END IF.
       END IF.
 
-  END VERB.
+  END VERB pour.
 
 
   VERB pour_in
@@ -1525,7 +1525,7 @@ EVERY liquid ISA OBJECT
                 "closed."
             END IF.
         END IF.
-  END VERB.
+  END VERB pour_in.
 
 
   VERB pour_on
@@ -1558,7 +1558,7 @@ EVERY liquid ISA OBJECT
               ELSE "It wouldn't be sensible to pour anything on" SAY THE surface.
             END IF.
         END IF.
-  END VERB.
+  END VERB pour_on.
 
 
   VERB fill_with
@@ -1566,7 +1566,7 @@ EVERY liquid ISA OBJECT
     -- vessel of the liquid:
     WHEN substance
        DOES SET vessel OF THIS TO cont.
-  END VERB.
+  END VERB fill_with.
 
 
   VERB put_in
@@ -1615,7 +1615,7 @@ EVERY liquid ISA OBJECT
             "closed."
           END IF.
       END IF.
-  END VERB.
+  END VERB put_in.
 
 
   VERB put_on
@@ -1640,7 +1640,7 @@ EVERY liquid ISA OBJECT
         END IF.
     WHEN surface
       DOES ONLY "It is not possible to $v" SAY obj. "onto" SAY THE THIS. "."
-  END VERB.
+  END VERB put_on.
 
 
 
@@ -1651,17 +1651,17 @@ EVERY liquid ISA OBJECT
   VERB 'empty'
     WHEN obj
     DOES ONLY "You can only empty containers."
-  END VERB.
+  END VERB 'empty'.
 
   VERB empty_in
     WHEN obj
     DOES ONLY "You can only empty containers."
-  END VERB.
+  END VERB empty_in.
 
   VERB empty_on
     WHEN obj
     DOES ONLY "You can only empty containers."
-  END VERB.
+  END VERB empty_on.
 
 
 END EVERY.
@@ -1731,7 +1731,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
         THEN LIST THIS.
         ELSE "You can't see inside" SAY THE THIS. "."
       END IF.
-  END VERB.
+  END VERB examine.
 
 
   VERB look_in
@@ -1740,7 +1740,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
         THEN LIST THIS.
         ELSE "You can't see inside" SAY THE THIS. "."
       END IF.
-  END VERB.
+  END VERB look_in.
 
 
   VERB search
@@ -1749,7 +1749,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
         THEN LIST THIS.
         ELSE "You can't see inside" SAY THE THIS. "."
       END IF.
-  END VERB.
+  END VERB search.
 
 
 
@@ -1773,7 +1773,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
           MAKE THIS NOT OPAQUE.
           LIST THIS.
       END IF.
-  END VERB.
+  END VERB open.
 
 
   VERB open_with
@@ -1783,7 +1783,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
           MAKE THIS NOT OPAQUE.
           LIST THIS.
       END IF.
-  END VERB.
+  END VERB open_with.
 
 
   VERB close, lock
@@ -1792,7 +1792,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
         THEN
           MAKE THIS OPAQUE.
       END IF.
-  END VERB.
+  END VERB close.
 
 
   VERB close_with
@@ -1801,7 +1801,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
         THEN
           MAKE THIS OPAQUE.
       END IF.
-  END VERB.
+  END VERB close_with.
 
 
   VERB lock_with
@@ -1810,7 +1810,7 @@ EVERY LISTED_CONTAINER ISA OBJECT
         THEN
           MAKE THIS OPAQUE.
       END IF.
-  END VERB.
+  END VERB lock_with.
 
 
 END EVERY.
@@ -1844,7 +1844,7 @@ EVERY sound ISA OBJECT
         ELSE "Those are not"
       END IF.
       "something you can smell."
-  END VERB.
+  END VERB smell.
 
 
 END EVERY.
@@ -1877,7 +1877,7 @@ EVERY supporter ISA OBJECT
   VERB examine
     DOES
       LIST THIS.
-  END VERB.
+  END VERB examine.
 
 
   -- in the following, we disable some verbs that are defined to work with normal containers:
@@ -1890,7 +1890,7 @@ EVERY supporter ISA OBJECT
         ELSE "Those are not"
       END IF.
       "something you can look into."
-  END VERB.
+  END VERB look_in.
 
 
   VERB empty_in, pour_in
@@ -1901,19 +1901,19 @@ EVERY supporter ISA OBJECT
         ELSE "Those are not"
       END IF.
       "something you can pour things into."
-  END VERB.
+  END VERB empty_in.
 
 
   VERB put_in
     WHEN cont
     DOES ONLY "You can't put anything inside" SAY THE THIS. "."
-  END VERB.
+  END VERB put_in.
 
 
   VERB throw_in
     WHEN cont
     DOES ONLY "You can't put anything inside" SAY THE THIS. "."
-  END VERB.
+  END VERB throw_in.
 
 
 END EVERY.
@@ -1983,13 +1983,13 @@ EVERY window ISA OBJECT
           END IF.
           "currently open."
       END IF.
-  END VERB.
+  END VERB examine.
 
 
   VERB look_behind
     DOES ONLY
       "That's not possible."
-  END VERB.
+  END VERB look_behind.
 
 
   VERB look_out_of
@@ -1998,7 +1998,7 @@ EVERY window ISA OBJECT
         THEN "window."
         ELSE "windows."
       END IF.
-  END VERB.
+  END VERB look_out_of.
 
 
   VERB look_through
@@ -2007,7 +2007,7 @@ EVERY window ISA OBJECT
         THEN "window."
         ELSE "windows."
       END IF.
-  END VERB.
+  END VERB look_through.
 
 
 END EVERY.
@@ -2161,7 +2161,7 @@ ADD TO EVERY ACTOR
         THEN
           LIST THIS.
       END IF.
-  END VERB.
+  END VERB examine.
 
 
 END ADD TO.

--- a/lib_definitions.i
+++ b/lib_definitions.i
@@ -760,7 +760,7 @@ EVERY definition_block ISA LOCATION
   CAN look_under.
   CAN look_up.
   CAN 'no'.
-  CAN 'notify'.
+  CAN notify.
   CAN notify_on.
   CAN notify_off.
   CAN open.
@@ -960,7 +960,7 @@ EVENT check_restriction
       MAKE my_game look_under.
       MAKE my_game look_up.
       MAKE my_game 'no'.
-      MAKE my_game 'notify'.
+      MAKE my_game notify.
       MAKE my_game notify_on.
       MAKE my_game notify_off.
       MAKE my_game open.
@@ -1250,7 +1250,7 @@ EVENT check_restriction
           MAKE my_game NOT credits.     -- (+ acknowledgments, author, copyright)
           MAKE my_game NOT hint.        -- (+ hints)
           MAKE my_game NOT 'no'.
-          MAKE my_game NOT 'notify'.
+          MAKE my_game NOT notify.
           MAKE my_game NOT notify_on.
           MAKE my_game NOT notify_off.
           MAKE my_game NOT 'quit'.

--- a/lib_definitions.i
+++ b/lib_definitions.i
@@ -753,7 +753,6 @@ EVERY definition_block ISA LOCATION
   CAN lock.
   CAN lock_with.
   CAN 'look'.        -- (+ gaze, peek)
-  CAN look_at.
   CAN look_behind.
   CAN look_in.
   CAN look_out_of.
@@ -954,7 +953,6 @@ EVENT check_restriction
       MAKE my_game lock.
       MAKE my_game lock_with.
       MAKE my_game 'look'.        -- (+ gaze, peek)
-      MAKE my_game look_at.
       MAKE my_game look_behind.
       MAKE my_game look_in.
       MAKE my_game look_out_of.
@@ -1221,7 +1219,6 @@ EVENT check_restriction
           MAKE my_game NOT listen0.
           MAKE my_game NOT listen.
           MAKE my_game NOT 'look'.        -- (+ gaze, peek)
-          MAKE my_game NOT look_at.
           MAKE my_game NOT look_behind.
           MAKE my_game NOT look_in.
           MAKE my_game NOT look_out_of.

--- a/lib_locations.i
+++ b/lib_locations.i
@@ -78,9 +78,9 @@ SYNONYMS
 -- THE piece_of_paper ISA OBJECT
 -- ...
 --    VERB tear
---    DOES ONLY "You tear the piece of paper to shreds."
---    LOCATE piece_of_paper AT nowhere.
---  END VERB.
+--      DOES ONLY "You tear the piece of paper to shreds."
+--        LOCATE piece_of_paper AT nowhere.
+--    END VERB tear.
 --
 -- END THE piece_of_paper.
 
@@ -166,30 +166,30 @@ THE floor ISA room_object
   VERB empty_in, pour_in
      WHEN cont
     DOES ONLY "That's not something you can $v things into."
-  END VERB.
+  END VERB empty_in.
 
 
   VERB look_in
     DOES ONLY "That's not possible."
-  END VERB.
+  END VERB look_in.
 
 
   VERB put_in
      WHEN cont
     DOES ONLY "That's not something you can $v things into."
-  END VERB.
+  END VERB put_in.
 
 
   VERB take_from
      WHEN holder
     DOES ONLY "If you want to pick up something, just TAKE it."
-  END VERB.
+  END VERB take_from.
 
 
   VERB throw_in
      WHEN cont
     DOES ONLY "That's not something you can $v things into."
-  END VERB.
+  END VERB throw_in.
 
 
 
@@ -229,30 +229,30 @@ THE ground ISA site_object
   VERB empty_in, pour_in
      WHEN cont
     DOES ONLY "That's not something you can $v things into."
-  END VERB.
+  END VERB empty_in.
 
 
   VERB look_in
     DOES ONLY "That's not possible."
-  END VERB.
+  END VERB look_in.
 
 
   VERB put_in
      WHEN cont
     DOES ONLY "That's not something you can $v things into."
-  END VERB.
+  END VERB put_in.
 
 
   VERB take_from
      WHEN holder
     DOES ONLY "If you want to pick up something, just TAKE it."
-  END VERB.
+  END VERB take_from.
 
 
   VERB throw_in
      WHEN cont
     DOES ONLY "That's not something you can $v things into."
-  END VERB.
+  END VERB throw_in.
 
 
 END THE.
@@ -275,16 +275,16 @@ ADD TO EVERY room_object
     WHEN bulk
       CHECK THIS = wall
         ELSE "That's not possible."
-  END VERB.
+  END VERB put_against.
 
   VERB put_behind, put_near, put_under
     WHEN bulk
       DOES ONLY "That's not possible."
-  END VERB.
+  END VERB put_behind.
 
   VERB look_behind, look_through, look_under
     DOES ONLY "That's not possible."
-  END VERB.
+  END VERB look_behind.
 
 END ADD TO.
 
@@ -294,11 +294,11 @@ ADD TO EVERY site_object
   VERB put_against, put_behind, put_near, put_under
     WHEN bulk
       DOES ONLY "That's not possible."
-  END VERB.
+  END VERB put_against.
 
   VERB look_behind, look_through, look_under
     DOES ONLY "That's not possible."
-  END VERB.
+  END VERB look_behind.
 
 END ADD TO.
 
@@ -318,7 +318,7 @@ END ADD TO.
 --          ELSIF...
 --          END IF.
 --    ...
--- END VERB.
+-- END VERB examine.
 --
 -- END THE my_game.
 

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -210,7 +210,7 @@
 SYNTAX 'about' = 'about'.
 
 
-VERB 'about'
+META VERB 'about'
   CHECK my_game CAN about
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -823,7 +823,7 @@ END ADD TO.
 SYNTAX brief = brief.
 
 
-VERB brief
+META VERB brief
   CHECK my_game CAN brief
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -1503,7 +1503,7 @@ END ADD TO.
 SYNTAX credits = credits.
 
 
-VERB credits
+META VERB credits
   CHECK my_game CAN credits
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -3355,7 +3355,7 @@ SYNONYMS walk = go.
 SYNTAX hint = hint.
 
 
-VERB hint
+META VERB hint
   CHECK my_game CAN hint
     ELSE SAY restricted_response OF my_game.
 
@@ -4623,7 +4623,7 @@ SYNTAX notify = notify.
     -- In case (s)he adds the prepositions to the end anyway.
 
 
-VERB notify
+META VERB notify
   CHECK my_game CAN notify
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -4637,7 +4637,7 @@ VERB notify
 END VERB.
 
 
-VERB notify_on
+META VERB notify_on
   CHECK my_game CAN notify_on
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -4650,7 +4650,7 @@ VERB notify_on
 END VERB.
 
 
-VERB notify_off
+META VERB notify_off
   CHECK my_game CAN notify_off
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -5680,7 +5680,7 @@ SYNTAX
   'quit' = 'quit'.
 
 
-VERB 'quit'
+META VERB 'quit'
   CHECK my_game CAN 'quit'
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -5816,7 +5816,7 @@ END ADD TO.
 SYNTAX 'restart' = 'restart'.
 
 
-VERB 'restart'
+META VERB 'restart'
   CHECK my_game CAN 'restart'
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -5837,7 +5837,7 @@ END VERB.
 SYNTAX 'restore' = 'restore'.
 
 
-VERB 'restore'
+META VERB 'restore'
   CHECK my_game CAN 'restore'
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -5919,7 +5919,7 @@ SYNONYMS massage = rub.
 SYNTAX 'save' = 'save'.
 
 
-VERB 'save'
+META VERB 'save'
   CHECK my_game CAN 'save'
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -6021,7 +6021,7 @@ END ADD TO.
 SYNTAX 'score' = 'score'.
 
 
-VERB 'score'
+META VERB 'score'
   CHECK my_game CAN 'score'
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -6107,7 +6107,7 @@ SYNTAX 'script' = 'script'.
 
 SYNONYMS 'transcript' = 'script'.
 
-VERB 'script'
+META VERB 'script'
   CHECK my_game CAN 'script'
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -6118,7 +6118,7 @@ VERB 'script'
     of the whole game."
 END VERB.
 
-VERB script_on
+META VERB script_on
   CHECK my_game CAN script_on
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -6126,7 +6126,7 @@ VERB script_on
     "Transcripting turned on."
 END VERB.
 
-VERB script_off
+META VERB script_off
   CHECK my_game CAN script_off
     ELSE SAY restricted_response OF my_game.
   DOES
@@ -8681,7 +8681,7 @@ END ADD TO.
 SYNTAX verbose = verbose.
 
 
-VERB verbose
+META VERB verbose
   CHECK my_game CAN verbose
     ELSE SAY restricted_response OF my_game.
   DOES

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -6086,7 +6086,7 @@ ADD TO EVERY THING
     DOES
       "Nothing would be achieved by that."
 
-  END VERB 'score'.
+  END VERB scratch.
 END ADD TO.
 
 

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -224,7 +224,7 @@ META VERB 'about'
     later on.
     $pType CREDITS to see information about the author and the copyright issues.
     $pTo stop playing and end the program, type QUIT.]$p"
-END VERB.
+END VERB 'about'.
 
 
 SYNONYMS help, info = 'about'.
@@ -249,7 +249,7 @@ VERB again
   DOES
     "[The AGAIN command is not supported in this game. As a workaround, try using
      the 'up' and 'down' arrow keys to scroll through your previous commands.]"
-END VERB.
+END VERB again.
 
 
 SYNONYMS g = again.
@@ -276,7 +276,7 @@ ADD TO EVERY STRING
       ELSE SAY restricted_response OF my_game.
     DOES
       "What was the question?"
-    END VERB.
+    END VERB answer.
 END ADD TO.
 
 
@@ -338,7 +338,7 @@ ADD TO EVERY ACTOR
       
       DOES
         "There is no reply."
-  END VERB.
+  END VERB ask.
 END ADD TO.
 
 
@@ -436,7 +436,7 @@ ADD TO EVERY ACTOR
         IF my_game IS NOT temp_compliant
           THEN MAKE act NOT compliant.
         END IF.
-  END VERB.
+  END VERB ask_for.
 END ADD TO.
 
 
@@ -455,7 +455,7 @@ ADD TO EVERY OBJECT
     DOES
       "Please use the formulation ASK PERSON FOR THING to ask somebody for
        something."
-  END VERB.
+  END VERB ask_for_error.
 END ADD TO.
 
 
@@ -518,7 +518,7 @@ ADD TO EVERY THING
 
     DOES
       "Resorting to brute force is not the solution here."
-  END VERB.
+  END VERB attack.
 END ADD TO.
 
 
@@ -597,7 +597,7 @@ ADD TO EVERY THING
 
     DOES
       "Resorting to brute force is not the solution here."
-  END VERB.
+  END VERB attack_with.
 END ADD TO.
 
 
@@ -671,7 +671,7 @@ ADD TO EVERY OBJECT
           ELSE "They taste nothing out of the ordinary."
         END IF.
 
-  END VERB.
+  END VERB bite.
 END ADD TO.
 
 
@@ -727,7 +727,7 @@ ADD TO EVERY OBJECT
 
     DOES
       "Resorting to brute force is not the solution here."
-  END VERB.
+  END VERB break.
 END ADD TO.
 
 
@@ -801,7 +801,7 @@ ADD TO EVERY OBJECT
       DOES
         "Trying to break" SAY THE obj. "with" SAY THE instr.
         "wouldn't accomplish anything."
-  END VERB.
+  END VERB break_with.
 END ADD TO.
 
 
@@ -830,7 +830,7 @@ META VERB brief
     Visits 1000.
     "Brief mode is now on. Location descriptions will only be shown
     the first time you visit."
-END VERB.
+END VERB brief.
 
 
 
@@ -867,7 +867,7 @@ ADD TO EVERY OBJECT
 
     DOES
       "You must state what you want to burn" SAY THE obj. "with."
-  END VERB.
+  END VERB burn.
 END ADD TO.
 
 
@@ -937,7 +937,7 @@ ADD TO EVERY OBJECT
 
       DOES
         "You can't burn" SAY THE obj. "with" SAY THE instr. "."
-  END VERB.
+  END VERB burn_with.
 END ADD TO.
 
 
@@ -977,7 +977,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "for sale."
-  END VERB.
+  END VERB buy.
 END ADD TO.
 
 
@@ -1028,7 +1028,7 @@ ADD TO EVERY THING
         ELSE "Those don't"
       END IF.
       "need to be caught."
-  END VERB.
+  END VERB catch.
 END ADD TO.
 
 
@@ -1082,7 +1082,7 @@ ADD TO EVERY OBJECT
 
     DOES
       "Nothing would be achieved by that."
-  END VERB.
+  END VERB clean.
 END ADD TO.
 
 
@@ -1150,7 +1150,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can climb."
-  END VERB.
+  END VERB climb.
 END ADD TO.
 
 
@@ -1205,7 +1205,7 @@ ADD TO EVERY SUPPORTER
         ELSE "Those are not"
       END IF.
       "something you can climb on."
-  END VERB.
+  END VERB climb_on.
 END ADD TO.
 
 
@@ -1266,7 +1266,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can climb through."
-  END VERB.
+  END VERB climb_through.
 END ADD TO.
 
 
@@ -1326,7 +1326,7 @@ ADD TO EVERY OBJECT
     DOES
       MAKE obj NOT open.
       "You close" SAY THE obj. "."
-  END VERB.
+  END VERB close.
 END ADD TO.
 
 
@@ -1405,7 +1405,7 @@ ADD TO EVERY OBJECT
 
       DOES
         "You can't $v" SAY THE obj. "with" SAY THE instr. "."
-  END VERB.
+  END VERB close_with.
 END ADD TO.
 
 
@@ -1468,7 +1468,7 @@ ADD TO EVERY THING
 
       DOES
         "You find nothing useful about" SAY THE topic. "in" SAY THE source. "."
-  END VERB.
+  END VERB consult.
 END ADD TO.
 
 
@@ -1486,7 +1486,7 @@ ADD TO EVERY THING
     DOES
       "To consult something, please use the formulation CONSULT THING ABOUT 
        PERSON/THING."
-  END VERB.
+  END VERB consult_error.
 END ADD TO.
 
 
@@ -1514,7 +1514,7 @@ META VERB credits
     about the ALAN system can be obtained from
     the World Wide Web Internet site
     $ihttp://www.alanif.se$p"
-END VERB.
+END VERB credits.
 
 
 SYNONYMS acknowledgments, author, copyright = credits.
@@ -1553,7 +1553,7 @@ ADD TO EVERY OBJECT
       ELSE SAY check_current_loc_lit OF my_game.
 
     DOES "You need to specify what you want to cut" SAY THE obj. "with."
-  END VERB.
+  END VERB cut.
 END ADD TO.
 
 
@@ -1623,7 +1623,7 @@ ADD TO EVERY OBJECT
 
       DOES
         "You can't cut" SAY THE obj. "with" SAY THE instr. "."
-  END VERB.
+  END VERB cut_with.
 END ADD TO.
 
 
@@ -1652,7 +1652,7 @@ VERB dance
 
   DOES
     "How about a waltz?"
-END VERB.
+END VERB dance.
 
 
 
@@ -1702,7 +1702,7 @@ ADD TO EVERY OBJECT
 
     DOES
       "There is nothing suitable to dig here."
-  END VERB.
+  END VERB dig.
 END ADD TO.
 
 
@@ -1731,7 +1731,7 @@ VERB dive
 
   DOES
     "There is no water suitable for swimming here."
-END VERB.
+END VERB dive.
 
 
 
@@ -1779,7 +1779,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can dive in."
-  END VERB.
+  END VERB dive_in.
 END ADD TO.
 
 
@@ -1861,7 +1861,7 @@ ADD TO EVERY LIQUID
               LOCATE liq AT nowhere.
           END IF.
       END IF.
-  END VERB.
+  END VERB drink.
 END ADD TO.
 
 
@@ -1923,7 +1923,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can drive."
-  END VERB.
+  END VERB drive.
 END ADD TO.
 
 
@@ -1935,7 +1935,7 @@ SYNTAX drive_error = drive.
 
 VERB drive_error
   DOES "To drive something, use the phrasing DRIVE SOMETHING."
-END VERB.
+END VERB drive_error.
 
 
 
@@ -1975,7 +1975,7 @@ ADD TO EVERY OBJECT
     DOES
       LOCATE obj HERE.
       "Dropped."
-  END VERB.
+  END VERB drop.
 END ADD TO.
 
 
@@ -2043,7 +2043,7 @@ ADD TO EVERY OBJECT
       "You eat all of" SAY THE food. "."
       LOCATE food AT nowhere.
 
-  END VERB.
+  END VERB eat.
 END ADD.
 
 
@@ -2144,7 +2144,7 @@ ADD TO EVERY OBJECT
           EMPTY obj AT hero.
       END IF.
 
-  END VERB.
+  END VERB 'empty'.
 END ADD TO.
 
 
@@ -2285,7 +2285,7 @@ ADD TO EVERY OBJECT
           "You $v the contents of" SAY THE obj.
           "in" SAY THE cont. "."
       END IF.
-  END VERB.
+  END VERB empty_in.
 END ADD TO.
 
 
@@ -2403,7 +2403,7 @@ ADD TO EVERY THING
             "You $v the contents of" SAY THE obj.
             "on" SAY THE surface. "."
         END IF.
-  END VERB.
+  END VERB empty_on.
 END ADD TO.
 
 
@@ -2448,7 +2448,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can enter."
-  END VERB.
+  END VERB enter.
 END ADD TO.
 
 
@@ -2460,7 +2460,7 @@ SYNTAX enter_error = enter.
 
 VERB enter_error
   DOES "You must state what you want to enter."
-END VERB.
+END VERB enter_error.
 
 
 
@@ -2528,7 +2528,7 @@ ADD TO EVERY THING
             ELSE "You notice nothing unusual about" SAY THE obj. "."
           END IF.
       END IF.
-  END VERB.
+  END VERB examine.
 END ADD TO.
 
 
@@ -2572,7 +2572,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can exit."
-  END VERB.
+  END VERB 'exit'.
 END ADD TO.
 
 
@@ -2585,7 +2585,7 @@ SYNTAX exit_error = 'exit'.
 VERB exit_error
   DOES
     "You must state what you want to exit."
-END VERB.
+END VERB exit_error.
 
 
 
@@ -2644,7 +2644,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "on fire."
-  END VERB.
+  END VERB extinguish.
 END ADD TO.
 
 
@@ -2691,7 +2691,7 @@ ADD TO EVERY OBJECT
 
     DOES
       "You have to say what you want to fill" SAY THE cont. "with."
-  END VERB.
+  END VERB fill.
 END ADD TO.
 
 
@@ -2779,7 +2779,7 @@ ADD TO EVERY OBJECT
       DOES
         "You can't fill" SAY THE cont. "with" SAY THE substance. "."
         -- allow the action at individual substances only
-  END VERB.
+  END VERB fill_with.
 END ADD TO.
 
 
@@ -2820,7 +2820,7 @@ ADD TO EVERY THING
 
     DOES
       "You'll have to $v it yourself."
-  END VERB.
+  END VERB find.
 END ADD TO.
 
 
@@ -2861,7 +2861,7 @@ ADD TO EVERY WEAPON
 
     DOES
       "You fire" SAY THE weapon. "into the air."
-  END VERB.
+  END VERB fire.
 END ADD TO.
 
 
@@ -2916,7 +2916,7 @@ ADD TO EVERY WEAPON
 
       DOES
         "Resorting to violence is not the solution here."
-  END VERB.
+  END VERB fire_at.
 END ADD TO.
 
 
@@ -2943,7 +2943,7 @@ ADD TO EVERY THING
 
     DOES
       "Resorting to violence is not the solution here."
-  END VERB.
+  END VERB fire_at_error.
 END ADD TO.
 
 
@@ -2996,7 +2996,7 @@ ADD TO EVERY OBJECT
 
     DOES
       "Please be more specific. How do you intend to fix it?"
-  END VERB.
+  END VERB fix.
 END ADD TO.
 
 
@@ -3046,7 +3046,7 @@ ADD TO EVERY THING
     DOES
       LOCATE hero AT act.
       "You follow" SAY THE act. "."
-  END VERB.
+  END VERB follow.
 END ADD TO.
 
 
@@ -3104,7 +3104,7 @@ ADD TO EVERY THING
         THEN "That doesn't need to be $vd."
         ELSE "Those don't need to be $vd."
       END IF.
-  END VERB.
+  END VERB free.
 END ADD TO.
 
 
@@ -3141,7 +3141,7 @@ ADD TO EVERY SUPPORTER
           MAKE hero NOT sitting.
         ELSE "You're standing up already."
       END IF.
-    END VERB.
+    END VERB get_off.
 END ADD TO.
 
 
@@ -3172,7 +3172,7 @@ VERB get_up
           MAKE hero NOT sitting.
       ELSE "You're standing up already."
     END IF.
-END VERB.
+END VERB get_up.
 
 
 
@@ -3258,7 +3258,7 @@ ADD TO EVERY OBJECT
         LOCATE obj IN recipient.
         "You give" SAY THE obj. "to" SAY THE recipient. "."
 
-  END VERB.
+  END VERB give.
 END ADD TO.
 
 
@@ -3319,7 +3319,7 @@ ADD TO EVERY THING
     DOES
       "You can't see" SAY THE dest. "anywhere nearby. You must state a
       direction where you want to go."
-  END VERB.
+  END VERB go_to.
 END ADD TO.
 
 
@@ -3361,7 +3361,7 @@ META VERB hint
 
   DOES
     "Unfortunately hints are not available in this game."
-END VERB.
+END VERB hint.
 
 
 SYNONYMS
@@ -3393,7 +3393,7 @@ VERB i
       THEN LIST worn.     -- This code will list what the hero is wearing.
     END IF.
 
-END VERB.
+END VERB i.
 
 
 SYNONYMS inv, inventory  = i.
@@ -3422,7 +3422,7 @@ VERB jump
 
   DOES
     "You jump on the spot, to no avail."
-END VERB.
+END VERB jump.
 
 
 
@@ -3483,7 +3483,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not something you can jump into."
       END IF.
 
-  END VERB.
+  END VERB jump_in.
 END ADD TO.
 
 
@@ -3524,7 +3524,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can jump onto."
 
-  END VERB.
+  END VERB jump_on.
 END ADD TO.
 
 
@@ -3583,7 +3583,7 @@ ADD TO EVERY THING
 
     DOES "Resorting to brute force is not the solution here."
 
-  END VERB.
+  END VERB kick.
 END ADD TO.
 
 
@@ -3623,7 +3623,7 @@ ADD TO EVERY ACTOR
 
     DOES "You have to state what you want to kill" SAY THE victim. "with."
 
-  END VERB.
+  END VERB kill.
 END ADD TO.
 
 
@@ -3673,7 +3673,7 @@ ADD TO EVERY ACTOR
       DOES
         "That would be needlessly brutal."
 
-  END VERB.
+  END VERB kill_with.
 END ADD TO.
 
 
@@ -3732,7 +3732,7 @@ ADD TO EVERY THING
         ELSE "Nothing would be achieved by that."
       END IF.
 
-  END VERB.
+  END VERB kiss.
 END ADD TO.
 
 
@@ -3791,7 +3791,7 @@ ADD TO EVERY OBJECT
     DOES
       "You knock on" SAY THE obj. "$$. Nothing happens."
 
-  END VERB.
+  END VERB knock.
 END ADD TO.
 
 
@@ -3804,7 +3804,7 @@ SYNTAX knock_error = knock.
 VERB knock_error
   DOES
     "Please use the formulation KNOCK ON SOMETHING to knock on something."
-END VERB.
+END VERB knock_error.
 
 
 
@@ -3834,7 +3834,7 @@ VERB lie_down
         -- DOES "You lie down."
         -- MAKE hero lying_down.
         -- MAKE hero NOT sitting_down.
-END VERB.
+END VERB lie_down.
 
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
@@ -3905,7 +3905,7 @@ ADD TO EVERY OBJECT
       -- Remember to: MAKE hero lying_down.
       -- Presently, an actor cannot be located inside a container object.
 
-  END VERB.
+  END VERB lie_in.
 END ADD TO.
 
 
@@ -3972,7 +3972,7 @@ ADD TO EVERY OBJECT
                 -- Presently, an actor cannot be located inside a container object
       -- or on a supporter.
 
-  END VERB.
+  END VERB lie_on.
 END ADD TO.
 
 
@@ -4047,7 +4047,7 @@ ADD TO EVERY OBJECT
     DOES
       "That wouldn't accomplish anything."
 
-  END VERB.
+  END VERB lift.
 END ADD TO.
 
 
@@ -4105,7 +4105,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can $v."
 
-  END VERB.
+  END VERB light.
 END ADD TO.
 
 
@@ -4130,7 +4130,7 @@ VERB listen0
     ELSE SAY restricted_response OF my_game.
   DOES
     "You hear nothing unusual."
-END VERB.
+END VERB listen0.
 
 
 
@@ -4175,7 +4175,7 @@ ADD TO EVERY THING
         THEN "You can't hear" SAY THE obj. "very well from here."
       END IF.
 
-  END VERB.
+  END VERB listen.
 END ADD TO.
 
 
@@ -4247,7 +4247,7 @@ ADD TO EVERY OBJECT
             ELSE  "You have to state what you want to lock" SAY THE obj. "with."
       END IF.
 
-  END VERB.
+  END VERB lock.
 END ADD TO.
 
 
@@ -4331,7 +4331,7 @@ ADD TO EVERY OBJECT
         END IF.
         "lock" SAY THE obj. "with" SAY THE key. "."
 
-  END VERB.
+  END VERB lock_with.
 END ADD TO.
 
 
@@ -4355,7 +4355,7 @@ VERB 'look'
     INCREASE described OF CURRENT LOCATION.
     -- see 'locations.i', attribute 'described'.
     LOOK.
-END VERB.
+END VERB 'look'.
 
 
 SYNONYMS l = 'look'.
@@ -4405,7 +4405,7 @@ ADD TO EVERY THING
         ELSE "You notice nothing unusual behind" SAY THE bulk. "."
       END IF.
 
-  END VERB.
+  END VERB look_behind.
 END ADD TO.
 
 
@@ -4445,7 +4445,7 @@ ADD TO EVERY OBJECT
     DOES
       LIST cont.
 
-  END VERB.
+  END VERB look_in.
 END ADD TO.
 
 
@@ -4489,7 +4489,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can look out of."
 
-  END VERB.
+  END VERB look_out_of.
 END ADD TO.
 
 
@@ -4521,7 +4521,7 @@ ADD TO EVERY OBJECT
     DOES
       "You can't see through" SAY THE bulk. "."
 
-  END VERB.
+  END VERB look_through.
 END ADD TO.
 
 
@@ -4555,7 +4555,7 @@ ADD TO EVERY THING
     DOES
       "You notice nothing unusual under" SAY THE bulk. "."
 
-  END VERB.
+  END VERB look_under.
 END ADD TO.
 
 
@@ -4576,7 +4576,7 @@ VERB look_up
   CHECK my_game CAN look_up
     ELSE SAY restricted_response OF my_game.
   DOES "Looking up, you see nothing unusual."
-END VERB.
+END VERB look_up.
 
 
 
@@ -4596,7 +4596,7 @@ VERB 'no'
   CHECK my_game CAN 'no'
     ELSE SAY restricted_response OF my_game.
   DOES "Really?"
-END VERB.
+END VERB 'no'.
 
 
 
@@ -4634,7 +4634,7 @@ META VERB notify
       ELSE MAKE my_game notify_turned_on. "Score notification is now enabled.
         (You can turn it off using the NOTIFY command again.)"
     END IF.
-END VERB.
+END VERB notify.
 
 
 META VERB notify_on
@@ -4647,7 +4647,7 @@ META VERB notify_on
         "Score notification is now enabled.
         (You can turn it off using the NOTIFY command again.)"
     END IF.
-END VERB.
+END VERB notify_on.
 
 
 META VERB notify_off
@@ -4660,7 +4660,7 @@ META VERB notify_off
         using the NOTIFY command again.)"
       ELSE "Score notification is already disabled."
     END IF.
-END VERB.
+END VERB notify_off.
 
 
 -- The 'notify' verb allows the players to disable the score change
@@ -4778,7 +4778,7 @@ ADD TO EVERY OBJECT
         "You open" SAY THE obj. "."
       END IF.
 
-  END VERB.
+  END VERB open.
 END ADD TO.
 
 
@@ -4870,7 +4870,7 @@ ADD TO EVERY OBJECT
           ELSE "You can't open" SAY THE obj. "with" SAY THE instr. "."
         END IF.
 
-  END VERB.
+  END VERB open_with.
 END ADD TO.
 
 
@@ -4928,7 +4928,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can play."
 
-  END VERB.
+  END VERB 'play'.
 END ADD TO.
 
 
@@ -4986,7 +4986,7 @@ ADD TO EVERY THING
       "After second thought you don't find it purposeful to start
        playing with" SAY THE obj. "."
 
-  END VERB.
+  END VERB play_with.
 END ADD TO.
 
 
@@ -5022,7 +5022,7 @@ VERB pray
   CHECK my_game CAN pray
     ELSE SAY restricted_response OF my_game.
   DOES "Your prayers don't seem to help right now."
-END VERB.
+END VERB pray.
 
 
 
@@ -5059,7 +5059,7 @@ ADD TO EVERY OBJECT
 
     DOES "You must state what you want to pry" SAY THE obj. "with."
 
-  END VERB.
+  END VERB pry.
 END ADD TO.
 
 
@@ -5129,7 +5129,7 @@ ADD TO EVERY OBJECT
 
     DOES "That doesn't work."
 
-  END VERB.
+  END VERB pry_with.
 END ADD TO.
 
 
@@ -5183,7 +5183,7 @@ ADD TO EVERY OBJECT
     DOES
       "That wouldn't accomplish anything."
 
-  END VERB.
+  END VERB pull.
 END ADD TO.
 
 
@@ -5237,7 +5237,7 @@ ADD TO EVERY THING
     DOES
       "You give" SAY THE obj. "a little push. Nothing happens."
 
-  END VERB.
+  END VERB push.
 END ADD TO.
 
 
@@ -5307,7 +5307,7 @@ ADD TO EVERY THING
       DOES
         "That wouldn't accomplish anything."
 
-  END VERB.
+  END VERB push_with.
 END ADD TO.
 
 
@@ -5343,7 +5343,7 @@ ADD TO EVERY OBJECT
         ELSE "them."
       END IF.
 
-  END VERB.
+  END VERB put.
 END ADD TO.
 
 
@@ -5458,7 +5458,7 @@ ADD TO EVERY OBJECT
         LOCATE obj IN cont.
         "You put" SAY THE obj. "into" SAY THE cont. "."
 
-  END VERB.
+  END VERB put_in.
 END ADD TO.
 
 
@@ -5555,7 +5555,7 @@ ADD TO EVERY OBJECT
       DOES
         "That wouldn't accomplish anything."
 
-  END VERB.
+  END VERB put_against.
 END ADD TO.
 
 
@@ -5649,7 +5649,7 @@ ADD TO EVERY OBJECT
 
         "You put" SAY THE obj. "on" SAY THE surface. "."
 
-  END VERB.
+  END VERB put_on.
 END ADD TO.
 
 
@@ -5685,7 +5685,7 @@ META VERB 'quit'
     ELSE SAY restricted_response OF my_game.
   DOES
     QUIT.
-END VERB.
+END VERB 'quit'.
 
 
 SYNONYMS q = 'quit'.
@@ -5742,7 +5742,7 @@ ADD TO EVERY OBJECT
           """$$" SAY text OF obj. "$$""."
       END IF.
 
-  END VERB.
+  END VERB read.
 END ADD TO.
 
 
@@ -5786,7 +5786,7 @@ ADD TO EVERY OBJECT
         ELSE "them."
       END IF.
 
-  END VERB.
+  END VERB remove.
 END ADD TO.
 
 
@@ -5821,7 +5821,7 @@ META VERB 'restart'
     ELSE SAY restricted_response OF my_game.
   DOES
     RESTART.
-END VERB.
+END VERB 'restart'.
 
 
 
@@ -5842,7 +5842,7 @@ META VERB 'restore'
     ELSE SAY restricted_response OF my_game.
   DOES
     RESTORE.
-END VERB.
+END VERB 'restore'.
 
 
 
@@ -5899,7 +5899,7 @@ ADD TO EVERY THING
     DOES
       "Nothing would be achieved by that."
 
-  END VERB.
+  END VERB rub.
 END ADD TO.
 
 
@@ -5924,7 +5924,7 @@ META VERB 'save'
     ELSE SAY restricted_response OF my_game.
   DOES
     SAVE.
-END VERB.
+END VERB 'save'.
 
 
 
@@ -5950,7 +5950,7 @@ ADD TO EVERY STRING
     DOES
       "Nothing happens."
 
-  END VERB.
+  END VERB 'say'.
 END ADD TO.
 
 
@@ -6004,7 +6004,7 @@ ADD TO EVERY ACTOR
       END IF.
       "interested."
 
-  END VERB.
+  END VERB say_to.
 END ADD TO.
 
 
@@ -6086,7 +6086,7 @@ ADD TO EVERY THING
     DOES
       "Nothing would be achieved by that."
 
-  END VERB.
+  END VERB 'score'.
 END ADD TO.
 
 
@@ -6116,7 +6116,7 @@ META VERB 'script'
     $pIn a GUI version you can also find this in the drop-down menu in the interpreter.
     $pIn a command line version you can start your game with the '-s' switch to get a transcript
     of the whole game."
-END VERB.
+END VERB 'script'.
 
 META VERB script_on
   CHECK my_game CAN script_on
@@ -6124,7 +6124,7 @@ META VERB script_on
   DOES
     TRANSCRIPT ON.
     "Transcripting turned on."
-END VERB.
+END VERB script_on.
 
 META VERB script_off
   CHECK my_game CAN script_off
@@ -6132,7 +6132,7 @@ META VERB script_off
   DOES
     TRANSCRIPT OFF.
     "Transcripting turned off."
-END VERB.
+END VERB script_off.
 
 
 
@@ -6183,7 +6183,7 @@ ADD TO EVERY THING
     DOES
       "You find nothing of interest."
 
-  END VERB.
+  END VERB search.
 END ADD TO.
 
 
@@ -6222,7 +6222,7 @@ ADD TO EVERY OBJECT
     DOES
       "There's nobody here who would be interested in buying" SAY THE item. "."
 
-  END VERB.
+  END VERB sell.
 END ADD TO.
 
 -- Depending on the situation, it might be good to add a check whether the item is carried
@@ -6285,7 +6285,7 @@ ADD TO EVERY OBJECT
         ELSE "There is no reason to start shaking" SAY THE obj. "."
       END IF.
 
-  END VERB.
+  END VERB shake.
 END ADD TO.
 
 
@@ -6342,7 +6342,7 @@ ADD TO EVERY THING
         ELSE "That wouldn't accomplish anything."
       END IF.
 
-  END VERB.
+  END VERB shoot.
 END ADD TO.
 
 
@@ -6358,7 +6358,7 @@ SYNTAX shoot_error = shoot.
 VERB shoot_error
   DOES
     "You must state what you want to shoot, for example SHOOT BEAR WITH RIFLE."
-END VERB.
+END VERB shoot_error.
 
 
 
@@ -6423,7 +6423,7 @@ ADD TO EVERY THING
         ELSE "That wouldn't accomplish anything."
       END IF.
 
-  END VERB.
+  END VERB shoot_with.
 END ADD TO.
 
 
@@ -6445,7 +6445,7 @@ VERB shout
     ELSE SAY restricted_response OF my_game.
     DOES
         "Nothing results from your $ving."
-END VERB.
+END VERB shout.
 
 
 SYNONYMS scream, yell = shout.
@@ -6501,7 +6501,7 @@ ADD TO EVERY OBJECT
       END IF.
       "not especially interested."
 
-  END VERB.
+  END VERB 'show'.
 END ADD TO.
 
 
@@ -6526,7 +6526,7 @@ VERB sing
     ELSE SAY restricted_response OF my_game.
   DOES
     "You $v a little tune."
-END VERB.
+END VERB sing.
 
 
 SYNONYMS hum, whistle = sing.
@@ -6607,7 +6607,7 @@ ADD TO EVERY LIQUID
           END IF.
       END IF.
 
-  END VERB.
+  END VERB sip.
 END ADD TO.
 
 
@@ -6643,7 +6643,7 @@ VERB sit
     --  ELSE "You sit down."
     -- END IF.
     -- MAKE hero sitting.
-END VERB.
+END VERB sit.
 
 -- When the hero is sitting or lying down, it will be impossible for her/him to
 -- perform certain actions, as numerous verbs in the library have checks for this.
@@ -6709,7 +6709,7 @@ ADD TO EVERY SUPPORTER
       -- END IF.
       -- MAKE hero sitting.
 
-  END VERB.
+  END VERB sit_on.
 END ADD TO.
 
 
@@ -6741,7 +6741,7 @@ VERB sleep
     ELSE SAY restricted_response OF my_game.
   DOES
     "There's no need to $v right now."
-END VERB.
+END VERB sleep.
 
 
 SYNONYMS rest = sleep.
@@ -6765,7 +6765,7 @@ VERB smell0
     ELSE SAY restricted_response OF my_game.
   DOES
     "You smell nothing unusual."
-END VERB.
+END VERB smell0.
 
 
 
@@ -6793,7 +6793,7 @@ ADD TO EVERY THING
       ELSE SAY restricted_response OF my_game.
     DOES
       "You smell nothing unusual."
-  END VERB.
+  END VERB smell.
 END ADD TO.
 
 
@@ -6847,7 +6847,7 @@ ADD TO EVERY THING
     DOES
       "Trying to squeeze" SAY THE obj. "wouldn't accomplish anything."
 
-  END VERB.
+  END VERB squeeze.
 END ADD TO.
 
 
@@ -6876,7 +6876,7 @@ VERB stand
         MAKE hero NOT lying_down.
       ELSE "You're standing up already."
     END IF.
-END VERB.
+END VERB stand.
 
 
 
@@ -6931,7 +6931,7 @@ ADD TO EVERY SUPPORTER
       -- you implement a nested location.)
       -- MAKE hero NOT sitting. MAKE hero NOT lying_down.
 
-  END VERB.
+  END VERB stand_on.
 END ADD TO.
 
 
@@ -6959,7 +6959,7 @@ VERB swim
     ELSE SAY check_current_loc_lit OF my_game.
   DOES
     "There is no water suitable for swimming here."
-END VERB.
+END VERB swim.
 
 
 
@@ -7015,7 +7015,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can swim in."
 
-  END VERB.
+  END VERB swim_in.
 END ADD TO.
 
 
@@ -7058,7 +7058,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "not something you can switch."
-  END VERB.
+  END VERB switch.
 END ADD TO.
 
 
@@ -7190,7 +7190,7 @@ ADD TO EVERY THING
         -- Objects held by NPCs cannot be taken by the hero by default.
         -- The hero must *ask for* the object to obtain it.
 
-  END VERB.
+  END VERB take.
 END ADD TO.
 
 
@@ -7336,7 +7336,7 @@ ADD TO EVERY THING
         -- Objects held by NPCs cannot be taken by the hero by default.
         -- The hero must *ask for* the object to obtain it.
 
-  END VERB.
+  END VERB take_from.
 END ADD TO.
 
 
@@ -7359,7 +7359,7 @@ VERB talk
   DOES
     "To talk to somebody, you can ASK PERSON ABOUT THING
      or TELL PERSON ABOUT THING."
-END VERB.
+END VERB talk.
 
 
 
@@ -7388,7 +7388,7 @@ ADD TO EVERY ACTOR
     DOES
       "To talk to somebody, you can ASK PERSON ABOUT THING or
        TELL PERSON ABOUT THING."
-  END VERB.
+  END VERB talk_to.
 END ADD TO.
 
 
@@ -7448,7 +7448,7 @@ ADD TO EVERY OBJECT
     DOES
       "You taste nothing unexpected."
 
-  END VERB.
+  END VERB taste.
 END ADD TO.
 
 
@@ -7505,7 +7505,7 @@ ADD TO EVERY OBJECT
     DOES
       "Trying to $v" SAY THE obj. "would be futile."
 
-  END VERB.
+  END VERB tear.
 END ADD TO.
 
 
@@ -7565,7 +7565,7 @@ ADD TO EVERY ACTOR
       END IF.
       "look interested."
 
-  END VERB.
+  END VERB tell.
 END ADD TO.
 
 
@@ -7590,7 +7590,7 @@ VERB think
     ELSE SAY restricted_response OF my_game.
   DOES
     "Nothing helpful comes to your mind."
-END VERB.
+END VERB think.
 
 
 SYNONYMS ponder, meditate, reflect = think.
@@ -7621,7 +7621,7 @@ ADD TO EVERY THING
       ELSE SAY restricted_response OF my_game.
     DOES
       "Nothing helpful comes to your mind."
-    END VERB.
+    END VERB think_about.
 END ADD TO.
 
 
@@ -7695,7 +7695,7 @@ ADD TO EVERY OBJECT
       "nearby."
       LOCATE projectile AT hero.
 
-  END VERB.
+  END VERB throw.
 END ADD TO.
 
 
@@ -7811,7 +7811,7 @@ ADD TO EVERY OBJECT
           -- when attacking enemies.
         END IF.
 
-  END VERB.
+  END VERB throw_at.
 END ADD TO.
 
 
@@ -7888,7 +7888,7 @@ ADD TO EVERY OBJECT
       "It wouldn't accomplish anything trying to throw"
       SAY the projectile. "to" SAY THE recipient. "."
 
-  END VERB.
+  END VERB throw_to.
 END ADD TO.
 
 
@@ -7994,7 +7994,7 @@ ADD TO EVERY OBJECT
       -- default; this is to avoid successful outcomes for commands like
       -- 'throw plate into cupboard' etc.
 
-  END VERB.
+  END VERB throw_in.
 END ADD TO.
 
 
@@ -8033,7 +8033,7 @@ ADD TO EVERY OBJECT
     DOES
       "You must state where you want to tie" SAY THE obj. "."
 
-  END VERB.
+  END VERB tie.
 END ADD TO.
 
 
@@ -8115,7 +8115,7 @@ ADD TO EVERY THING
 
       "It's not possible to tie" SAY THE obj. "to" SAY THE target. "."
 
-  END VERB.
+  END VERB tie_to.
 END ADD TO.
 
 
@@ -8173,7 +8173,7 @@ ADD TO EVERY THING
     DOES
       "You feel nothing unexpected."
 
-  END VERB.
+  END VERB touch.
 END ADD TO.
 
 
@@ -8251,7 +8251,7 @@ ADD TO EVERY THING
     DOES
       "You touch" SAY THE obj. "with" SAY THE instr. ". Nothing special happens."
 
-  END VERB.
+  END VERB touch_with.
 END ADD TO.
 
 
@@ -8321,7 +8321,7 @@ ADD TO EVERY OBJECT
         ELSE "That wouldn't accomplish anything."
       END IF.
 
-  END VERB.
+  END VERB turn.
 END ADD TO.
 
 
@@ -8377,7 +8377,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can $v on."
 
-  END VERB.
+  END VERB turn_on.
 END ADD TO.
 
 
@@ -8429,7 +8429,7 @@ ADD TO EVERY OBJECT
         ELSE "Those are not"
       END IF.
       "something you can $v off."
-  END VERB.
+  END VERB turn_off.
 END ADD TO.
 
 
@@ -8459,7 +8459,7 @@ VERB undress
       --     "You remove all the items you were wearing."
       --   ELSE "You're not wearing anything you can remove."
       -- END IF.
-END VERB.
+END VERB undress.
 
 
 
@@ -8523,7 +8523,7 @@ ADD TO EVERY OBJECT
         ELSE "You don't have the key that unlocks" SAY THE obj. "."
       END IF.
 
-  END VERB.
+  END VERB unlock.
 END ADD TO.
 
 
@@ -8599,7 +8599,7 @@ ADD TO EVERY OBJECT
       MAKE obj NOT locked.
       "You unlock" SAY THE obj. "with" SAY THE key. "."
 
-  END VERB.
+  END VERB unlock_with.
 END ADD TO.
 
 
@@ -8631,7 +8631,7 @@ ADD TO EVERY OBJECT
         ELSE "them?"
       END IF.
 
-  END VERB.
+  END VERB 'use'.
 END ADD TO.
 
 
@@ -8663,7 +8663,7 @@ ADD TO EVERY OBJECT
     DOES
       "Please be more specific. How do you intend to use them together?"
 
-  END VERB.
+  END VERB use_with.
 END ADD TO.
 
 
@@ -8688,7 +8688,7 @@ META VERB verbose
     VISITS 0.
     "Verbose mode is now on. Location descriptions will be
     always shown in full."
-END VERB.
+END VERB verbose.
 
 
 
@@ -8709,7 +8709,7 @@ VERB 'wait'
     ELSE SAY restricted_response OF my_game.
   DOES
     "Time passes..."
-END VERB.
+END VERB 'wait'.
 
 
 SYNONYMS
@@ -8777,7 +8777,7 @@ ADD TO EVERY OBJECT
       END IF.
       "something you can wear."
 
-  END VERB.
+  END VERB wear.
 END ADD TO.
 
 
@@ -8799,7 +8799,7 @@ VERB what_am_i
     ELSE SAY restricted_response OF my_game.
   DOES
     "Maybe examining yourself might help."
-END VERB.
+END VERB what_am_i.
 
 
 
@@ -8829,7 +8829,7 @@ ADD TO EVERY THING
       ELSE SAY restricted_response OF my_game.
     DOES
       "You'll have to find it out yourself."
-  END VERB.
+  END VERB what_is.
 END ADD TO.
 
 
@@ -8851,7 +8851,7 @@ VERB where_am_i
     ELSE SAY restricted_response OF my_game.
   DOES
     LOOK.
-END VERB.
+END VERB where_am_i.
 
 
 
@@ -8887,7 +8887,7 @@ ADD TO EVERY THING
         END IF.
     DOES
       "You'll have to find it out yourself."
-  END VERB.
+  END VERB where_is.
 END ADD TO.
 
 
@@ -8909,7 +8909,7 @@ VERB who_am_i
     ELSE SAY restricted_response OF my_game.
   DOES
     "Maybe examining yourself might help."
-END VERB.
+END VERB who_am_i.
 
 
 
@@ -8939,7 +8939,7 @@ ADD TO EVERY ACTOR
       ELSE SAY restricted_response OF my_game.
     DOES
       "You'll have to find it out yourself."
-  END VERB.
+  END VERB who_is.
 END ADD TO.
 
 
@@ -8999,7 +8999,7 @@ ADD TO EVERY OBJECT
       -- "You write ""$$" SAY txt. "$$"" on" SAY THE obj. "."
         -- MAKE obj readable.
 
-  END VERB.
+  END VERB write.
 END ADD TO.
 
 
@@ -9017,7 +9017,7 @@ ADD TO EVERY OBJECT
   VERB write_error1
     DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
           to write something."
-  END VERB.
+  END VERB write_error1.
 END ADD TO.
 
 
@@ -9026,7 +9026,7 @@ SYNTAX write_error2 = write.
 VERB write_error2
   DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
         to write something."
-END VERB.
+END VERB write_error2.
 
 
 SYNTAX write_error3 = write (txt)
@@ -9039,7 +9039,7 @@ ADD TO EVERY STRING
   VERB write_error3
     DOES "Please use the formulation WRITE ""TEXT"" ON (IN) OBJECT
           to write something."
-  END VERB.
+  END VERB write_error3.
 END ADD TO.
 
 
@@ -9060,7 +9060,7 @@ VERB yes
   CHECK my_game CAN yes
     ELSE SAY restricted_response OF my_game.
   DOES "Really?"
-END VERB.
+END VERB yes.
 
 
 

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -83,7 +83,6 @@
 ----- lock                                                        lock (obj)                          1       x
 ----- lock_with                                                   lock (obj) with (key)               2       x
 ----- look        (+ gaze, peek)                                  look                                0
------ look_at                                                     look at (obj)                       1       x
 ----- look_behind                                                 look behind (bulk)                  1
 ----- look_in                                                     look in (cont)                      1
 ----- look_out_of                                                 look out of (obj)                   1       x

--- a/mygame_import.i
+++ b/mygame_import.i
@@ -43,7 +43,7 @@
 --         -- this is the original default response defined by the library, 
 --         -- and in the list of verbs further below.
 --     END IF.
--- END VERB.
+-- END VERB look_through.
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -- Above, the author has added an IF clause to cater for both window objects and
@@ -57,7 +57,7 @@
 -- EVERY cat ISA ACTOR
 --   VERB examine 
 --     DOES ONLY "It's just an ordinary cat"
---   END VERB.
+--   END VERB examine.
 -- END EVERY.  
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -72,7 +72,7 @@
 --   CHECK strength OF hero > 5            -- your own check, added in this file 
 --     ELSE "You feel too weak."           -- and not in the library files!
 --   DOES "You jump on the spot, to no avail."
--- END VERB.
+-- END VERB jump.
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
@@ -490,7 +490,7 @@ VERB 'about'
      RESTORE it later on.
      $pType CREDITS to see information about the author and the copyright issues.
      $pTo stop playing and end the program, type QUIT.]$p"
-END VERB.
+END VERB 'about'.
 
 
 
@@ -498,21 +498,21 @@ VERB 'again'
   DOES ONLY
     "[The AGAIN command is not supported in this game. As a workaround, try using
      the 'up' and 'down' arrow keys to scroll through your previous commands.]" 
-END VERB.
+END VERB 'again'.
 
 
 
 VERB answer
   DOES ONLY
     "What was the question?"
-END VERB.
+END VERB answer.
 
 
 
 VERB ask
   WHEN act
     DOES ONLY "There is no reply."
-END VERB.
+END VERB ask.
 
 
 
@@ -524,14 +524,14 @@ VERB ask_for
     LOCATE obj IN hero.
     SAY THE act. "gives" SAY THE obj. "to you."
     MAKE act NOT compliant.
-END VERB.
+END VERB ask_for.
 
 
 
 VERB attack
   DOES ONLY
     "Resorting to brute force is not the solution here."
-END VERB.
+END VERB attack.
 
 
 
@@ -539,7 +539,7 @@ VERB attack_with
   WHEN target
     DOES ONLY
       "Resorting to brute force is not the solution here."
-END VERB.
+END VERB attack_with.
 
 
 
@@ -552,14 +552,14 @@ VERB bite
           ELSE "They taste nothing out of the ordinary."
         END IF.
     END IF.
-END VERB.
+END VERB bite.
 
 
 
 VERB break
   DOES ONLY
     "Resorting to brute force is not the solution here."
-END VERB.
+END VERB break.
 
 
 
@@ -567,7 +567,7 @@ VERB break_with
   DOES ONLY   
     "Trying to break" SAY THE obj. "with" SAY THE instr. 
     "wouldn't accomplish anything."
-END VERB.
+END VERB break_with.
 
 
 
@@ -576,21 +576,21 @@ VERB 'brief'
     Visits 1000.
     "Brief mode is now on. Location descriptions will only be shown
      the first time you visit."
-END VERB.
+END VERB 'brief'.
 
 
 
 VERB burn
   DOES ONLY
     "You must state what you want to burn" SAY THE obj. "with."
-END VERB.
+END VERB burn.
 
 
 
 VERB burn_with
   DOES ONLY
     "You can't burn" SAY THE obj. "with" SAY THE instr. "."
-END VERB.
+END VERB burn_with.
 
 
 
@@ -601,7 +601,7 @@ VERB buy
       ELSE "Those are not"
     END IF. 
     "for sale."
-END VERB.
+END VERB buy.
 
 
 
@@ -612,14 +612,14 @@ VERB catch
       ELSE "Those don't"
     END IF.
     "need to be caught."
-END VERB.
+END VERB catch.
 
 
 
 VERB clean
   DOES ONLY
     "Nothing would be achieved by that."
-END VERB.
+END VERB clean.
 
 
 
@@ -630,7 +630,7 @@ VERB climb
       ELSE "Those are not"
     END IF. 
     "something you can climb."
-END VERB.
+END VERB climb.
 
 
 
@@ -641,7 +641,7 @@ VERB climb_on
       ELSE "Those are not"
     END IF.
     "something you can climb on."
-END VERB.
+END VERB climb_on.
 
 
 
@@ -652,7 +652,7 @@ VERB climb_through
       ELSE "Those are not"
     END IF.
     "something you can climb through."
-END VERB.
+END VERB climb_through.
 
 
 
@@ -660,21 +660,21 @@ VERB close
   DOES ONLY
         MAKE obj NOT open.
         "You close" SAY THE obj. "."
-END VERB.
+END VERB close.
 
 
 
 VERB close_with
   DOES ONLY
         "You can't $v" SAY THE obj. "with" SAY THE instr. "."
-END VERB.
+END VERB close_with.
 
 
 
 VERB consult
   DOES ONLY
     "You find nothing useful about" SAY THE topic. "in" SAY THE source. "."
-END VERB.
+END VERB consult.
 
 
 
@@ -687,42 +687,42 @@ VERB credits
      about the ALAN system can be obtained from
      the World Wide Web Internet site
      $ihttp://www.alanif.se$p"
-END VERB.
+END VERB credits.
 
 
 
 VERB cut
   DOES ONLY
     "You need to specify what you want to cut" SAY THE obj. "with."
-END VERB.
+END VERB cut.
 
 
 
 VERB cut_with
   DOES ONLY
     "You can't cut" SAY THE obj. "with" SAY THE instr. "."
-END VERB.
+END VERB cut_with.
 
 
 
 VERB dance
   DOES ONLY
         "How about a waltz?"
-END VERB.
+END VERB dance.
 
 
 
 VERB dig
   DOES ONLY
     "There is nothing suitable to dig here."
-END VERB.
+END VERB dig.
 
 
 
 VERB dive
   DOES ONLY 
     "There is no water suitable for swimming here."
-END VERB.
+END VERB dive.
 
 
 
@@ -733,7 +733,7 @@ VERB dive_in
       ELSE "Those are not"
     END IF.
     "something you can dive in."
-END VERB.
+END VERB dive_in.
 
 
 
@@ -770,7 +770,7 @@ VERB drink
         END IF.
     END IF.
 
-END VERB.
+END VERB drink.
 
 
 
@@ -781,7 +781,7 @@ VERB drive
       ELSE "Those are not"
     END IF.
     "something you can drive."
-END VERB.
+END VERB drive.
 
 
 
@@ -789,7 +789,7 @@ VERB drop
   DOES ONLY
         LOCATE obj HERE.
         "Dropped."
-END VERB.
+END VERB drop.
 
 
 
@@ -804,7 +804,7 @@ VERB eat
       
     "You eat all of" SAY THE food. "."
     LOCATE food AT nowhere.
-END VERB.
+END VERB eat.
 
 
 
@@ -827,7 +827,7 @@ VERB 'empty'
           END IF.
         EMPTY obj AT hero.
     END IF.
-END VERB.
+END VERB 'empty'.
 
 
 
@@ -847,7 +847,7 @@ VERB empty_in, pour_in
         "You $v the contents of" SAY THE obj.
         "in" SAY THE cont. "."
     END IF.
-END VERB. 
+END VERB empty_in. 
     
 
 
@@ -870,7 +870,7 @@ VERB empty_on, pour_on
         "You $v the contents of" SAY THE obj.
         "on" SAY THE surface. "."
     END IF.
-END VERB.
+END VERB empty_on.
 
 
 
@@ -881,7 +881,7 @@ VERB enter
       ELSE "Those are not"
     END IF.
     "something you can enter."
-END VERB.
+END VERB enter.
 
 
 
@@ -905,7 +905,7 @@ VERB examine
           ELSE "You notice nothing unusual about" SAY THE obj. "."
         END IF. 
     END IF.
-END VERB.
+END VERB examine.
 
 
 
@@ -916,7 +916,7 @@ VERB 'exit'
       ELSE "Those are not"
     END IF.   
     "something you can exit."
-END VERB.
+END VERB 'exit'.
 
 
 
@@ -927,14 +927,14 @@ VERB extinguish
       ELSE "Those are not"
     END IF.
     "on fire."
-END VERB.
+END VERB extinguish.
 
 
 
 VERB fill
   DOES ONLY
     "You have to say what you want to fill" SAY THE cont. "with."
-END VERB.
+END VERB fill.
 
 
 
@@ -942,35 +942,35 @@ VERB fill_with
   DOES ONLY 
     "You can't fill" SAY THE cont. "with" SAY THE substance. "."
     -- allow the action at individual substances only
-END VERB.
+END VERB fill_with.
 
 
 
 VERB find
   DOES ONLY
     "You'll have to $v it yourself."
-END VERB.
+END VERB find.
 
 
 
 VERB fire
   DOES ONLY
     "You fire" SAY THE weapon. "into the air."
-END VERB.
+END VERB fire.
 
 
 
 VERB fire_at
   DOES ONLY
     "Resorting to violence is not the solution here."
-END VERB.
+END VERB fire_at.
 
 
 
 VERB fix
   DOES ONLY
     "Please be more specific. How do you intend to fix it?"
-END VERB.
+END VERB fix.
 
 
 
@@ -978,7 +978,7 @@ VERB follow
   DOES ONLY 
     LOCATE hero AT act.
     "You follow" SAY THE act. "."   
-END VERB.
+END VERB follow.
 
 
 
@@ -988,7 +988,7 @@ VERB free
       THEN "That doesn't need to be $vd."
       ELSE "Those don't need to be $vd."
     END IF.
-END VERB.
+END VERB free.
 
 
 
@@ -1000,7 +1000,7 @@ VERB get_off
         MAKE hero NOT sitting.
       ELSE "You're standing up already."
     END IF.
-END VERB.
+END VERB get_off.
 
 
 
@@ -1016,7 +1016,7 @@ VERB get_up
         MAKE hero NOT sitting.
     ELSE "You're standing up already."
     END IF.
-END VERB.
+END VERB get_up.
 
 
 
@@ -1031,7 +1031,7 @@ VERB give
 
     LOCATE obj IN recipient.  
     "You give" SAY THE obj. "to" SAY THE recipient. "."
-END VERB.
+END VERB give.
 
 
 
@@ -1039,14 +1039,14 @@ VERB go_to
   DOES ONLY
     "You can't see" SAY THE dest. "anywhere nearby. You must state a
     direction where you want to go."
-END VERB.
+END VERB go_to.
 
 
 
 VERB hint
   DOES ONLY
     "Unfortunately hints are not available in this game."
-END VERB.
+END VERB hint.
 
 
 
@@ -1070,14 +1070,14 @@ VERB i
       THEN LIST worn.     -- This code will list what the hero is wearing.
     END IF.
   
-END VERB.
+END VERB i.
 
 
 
 VERB jump
   DOES ONLY
     "You jump on the spot, to no avail."
-END VERB.
+END VERB jump.
 
 
 
@@ -1087,7 +1087,7 @@ VERB jump_in
       THEN "That's not something you can jump into."
       ELSE "Those are not something you can jump into."
     END IF.
-END VERB.
+END VERB jump_in.
 
 
 
@@ -1098,21 +1098,21 @@ VERB jump_on
       ELSE "Those are not"
     END IF.
     "something you can jump onto."  
-END VERB.
+END VERB jump_on.
 
 
 
 VERB kick
   DOES ONLY
     "Resorting to brute force is not the solution here."
-END VERB.
+END VERB kick.
 
 
 
 VERB kill
   DOES ONLY
     "You have to state what you want to kill" SAY THE victim. "with."
-END VERB.
+END VERB kill.
 
 
 
@@ -1120,7 +1120,7 @@ VERB kill_with
    WHEN victim
   DOES ONLY
     "That would be needlessly brutal."
-END VERB.
+END VERB kill_with.
 
 
 
@@ -1130,14 +1130,14 @@ VERB kiss
       THEN SAY THE obj. "avoids your advances."
       ELSE "Nothing would be achieved by that."
     END IF.
-END VERB.
+END VERB kiss.
 
 
 
 VERB knock
   DOES ONLY
     "You knock on" SAY THE obj. "$$. Nothing happens."
-END VERB.
+END VERB knock.
 
 
 
@@ -1148,7 +1148,7 @@ VERB lie_down
       -- DOES "You lie down."
       -- MAKE hero lying_down.
       -- MAKE hero NOT sitting.
-END VERB.
+END VERB lie_down.
 
 
 
@@ -1159,7 +1159,7 @@ VERB lie_in
     -- (e.g. THE in_bed ISA LOCATION AT bedroom; etc.)
     -- Remember to: MAKE hero lying_down.
     -- Presently, an actor cannot be located inside a container object. 
-END VERB.
+END VERB lie_in.
 
 
 
@@ -1171,14 +1171,14 @@ VERB lie_on
     -- Remember to: MAKE hero lying_down.
     -- Presently, an actor cannot be located inside a container object
     -- or on a supporter.
-END VERB.
+END VERB lie_on.
 
 
 
 VERB lift
   DOES ONLY
     "That wouldn't accomplish anything."  
-END VERB.
+END VERB lift.
 
 
 
@@ -1189,14 +1189,14 @@ VERB light
       ELSE "Those are not"
     END IF.
     "something you can $v."
-END VERB.
+END VERB light.
 
 
 
 VERB listen0
   DOES ONLY
     "You hear nothing unusual."
-END VERB.
+END VERB listen0.
 
 
 
@@ -1208,7 +1208,7 @@ VERB listen
       THEN "You can't hear" SAY THE obj. "very well from here."
       ELSE "You can't hear anything."
     END IF.
-END VERB.
+END VERB listen.
 
 
 
@@ -1227,7 +1227,7 @@ VERB lock
         "lock" SAY THE obj. "."
           ELSE  "You have to state what you want to lock" SAY THE obj. "with."
     END IF.
-END VERB.
+END VERB lock.
 
 
 
@@ -1241,7 +1241,7 @@ VERB lock_with
       END IF.
 
      "lock" SAY THE obj. "with" SAY THE key. "."
-END VERB.
+END VERB lock_with.
 
 
 
@@ -1250,7 +1250,7 @@ VERB 'look'
     INCREASE described OF CURRENT LOCATION.     
     -- see 'locations.i', attribute 'described'.
     LOOK.
-END VERB.
+END VERB 'look'.
 
 
 
@@ -1260,14 +1260,14 @@ VERB look_behind
       THEN "You turn" SAY THE bulk. "in your hands but notice nothing unusual about it."
       ELSE "You notice nothing unusual behind" SAY THE bulk. "."
     END IF.
-END VERB.
+END VERB look_behind.
 
 
 
 VERB look_in
   DOES ONLY 
     LIST cont.
-END VERB.
+END VERB look_in.
 
 
 
@@ -1278,77 +1278,77 @@ VERB look_out_of
       ELSE "Those are not"
     END IF.
     "something you can look out of."
-END VERB.
+END VERB look_out_of.
 
 
 
 VERB look_through
   DOES ONLY
     "You can't see through" SAY THE bulk. "."
-END VERB.
+END VERB look_through.
 
 
 
 VERB look_under
   DOES ONLY
     "You notice nothing unusual under" SAY THE bulk. "."
-END VERB.
+END VERB look_under.
 
 
 
 VERB look_up
   DOES ONLY
     "Looking up, you see nothing unusual."
-END VERB.
+END VERB look_up.
 
 
 
 VERB 'no'
   DOES ONLY 
     "Really?"
-END VERB.
+END VERB 'no'.
 
 
 
 VERB pray
   DOES ONLY 
     "Your prayers don't seem to help right now."
-END VERB.
+END VERB pray.
 
 
 
 VERB pry
   DOES ONLY 
     "You must state what you want to pry" SAY THE obj. "with."
-END VERB.
+END VERB pry.
 
 
 
 VERB pry_with
   DOES ONLY 
     "That doesn't work."
-END VERB.
+END VERB pry_with.
 
 
 
 VERB pull 
   DOES ONLY 
     "That wouldn't accomplish anything."
-END VERB.
+END VERB pull.
 
 
 
 VERB push
   DOES ONLY 
     "You give" SAY THE obj. "a little push. Nothing happens."
-END VERB.
+END VERB push.
 
 
 
 VERB push_with
   DOES ONLY 
     "That wouldn't accomplish anything."
-END VERB. 
+END VERB push_with. 
 
 
 
@@ -1359,7 +1359,7 @@ VERB put
         THEN "it."
         ELSE "them."
       END IF.
-END VERB.
+END VERB put.
 
 
 
@@ -1367,14 +1367,14 @@ VERB put_in
   DOES ONLY 
     LOCATE obj IN cont.
     "You put" SAY THE obj. "into" SAY THE cont. "." 
-END VERB.
+END VERB put_in.
 
 
 
 VERB put_against, put_behind, put_near, put_under
   DOES ONLY 
     "That wouldn't accomplish anything."
-END VERB.
+END VERB put_against.
 
 
 
@@ -1389,14 +1389,14 @@ VERB put_on
             "You put" SAY THE obj. "on" SAY THE surface. "."
           END IF. 
       END IF.
-END VERB.
+END VERB put_on.
 
 
 
 VERB 'quit'
   DOES ONLY
     QUIT.
-END VERB.
+END VERB 'quit'.
 
 
 
@@ -1411,7 +1411,7 @@ VERB read
         END IF.
         """$$" SAY text OF obj. "$$""." 
     END IF.
-END VERB.
+END VERB read.
 
 
 
@@ -1428,42 +1428,42 @@ VERB remove
       THEN "it."
       ELSE "them."
     END IF. 
-END VERB.
+END VERB remove.
 
 
 
 VERB 'restart'
   DOES ONLY
     RESTART.
-END VERB.
+END VERB 'restart'.
 
 
 
 VERB 'restore'
   DOES ONLY
     RESTORE.
-END VERB.
+END VERB 'restore'.
 
 
 
 VERB rub 
   DOES ONLY 
     "Nothing would be achieved by that."
-END VERB.
+END VERB rub.
 
 
 
 VERB 'save'
   DOES ONLY
     SAVE.
-END VERB.
+END VERB 'save'.
 
 
 
 VERB 'say'
       DOES ONLY 
     "Nothing happens."
-END VERB.
+END VERB 'say'.
 
 
 
@@ -1475,7 +1475,7 @@ VERB say_to
         ELSE "don't look"
       END IF.
       "interested."
-END VERB.
+END VERB say_to.
 
 
 
@@ -1485,14 +1485,14 @@ VERB 'score'
     -- (or, if you wish to disable the score, use the following kind of 
       -- line instead of the above:
     -- "There is no score in this game.")
-END VERB.
+END VERB 'score'.
 
 
 
 VERB scratch
   DOES ONLY 
     "Nothing would be achieved by that."
-END VERB.
+END VERB scratch.
 
 
 
@@ -1503,7 +1503,7 @@ VERB 'script'
     $pIn a GUI version you can also find this in the drop-down menu in the interpreter. 
     $pIn a command line version you can start your game with the '-s' switch to get a transcript 
     of the whole game."
-END VERB.
+END VERB 'script'.
 
 
 
@@ -1511,7 +1511,7 @@ VERB script_on
     DOES ONLY
         TRANSCRIPT ON.
         "Transcripting turned on."
-END VERB.
+END VERB script_on.
 
 
 
@@ -1519,21 +1519,21 @@ VERB script_off
     DOES ONLY
         TRANSCRIPT OFF.
         "Transcripting turned off."
-END VERB.
+END VERB script_off.
 
 
 
 VERB search
   DOES ONLY 
     "You find nothing of interest."
-END VERB.
+END VERB search.
 
 
 
 VERB sell
   DOES ONLY 
     "There's nobody here who would be interested in buying" SAY THE item. "."
-END VERB.
+END VERB sell.
 
 
 
@@ -1543,28 +1543,28 @@ VERB shake
       THEN "You shake" SAY THE obj. "cautiously in your hands. Nothing happens."
       ELSE "There is no reason to start shaking" SAY THE obj. "."
     END IF.
-END VERB.
+END VERB shake.
 
 
 
 VERB shoot
   DOES ONLY 
     "Resorting to violence is not the solution here."
-END VERB.
+END VERB shoot.
 
 
 
 VERB shoot_with
   DOES ONLY 
     "Resorting to violence is not the solution here."
-END VERB.
+END VERB shoot_with.
 
 
 
 VERB shout
     DOES ONLY
         "Nothing results from your $ving."
-END VERB.
+END VERB shout.
 
 
 
@@ -1578,14 +1578,14 @@ VERB 'show'
       END IF.
 
       "not especially interested."
-END VERB.
+END VERB 'show'.
 
 
 
 VERB sing
     DOES ONLY
         "You $v a little tune."
-END VERB.
+END VERB sing.
 
 
 
@@ -1618,7 +1618,7 @@ VERB sip
         END IF.
     END IF.
       
-END VERB.
+END VERB sip.
 
 
 
@@ -1632,7 +1632,7 @@ VERB sit
     --  ELSE "You sit down."
     -- END IF.
     -- MAKE hero sitting.
-END VERB.
+END VERB sit.
 
 
 
@@ -1647,35 +1647,35 @@ VERB sit_on
     --  ELSE "You sit down on" SAY THE surface. "."
     -- END IF.
     -- MAKE hero sitting.
-END VERB.
+END VERB sit_on.
 
 
 
 VERB sleep
   DOES ONLY
     "There's no need to $v right now."
-END VERB.
+END VERB sleep.
 
 
 
 VERB smell0
     DOES ONLY
     "You smell nothing unusual."
-END VERB.
+END VERB smell0.
 
 
 
 VERB smell
   DOES ONLY
         "You smell nothing unusual."  
-END VERB.
+END VERB smell.
 
 
 
 VERB squeeze
   DOES ONLY
         "Trying to squeeze" SAY THE obj. "wouldn't accomplish anything."    
-END VERB.
+END VERB squeeze.
 
 
 
@@ -1687,7 +1687,7 @@ VERB stand
         MAKE hero NOT lying_down.
       ELSE "You're standing up already."
     END IF.
-END VERB.
+END VERB stand.
 
 
 
@@ -1700,14 +1700,14 @@ VERB stand_on
     -- It is not possible to actually locate him on the surface (unless
     -- you implement a nested location.)  
     -- MAKE hero NOT sitting. MAKE hero NOT lying_down.
-END VERB.
+END VERB stand_on.
 
 
 
 VERB swim 
   DOES ONLY
     "There is no water suitable for swimming here."
-END VERB.
+END VERB swim.
 
 
 
@@ -1718,7 +1718,7 @@ VERB swim_in
       ELSE "Those are not"
     END IF.
     "something you can swim in."
-END VERB.
+END VERB swim_in.
 
 
 
@@ -1729,7 +1729,7 @@ VERB switch
       ELSE "Those are not"
     END IF.
     "not something you can switch."
-END VERB.
+END VERB switch.
 
 
 
@@ -1762,7 +1762,7 @@ VERB take
         -- Objects held by NPCs cannot be taken by the hero by default.
         -- The hero must *ask for* the object to obtain it.
               
-END VERB.
+END VERB take.
 
 
 
@@ -1784,7 +1784,7 @@ VERB take_from
           -- The hero must *ask for* the object to obtain it.
         
           
-END VERB.
+END VERB take_from.
 
 
 
@@ -1792,7 +1792,7 @@ VERB talk
   DOES ONLY
     "To talk to somebody, you can ASK PERSON ABOUT THING
     or TELL PERSON ABOUT THING."
-END VERB.
+END VERB talk.
 
 
 
@@ -1800,21 +1800,21 @@ VERB talk_to
   DOES ONLY
     "To talk to somebody, you can ASK PERSON ABOUT THING or
     TELL PERSON ABOUT THING." 
-END VERB.
+END VERB talk_to.
 
 
 
 VERB taste
   DOES ONLY
     "You taste nothing unexpected."
-END VERB.
+END VERB taste.
 
 
 
 VERB tear
   DOES ONLY
     "Trying to $v" SAY THE obj. "would be futile."
-END VERB.
+END VERB tear.
 
 
 
@@ -1829,21 +1829,21 @@ VERB tell
       END IF.
 
       "look interested."
-END VERB.
+END VERB tell.
 
 
 
 VERB think 
   DOES ONLY
     "Nothing helpful comes to your mind."
-END VERB.
+END VERB think.
 
 
 
 VERB think_about
   DOES ONLY
     "Nothing helpful comes to your mind."
-END VERB.
+END VERB think_about.
 
 
 
@@ -1872,7 +1872,7 @@ VERB throw
     "nearby."
         LOCATE projectile AT hero.
       
-END VERB.
+END VERB throw.
 
 
 VERB throw_at
@@ -1924,7 +1924,7 @@ VERB throw_at
             -- when attacking enemies.
           END IF.   
 
-END VERB.
+END VERB throw_at.
 
 
 
@@ -1941,7 +1941,7 @@ VERB throw_to
     "It wouldn't accomplish anything trying to throw"
     SAY the projectile. "to" SAY THE recipient. "."
 
-END VERB.
+END VERB throw_to.
 
 
 
@@ -1964,14 +1964,14 @@ VERB throw_in
     -- default; this is to avoid successful outcomes for commands like
     -- 'throw plate into cupboard' etc. 
   
-END VERB.
+END VERB throw_in.
 
 
 
 VERB tie
   DOES ONLY 
     "You must state where you want to tie" SAY THE obj. "."
-END VERB.
+END VERB tie.
 
 
 
@@ -1987,14 +1987,14 @@ VERB tie_to
                 
         "It's not possible to tie" SAY THE obj. "to" SAY THE target. "."  
 
-END VERB.
+END VERB tie_to.
 
 
 
 VERB touch
   DOES ONLY
         "You feel nothing unexpected."
-END VERB.
+END VERB touch.
 
 
 
@@ -2002,7 +2002,7 @@ VERB touch_with
     WHEN obj
     DOES ONLY
             "You touch" SAY THE obj. "with" SAY THE instr. ". Nothing special happens."
-END VERB.
+END VERB touch_with.
 
 
 
@@ -2012,7 +2012,7 @@ VERB turn
       THEN "You turn" SAY THE obj. "in your hands, noticing nothing special."
       ELSE "That wouldn't accomplish anything."
     END IF.
-END VERB.
+END VERB turn.
 
 
 
@@ -2024,7 +2024,7 @@ VERB turn_on
     END IF.
       
     "something you can $v on."
-END VERB.
+END VERB turn_on.
 
 
 
@@ -2036,7 +2036,7 @@ VERB turn_off
     END IF.
 
     "something you can $v off."
-END VERB.
+END VERB turn_off.
 
 
 
@@ -2050,7 +2050,7 @@ VERB undress
         --"You remove all the items you were wearing."
           --ELSE "You're not wearing anything you can remove."
         -- END IF.
-END VERB.
+END VERB undress.
 
 
 
@@ -2062,7 +2062,7 @@ VERB unlock
         "You unlock" SAY THE obj. "."
           ELSE "You don't have the key that unlocks" SAY THE obj. "."
     END IF.
-END VERB.
+END VERB unlock.
 
 
 
@@ -2071,7 +2071,7 @@ VERB unlock_with
   DOES ONLY
     MAKE obj NOT locked.
     "You unlock" SAY THE obj. "with" SAY THE key. "."
-END VERB.
+END VERB unlock_with.
 
 
 
@@ -2082,7 +2082,7 @@ VERB 'use'
       THEN "it?" 
       ELSE "them?"
     END IF.
-END VERB.
+END VERB 'use'.
 
 
 
@@ -2090,7 +2090,7 @@ VERB use_with
    WHEN obj
   DOES ONLY
     "Please be more specific. How do you intend to use them together?"
-END VERB.
+END VERB use_with.
 
 
 
@@ -2099,14 +2099,14 @@ VERB 'verbose'
     VISITS 0.
     "Verbose mode is now on. Location descriptions will be 
     always shown in full."
-END VERB.
+END VERB 'verbose'.
 
 
 
 VERB 'wait'
   DOES ONLY
     "Time passes..."
-END VERB.
+END VERB 'wait'.
 
 
 
@@ -2117,63 +2117,63 @@ VERB wear
       ELSE "Those are"
     END IF.
     "not something you can wear."
-END VERB.
+END VERB wear.
 
 
 
 VERB what_am_i
   DOES ONLY
     "Maybe examining yourself might help."
-END VERB.
+END VERB what_am_i.
 
 
 
 VERB what_is
   DOES ONLY
     "You'll have to find it out yourself."
-END VERB.
+END VERB what_is.
 
 
 
 VERB where_am_i
   DOES ONLY
     LOOK.
-END VERB.
+END VERB where_am_i.
 
 
 
 VERB where_is
   DOES ONLY
     "You'll have to find it out yourself."
-END VERB.
+END VERB where_is.
 
 
 
 VERB who_am_i 
   DOES ONLY
     "Maybe examining yourself might help."
-END VERB.
+END VERB who_am_i.
 
 
 
 VERB who_is
   DOES ONLY
     "You'll have to find it out yourself."
-END VERB.
+END VERB who_is.
 
 
 
 VERB write
   DOES  ONLY
     "You don't have anything to write with."
-END VERB.
+END VERB write.
 
 
 
 VERB yes 
   DOES ONLY 
     "Really?"
-END VERB.
+END VERB yes.
 
 
 


### PR DESCRIPTION
The verb restriction attribute `look_at` was not no longer used by any verb:

- delete its definition.
- delete it from `check_restriction` Event.
- delete it from comments list of verbs in `lib_verbs.i`.