### PR TITLE
Delete `put_down` Attribute

### DIFF
--- a/lib_definitions.i
+++ b/lib_definitions.i
@@ -779,7 +779,6 @@ EVERY definition_block ISA LOCATION
   CAN put.         -- (+ lay, place)
   CAN put_against.
   CAN put_behind.
-  CAN put_down.
   CAN put_in.      -- (+ insert)
   CAN put_near.
   CAN put_on.
@@ -979,7 +978,6 @@ EVENT check_restriction
       MAKE my_game put.         -- (+ lay, place)
       MAKE my_game put_against.
       MAKE my_game put_behind.
-      MAKE my_game put_down.
       MAKE my_game put_in.      -- (+ insert)
       MAKE my_game put_near.
       MAKE my_game put_on.
@@ -1158,7 +1156,6 @@ EVENT check_restriction
           MAKE my_game NOT put.         -- (+ lay, place)
           MAKE my_game NOT put_against.
           MAKE my_game NOT put_behind.
-          MAKE my_game NOT put_down.
           MAKE my_game NOT put_in.      -- (+ insert)
           MAKE my_game NOT put_near.
           MAKE my_game NOT put_on.

--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -8747,11 +8747,7 @@ ADD TO EVERY OBJECT
     AND obj NOT IN worn
       ELSE SAY check_obj_not_in_worn1 OF my_game.
     AND obj IS takeable
-      ELSE
-        IF THIS IS NOT plural
-          THEN SAY check_obj_takeable OF my_game.
-          ELSE SAY check_obj_takeable OF my_game.
-        END IF.
+      ELSE SAY check_obj_takeable OF my_game.
     AND CURRENT LOCATION IS lit
       ELSE SAY check_current_loc_lit OF my_game.
     AND obj IS reachable AND obj IS NOT distant


### PR DESCRIPTION
The `put_down` verb restriction attribute was not being used inside any verbs (probably left over from and old `put_down` verb).

Currently 'put down' is a syntax of `drop`, which is contolled by the `drop` restriction attribute.