### PR TITLE
Add Tests for Room Objects

### DIFF
--- a/tests/house.alan
+++ b/tests/house.alan
@@ -1,0 +1,194 @@
+--==============================================================================
+-- "The House" by Tristano Ajmone, 2018.
+--==============================================================================
+IMPORT 'library.i'. -- ALAN Standard Library v2.1
+
+
+THE my_game IsA DEFINITION_BLOCK
+
+  HAS title    "The House".
+  HAS subtitle "A rooms & sites setting for various tests.".
+  HAS author   "Tristano Ajmone".
+  HAS year     2018.
+  HAS version  "1".
+
+END THE.
+
+-- =============================================================================
+
+-- ROOM: The Kitchen
+
+-- =============================================================================
+-- The kitchen will be our testing location for the 'room' class.
+
+THE kitchen IsA room.
+  NAME 'The Kitchen'.
+  EXIT south TO garden.
+  DESCRIPTION "The south exit leads to your back garden."
+  
+END THE kitchen.
+
+-- =============================================================================
+
+-- SITE: The Garden
+
+-- =============================================================================
+-- The garden will be our testing location for the 'site' class.
+
+THE garden IsA site.
+  NAME 'The Back Garden'.
+  EXIT north TO kitchen.
+  DESCRIPTION "To the north lies your home."
+  
+END THE garden.
+
+-- =============================================================================
+
+-- Kitchen Props
+
+-- =============================================================================
+
+--==============================================================================
+-- The Fridge (listed container + openable)
+--==============================================================================
+THE fridge IsA listed_container AT kitchen.
+  OPAQUE CONTAINER -- NOTE: The library doesn't initialize closed listed containers
+                   --       to be automatically opaque!
+  IS openable.
+  IS NOT open.
+
+  INITIALIZE -- Allow the fridge to contain every food item in the game:
+    FOR EACH fooditem IsA food
+      DO INCLUDE fooditem IN allowed OF THIS.
+    END FOR.
+  
+END THE fridge.
+--==============================================================================
+-- The Kitchen Table (supported)
+--==============================================================================
+
+THE kitchen_table IsA supporter AT kitchen.
+  IS NOT takeable.
+  NAME table.
+END THE kitchen_table.
+
+--==============================================================================
+-- Fruits Basket (listed container on table)
+--==============================================================================
+
+THE basket IsA listed_container IN kitchen_table.
+  
+END THE basket.
+
+-- =============================================================================
+
+-- Food & Beverages (Edibles & Drinkables)
+
+-- =============================================================================
+-- We'll create some 'edible' and 'drinkable' object classes and instances to
+-- allow testing with solids and liquids. Hierarchical subclassing will allow us
+-- to easily set which kind of food can be put where, and also provide a mean to
+-- test disambiguation.
+--==============================================================================
+-- Food Classes
+--==============================================================================
+EVERY food IsA object.
+  NAME food.
+  IS edible.
+END EVERY.
+
+EVERY beverage IsA liquid.
+  IS drinkable.
+  NAME beverage.
+END EVERY.
+
+EVERY snack IsA food.
+  NAME snack.
+END EVERY.
+--------------------------------------------------------------------------------
+-- Food Subclasses
+--------------------------------------------------------------------------------
+EVERY fruit IsA food.
+  NAME fruit.
+END EVERY fruit.
+--------------------------------------------------------------------------------
+-- Beverage Vessels
+--------------------------------------------------------------------------------
+-- Let's create a specialized class for beverage containers, to simplify pouring
+-- liquids from one container to another...
+EVERY beverage_vessel IsA listed_container.
+
+  INITIALIZE -- Allow every beverage vessel to contain every beverage in the game:
+    FOR EACH bevitem IsA beverage
+      DO INCLUDE bevitem IN allowed OF THIS.
+    END FOR.
+END EVERY beverage_vessel.
+--------------------------------------------------------------------------------
+-- Snacks Containers
+--------------------------------------------------------------------------------
+-- Snacks containers are small packages that can take small snacks (chips, olives,
+-- etc.) but not big food items (like fruits, etc.). Useful for testing responses
+-- of verbs that allow putting things in containers.
+
+EVERY snack_cont IsA listed_container.
+
+  INITIALIZE -- Allow every snack container to contain every snack in the game:
+    FOR EACH snackitem IsA snack
+      DO INCLUDE snackitem IN allowed OF THIS.
+    END FOR.
+END EVERY snack_cont.
+
+--==============================================================================
+-- FOOD INSTANCES: Fruits
+--==============================================================================
+-- Let's put some fruits in the fruit basket.
+
+THE apple IsA fruit IN basket.
+  NAME apple.
+END THE.
+
+THE banana IsA fruit IN basket.
+  NAME banana.
+END THE.
+
+THE pear IsA fruit IN basket.
+  NAME pear.
+END THE.
+--==============================================================================
+-- BEVERAGE INSTANCES
+--==============================================================================
+
+--------------------------------------------------------------------------------
+-- Empty Jar
+--------------------------------------------------------------------------------
+THE jar IsA beverage_vessel IN kitchen_table.
+  HAS allowed {wine}.
+END THE.
+--------------------------------------------------------------------------------
+-- Wine Bottle
+--------------------------------------------------------------------------------
+THE bottle IsA beverage_vessel IN kitchen_table.
+END THE.
+
+THE wine IsA liquid IN bottle.
+  HAS vessel bottle. 
+  INDEFINITE ARTICLE "some"
+END THE.
+--==============================================================================
+-- SNACKS INSTANCES
+--==============================================================================
+-- TODO: implemt it as a once-only openable container (ie, once open can't be
+--       closed again).
+THE chips_bag IsA snack_cont IN kitchen_table.
+  NAME 'chips bag'.
+  NAME bag.
+END THE chips_bag.
+
+THE chips IsA snack IN chips_bag.
+  INDEFINITE ARTICLE "some"
+  
+  
+END THE chips.
+--------------------------------------------------------------------------------
+Start at kitchen.
+DESCRIBE banner.

--- a/tests/house_room-objects.a3log
+++ b/tests/house_room-objects.a3log
@@ -1,0 +1,102 @@
+
+
+The House 
+A rooms & sites setting for various tests. 
+(C) 2018 by Tristano Ajmone 
+Programmed with the ALAN Interactive Fiction Language v3.0 beta5
+Standard Library v2.1 
+Version 1 
+All rights reserved.
+
+
+The Kitchen
+The south exit leads to your back garden. There is a fridge and a table 
+here. On the table you see a bottle, a chips bag, a jar and a basket.
+
+> ; ******************************************************************************
+> ; *                                                                            *
+> ; *                             ROOM OBJECTS TESTS                             *
+> ; *                                                                            *
+> ; ******************************************************************************
+> ; This solution file carries out some tests on the 'room_object' class.
+> x table
+You notice nothing unusual about the table. On the table you see a bottle, 
+a chips bag, a jar and a basket.
+
+> x basket
+The basket contains a pear, a banana and a apple.
+
+> ; ==============================================================================
+> ; ROOM FLOOR
+> ; ==============================================================================
+> ; The 'floor' instance (present in all 'room' instances) has its own VERB bodies
+> ; for: empty_in, pour_in, look_in, put_in, take_from, throw_in. We're going to
+> ; test if these are executed as expected...
+> ; ------------------------------------------------------------------------------
+> ; TEST VERB 'put_in'
+> ; ------------------------------------------------------------------------------
+> ; **FAIL** The 'put_in' verb body on the 'floor' instance should be executed and
+> ;          show "That's not something you can $v things into.":
+> put apple in floor
+The apple doesn't belong in the floor.
+
+> ;          We got instead the response of the 'obj IN allowed OF cont' CHECK from
+> ;          the main 'put_in' verb definition in 'lib_verbs.i', which hinders the
+> ;          execution of the 'floor' body.
+> ; ------------------------------------------------------------------------------
+> ; TEST VERB 'pour_in'
+> ; ------------------------------------------------------------------------------
+> ; **FAIL** The 'pour_in' verb body on the 'floor' instance should be executed and
+> ;          show "That's not something you can $v things into.":
+> pour wine in floor
+The wine doesn't belong in the floor.
+
+> ;          We got instead the response of the 'obj IN allowed OF cont' CHECK from
+> ;          the main 'pour_in' verb definition in 'lib_verbs.i', which hinders the
+> ;          execution of the 'floor' body.
+> ; ------------------------------------------------------------------------------
+> ; TEST VERB 'empty_in'
+> ; ------------------------------------------------------------------------------
+> ; **FAIL** Expecting "That's not something you can $v things into.":
+> empty bag in floor
+The chips bag doesn't belong in the floor.
+
+> ;          Some as 'pour_in' verb (both share the same verb bodies in the main
+> ;          verb definition as well as on the 'floor' instance).
+> ; ------------------------------------------------------------------------------
+> ; TEST VERB 'throw_in'
+> ; ------------------------------------------------------------------------------
+> ; **FAIL** Expecting "That's not something you can $v things into.":
+> throw bag in floor
+The chips bag doesn't belong in the floor.
+
+> ;          We got instead the response of the 'projectile IN allowed OF cont'
+> ;          CHECK from the main 'throw_in' verb definition in 'lib_verbs.i',
+> ;          which hinders the execution of the 'floor' body.
+> ; ------------------------------------------------------------------------------
+> ; TEST VERB 'look_in'
+> ; ------------------------------------------------------------------------------
+> ; (PASS) We expect the 'look_in' body defined on 'floor' instance to print out
+> ;        "That's not possible."
+> look in floor
+That's not possible.
+
+> ; ------------------------------------------------------------------------------
+> ; TEST VERB 'take_from'
+> ; ------------------------------------------------------------------------------
+> take apple
+Taken.
+
+> drop apple
+Dropped.
+
+> ; **FAIL** The 'take_from' body from 'floor' should print:
+> ;          "If you want to pick up something, just TAKE it."
+> take apple from floor
+The apple is not in the floor.
+
+> ;          We got instead the 'check_obj_in_cont_sg' response ("$+1 is not in $+2.")
+> ;          from the main 'take_from' verb CHECK 'AND obj IN holder', which hinders
+> ;          the execution of the 'floor' verb body.
+
+Do you want to RESTART, RESTORE, QUIT or UNDO? 

--- a/tests/house_room-objects.a3sol
+++ b/tests/house_room-objects.a3sol
@@ -1,0 +1,64 @@
+; ******************************************************************************
+; *                                                                            *
+; *                             ROOM OBJECTS TESTS                             *
+; *                                                                            *
+; ******************************************************************************
+; This solution file carries out some tests on the 'room_object' class.
+x table
+x basket
+; ==============================================================================
+; ROOM FLOOR
+; ==============================================================================
+; The 'floor' instance (present in all 'room' instances) has its own VERB bodies
+; for: empty_in, pour_in, look_in, put_in, take_from, throw_in. We're going to
+; test if these are executed as expected...
+; ------------------------------------------------------------------------------
+; TEST VERB 'put_in'
+; ------------------------------------------------------------------------------
+; **FAIL** The 'put_in' verb body on the 'floor' instance should be executed and
+;          show "That's not something you can $v things into.":
+put apple in floor
+;          We got instead the response of the 'obj IN allowed OF cont' CHECK from
+;          the main 'put_in' verb definition in 'lib_verbs.i', which hinders the
+;          execution of the 'floor' body.
+; ------------------------------------------------------------------------------
+; TEST VERB 'pour_in'
+; ------------------------------------------------------------------------------
+; **FAIL** The 'pour_in' verb body on the 'floor' instance should be executed and
+;          show "That's not something you can $v things into.":
+pour wine in floor
+;          We got instead the response of the 'obj IN allowed OF cont' CHECK from
+;          the main 'pour_in' verb definition in 'lib_verbs.i', which hinders the
+;          execution of the 'floor' body.
+; ------------------------------------------------------------------------------
+; TEST VERB 'empty_in'
+; ------------------------------------------------------------------------------
+; **FAIL** Expecting "That's not something you can $v things into.":
+empty bag in floor
+;          Some as 'pour_in' verb (both share the same verb bodies in the main
+;          verb definition as well as on the 'floor' instance).
+; ------------------------------------------------------------------------------
+; TEST VERB 'throw_in'
+; ------------------------------------------------------------------------------
+; **FAIL** Expecting "That's not something you can $v things into.":
+throw bag in floor
+;          We got instead the response of the 'projectile IN allowed OF cont'
+;          CHECK from the main 'throw_in' verb definition in 'lib_verbs.i',
+;          which hinders the execution of the 'floor' body.
+; ------------------------------------------------------------------------------
+; TEST VERB 'look_in'
+; ------------------------------------------------------------------------------
+; (PASS) We expect the 'look_in' body defined on 'floor' instance to print out
+;        "That's not possible."
+look in floor
+; ------------------------------------------------------------------------------
+; TEST VERB 'take_from'
+; ------------------------------------------------------------------------------
+take apple
+drop apple
+; **FAIL** The 'take_from' body from 'floor' should print:
+;          "If you want to pick up something, just TAKE it."
+take apple from floor
+;          We got instead the 'check_obj_in_cont_sg' response ("$+1 is not in $+2.")
+;          from the main 'take_from' verb CHECK 'AND obj IN holder', which hinders
+;          the execution of the 'floor' verb body.


### PR DESCRIPTION
Create new multipurpose test location (a house with kitchen and garden)
to allow testing different categories of classes and verbs against each
other. Since the new tests script allows running multiple solution files
against the same adventure, we'll be using the house setting for various
independent tests from now on.

Add solution file to test `room_object` class: currently tests `floor`
with various verbs that should be overridden by floor body -- the test
shows that most of them fail due to `CHECK`s on the main verb preventing
their execution.