### PR TITLE
Extend Tests + Fix 'listen'

### DIFF
--- a/lib_verbs.i
+++ b/lib_verbs.i
@@ -4160,7 +4160,7 @@ ADD TO EVERY THING
       ELSE SAY check_obj_not_hero1 OF my_game.
 
     DOES
-      IF obj AT hero
+      IF hero AT obj
         THEN
           IF obj ISA ACTOR
             THEN SAY THE obj.

--- a/tests/house.alan
+++ b/tests/house.alan
@@ -40,6 +40,11 @@ THE garden IsA site.
   EXIT north TO kitchen.
   DESCRIPTION "To the north lies your home."
   
+  -- Since we've excluded the 'chirp' sound from the room description, we'll
+  -- make it available at the garden via 'listen':
+  VERB listen0
+    DOES ONLY "You can ear a faint chirp."
+  END VERB listen0.
 END THE garden.
 
 -- =============================================================================
@@ -47,6 +52,24 @@ END THE garden.
 -- Kitchen Props
 
 -- =============================================================================
+
+--==============================================================================
+-- The Chair
+--==============================================================================
+-- Let's provide a usable chair.
+
+THE chair IsA supporter AT kitchen.
+  
+  VERB sit_on
+    DOES ONLY
+      IF hero IS lying_down
+        THEN "You get up and"
+          MAKE hero NOT lying_down.
+      END IF.
+      "you sit on $+1."
+      MAKE hero sitting.
+  END VERB sit_on.
+END THE chair.
 
 --==============================================================================
 -- The Fridge (listed container + openable)
@@ -186,9 +209,123 @@ END THE chips_bag.
 
 THE chips IsA snack IN chips_bag.
   INDEFINITE ARTICLE "some"
-  
-  
 END THE chips.
+
+-- =============================================================================
+
+-- Garden Props
+
+-- =============================================================================
+
+--==============================================================================
+-- Bird's Chirp
+--==============================================================================
+-- Let's add a 'sound' to test 'listen' and to also provide an object which is
+-- NOT examibable, takeable, reachable or movable.
+THE chirp IsA sound AT garden.
+  DESCRIPTION ""  -- We don't want it to show up in the room description
+                  -- (it'll show up when listening in the garden via listen0).
+  
+  VERB listen
+    DOES ONLY
+      IF hero AT obj
+        THEN "It sounds like a sparrow's chirp."
+      ELSIF obj NEAR hero
+        THEN "From this distance it's difficoult to tell which bird it might be."
+      END IF.
+  END VERB listen.
+END THE chirp.
+
+--==============================================================================
+-- The Garden's Table
+--==============================================================================
+THE garden_table IsA supporter AT garden.
+  IS NOT takeable.
+  NAME table.
+END THE garden_table.
+
+--==============================================================================
+-- Folding Bed
+--==============================================================================
+THE garden_bed IsA supporter AT garden.
+  NAME folding bed.
+  NAME bed.
+  HAS ex "It's a folding bed, ideal for beaches and camping.".
+  
+  VERB lie_on
+    DOES ONLY
+      IF hero IS sitting
+        THEN "You get up and"
+          MAKE hero NOT sitting.
+      END IF.
+      "you lie down on $+1."
+      MAKE hero lying_down.
+  END VERB lie_on.
+END THE garden_bed.
+
+--==============================================================================
+-- The Swimming Pool
+--==============================================================================
+-- Let's create a swimming pool to test both 'swim' and 'enter'.
+
+THE swimming_pool IsA liquid AT garden.
+  NAME swimming pool.
+  NAME water.
+  
+  VERB swim
+    DOES ONLY
+      IF hero DIRECTLY AT inside_pool
+        THEN "You are already in the swimming pool."
+        ELSE
+          LOCATE hero AT inside_pool.
+      END IF.
+  END VERB swim.
+  
+  VERB swim_in
+    DOES ONLY
+      IF hero DIRECTLY AT inside_pool
+        THEN "You are already in the swimming pool."
+        ELSE
+          LOCATE hero AT inside_pool.
+      END IF.
+  END VERB swim_in.
+    
+  VERB enter
+    DOES ONLY
+      IF hero DIRECTLY AT inside_pool
+        THEN "You are already in the swimming pool."
+        ELSE
+          LOCATE hero AT inside_pool.
+      END IF.
+  END VERB enter.
+
+  VERB 'exit'
+    DOES ONLY
+      IF hero NOT DIRECTLY AT inside_pool
+        THEN "You are not inside the swimming pool."
+        ELSE
+          "You climb over the pool border and get back on the grass."
+          LOCATE hero AT garden.
+      END IF.
+  END VERB 'exit'.
+END THE swimming_pool.
+
+--==============================================================================
+-- Inside The Swimmin Pool
+--==============================================================================
+-- To simulate the hero entering the pool we create a nested location AT the
+-- garden.
+
+THE inside_pool IsA location AT garden.
+  NAME 'Inside The Swimming Pool (in Garden)'.
+  DESCRIPTION
+    "The pool is wide enough to enjoy swimming in it."
+  
+  ENTERED
+    "You dive savagely into the pool, splashing water everywhere."
+  
+END THE inside_pool.
+
 --------------------------------------------------------------------------------
 Start at kitchen.
 DESCRIBE banner.

--- a/tests/house_room-objects.a3log
+++ b/tests/house_room-objects.a3log
@@ -10,8 +10,9 @@ All rights reserved.
 
 
 The Kitchen
-The south exit leads to your back garden. There is a fridge and a table 
-here. On the table you see a bottle, a chips bag, a jar and a basket.
+The south exit leads to your back garden. There is a chair, a fridge and a 
+table here. On the table you see a bottle, a chips bag, a jar and a basket
+.
 
 > ; ******************************************************************************
 > ; *                                                                            *

--- a/tests/house_site-objects.a3log
+++ b/tests/house_site-objects.a3log
@@ -10,8 +10,9 @@ All rights reserved.
 
 
 The Kitchen
-The south exit leads to your back garden. There is a fridge and a table 
-here. On the table you see a bottle, a chips bag, a jar and a basket.
+The south exit leads to your back garden. There is a chair, a fridge and a 
+table here. On the table you see a bottle, a chips bag, a jar and a basket
+.
 
 > ; ******************************************************************************
 > ; *                                                                            *
@@ -43,7 +44,8 @@ Taken.
 
 > south
 The Back Garden
-To the north lies your home.
+To the north lies your home. There is a table, a folding bed and a 
+swimming pool here.
 
 > ; ==============================================================================
 > ; SITE FLOOR

--- a/tests/house_sitting-and-lying.a3log
+++ b/tests/house_sitting-and-lying.a3log
@@ -1,0 +1,202 @@
+
+
+The House 
+A rooms & sites setting for various tests. 
+(C) 2018 by Tristano Ajmone 
+Programmed with the ALAN Interactive Fiction Language v3.0 beta5
+Standard Library v2.1 
+Version 1 
+All rights reserved.
+
+
+The Kitchen
+The south exit leads to your back garden. There is a chair, a fridge and a 
+table here. On the table you see a bottle, a chips bag, a jar and a basket
+.
+
+> ; ******************************************************************************
+> ; *                                                                            *
+> ; *                   TEST SITTING, LYING DOWN & GETTING UP                    *
+> ; *                                                                            *
+> ; ******************************************************************************
+> sit
+You feel no urge to sit down at present.
+
+> sit down
+You feel no urge to sit down at present.
+
+> lie
+There's no need to lie down right now.
+
+> lie down
+There's no need to lie down right now.
+
+> stand
+You're standing up already.
+
+> get up
+You're standing up already.
+
+> ; ==============================================================================
+> ; TEST VERB 'sit_on'
+> ; ==============================================================================
+> ; ------------------------------------------------------------------------------
+> ; THE CHAIR (supporter + custom 'sit_on' )
+> ; ------------------------------------------------------------------------------
+> ; We've created a chair on which the hero can sit.
+> sit on chair
+You sit on the chair.
+
+> sit on chair
+You're sitting down already.
+
+> get up
+You stand up.
+
+> sit on chair
+You sit on the chair.
+
+> get off the chair
+You get off the chair.
+
+> get off the chair
+You're standing up already.
+
+> ; ==============================================================================
+> ; TEST VERB 'lie_on'
+> ; ==============================================================================
+> south
+The Back Garden
+To the north lies your home. There is a table, a folding bed and a 
+swimming pool here.
+
+> ; ------------------------------------------------------------------------------
+> ; THE FOLDING BED (supporter + custom 'lie_on' )
+> ; ------------------------------------------------------------------------------
+> ; We've created a bed on which the hero can lie down.
+> examine bed
+It's a folding bed, ideal for beaches and camping. There's nothing on the 
+folding bed.
+
+> lie on bed
+You lie down on the folding bed.
+
+> lie on bed
+You're lying down already.
+
+> get off bed
+You get off the folding bed.
+
+> ; ------------------------------------------------------------------------------
+> ; VANILLA TESTS
+> ; ------------------------------------------------------------------------------
+> ; Let's try the verb with surfaces which don't have a custom implementation of
+> ; the verb, so we can check the vanilla responses...
+> north
+The Kitchen
+The south exit leads to your back garden. There is a chair, a fridge and a 
+table here. On the table you see a bottle, a chips bag, a jar and a basket
+.
+
+> lie on table
+There's no need to lie down on the table.
+
+> lie on chair
+There's no need to lie down on the chair.
+
+> ; ------------------------------------------------------------------------------
+> ; TEST ILLEGAL PARAMETERS
+> ; ------------------------------------------------------------------------------
+> ; Let's test the verb with objects which are not 'supporter' (ie, no 'surface'):
+> lie on basket
+That's not something you can lie on.
+
+> ; ==============================================================================
+> ; TEST VERB 'lie_in'
+> ; ==============================================================================
+> ; ------------------------------------------------------------------------------
+> ; VANILLA TESTS
+> ; ------------------------------------------------------------------------------
+> ; Let's try the verb with surfaces which don't have a custom implementation of
+> ; the verb, so we can check the vanilla responses...
+> lie in chair
+There's no need to lie down in the chair.
+
+> lie in table
+There's no need to lie down in the table.
+
+> ; ------------------------------------------------------------------------------
+> ; TEST ILLEGAL PARAMETERS
+> ; ------------------------------------------------------------------------------
+> ; Let's test the verb with objects which are not containers:
+> lie in apple
+That's not something you can lie in.
+
+> ; ==============================================================================
+> ; TEST VERBS WITH ROOM/SITE OBJECTS
+> ; ==============================================================================
+> ; ------------------------------------------------------------------------------
+> ; ROOM OBJECTS
+> ; ------------------------------------------------------------------------------
+> ; 'lie_in':
+> lie in ceiling
+That's not something you can lie in.
+
+> lie in floor
+There's no need to lie down in the floor.
+
+> lie in wall
+That's not something you can lie in.
+
+> ; 'lie_on':
+> lie on ceiling
+That's not something you can lie on.
+
+> lie on floor
+That's not something you can lie on.
+
+> lie on wall
+That's not something you can lie on.
+
+> ; 'sit_on':
+> sit on ceiling
+That's not something you can sit on.
+
+> sit on floor
+That's not something you can sit on.
+
+> sit on wall
+That's not something you can sit on.
+
+> ; ------------------------------------------------------------------------------
+> ; SITE OBJECTS
+> ; ------------------------------------------------------------------------------
+> south
+The Back Garden
+To the north lies your home. There is a table, a folding bed and a 
+swimming pool here.
+
+> ; 'lie_in':
+> lie in sky
+That's not something you can lie in.
+
+> lie in ground
+There's no need to lie down in the ground.
+
+> ; 'lie_on':
+> lie on sky
+That's not something you can lie on.
+
+> lie on ground
+That's not something you can lie on.
+
+> ; 'sit_on':
+> sit on sky
+That's not something you can sit on.
+
+> sit on ground
+That's not something you can sit on.
+
+> 
+
+Do you want to RESTART, RESTORE, QUIT or UNDO? 

--- a/tests/house_sitting-and-lying.a3sol
+++ b/tests/house_sitting-and-lying.a3sol
@@ -1,0 +1,95 @@
+; ******************************************************************************
+; *                                                                            *
+; *                   TEST SITTING, LYING DOWN & GETTING UP                    *
+; *                                                                            *
+; ******************************************************************************
+sit
+sit down
+lie
+lie down
+stand
+get up
+; ==============================================================================
+; TEST VERB 'sit_on'
+; ==============================================================================
+; ------------------------------------------------------------------------------
+; THE CHAIR (supporter + custom 'sit_on' )
+; ------------------------------------------------------------------------------
+; We've created a chair on which the hero can sit.
+sit on chair
+sit on chair
+get up
+sit on chair
+get off the chair
+get off the chair
+; ==============================================================================
+; TEST VERB 'lie_on'
+; ==============================================================================
+south
+; ------------------------------------------------------------------------------
+; THE FOLDING BED (supporter + custom 'lie_on' )
+; ------------------------------------------------------------------------------
+; We've created a bed on which the hero can lie down.
+examine bed
+lie on bed
+lie on bed
+get off bed
+; ------------------------------------------------------------------------------
+; VANILLA TESTS
+; ------------------------------------------------------------------------------
+; Let's try the verb with surfaces which don't have a custom implementation of
+; the verb, so we can check the vanilla responses...
+north
+lie on table
+lie on chair
+; ------------------------------------------------------------------------------
+; TEST ILLEGAL PARAMETERS
+; ------------------------------------------------------------------------------
+; Let's test the verb with objects which are not 'supporter' (ie, no 'surface'):
+lie on basket
+; ==============================================================================
+; TEST VERB 'lie_in'
+; ==============================================================================
+; ------------------------------------------------------------------------------
+; VANILLA TESTS
+; ------------------------------------------------------------------------------
+; Let's try the verb with surfaces which don't have a custom implementation of
+; the verb, so we can check the vanilla responses...
+lie in chair
+lie in table
+; ------------------------------------------------------------------------------
+; TEST ILLEGAL PARAMETERS
+; ------------------------------------------------------------------------------
+; Let's test the verb with objects which are not containers:
+lie in apple
+; ==============================================================================
+; TEST VERBS WITH ROOM/SITE OBJECTS
+; ==============================================================================
+; ------------------------------------------------------------------------------
+; ROOM OBJECTS
+; ------------------------------------------------------------------------------
+; 'lie_in':
+lie in ceiling
+lie in floor
+lie in wall
+; 'lie_on':
+lie on ceiling
+lie on floor
+lie on wall
+; 'sit_on':
+sit on ceiling
+sit on floor
+sit on wall
+; ------------------------------------------------------------------------------
+; SITE OBJECTS
+; ------------------------------------------------------------------------------
+south
+; 'lie_in':
+lie in sky
+lie in ground
+; 'lie_on':
+lie on sky
+lie on ground
+; 'sit_on':
+sit on sky
+sit on ground

--- a/tests/house_sounds.a3log
+++ b/tests/house_sounds.a3log
@@ -1,0 +1,97 @@
+
+
+The House 
+A rooms & sites setting for various tests. 
+(C) 2018 by Tristano Ajmone 
+Programmed with the ALAN Interactive Fiction Language v3.0 beta5
+Standard Library v2.1 
+Version 1 
+All rights reserved.
+
+
+The Kitchen
+The south exit leads to your back garden. There is a chair, a fridge and a 
+table here. On the table you see a bottle, a chips bag, a jar and a basket
+.
+
+> ; ******************************************************************************
+> ; *                                                                            *
+> ; *                                TEST SOUNDS                                 *
+> ; *                                                                            *
+> ; ******************************************************************************
+> listen
+You hear nothing unusual.
+
+> ; ==============================================================================
+> ; TEST ROOM AND SITE OBJECTS
+> ; ==============================================================================
+> ; **ERR!** Room and site objects are not in scope to the 'listen' verb!
+> ;          This is because the verb checks 'IF obj AT hero', but these objs are
+> ;          implemented AT outdoor/indoor, which are locations enwrapping the
+> ;          current hero's location -- i.e., the obj is never AT hero's location,
+> ;          but the inverse is true, for the hero is always AT obj's location!
+> ; ------------------------------------------------------------------------------
+> ; ROOM OBJECTS
+> ; ------------------------------------------------------------------------------
+> listen to ceiling
+
+> listen to floor
+
+> listen to wall
+
+> ; ------------------------------------------------------------------------------
+> ; SITE OBJECTS
+> ; ------------------------------------------------------------------------------
+> ; NOTE: 'listen' allows parameters not in current location (!):
+> listen to sky
+
+> listen to ground
+
+> ; ==============================================================================
+> ; THE CHIRP (sound AT garden + custom verbs)
+> ; ==============================================================================
+> south
+The Back Garden
+To the north lies your home. There is a table, a folding bed and a 
+swimming pool here.
+
+> listen
+You can ear a faint chirp.
+
+> listen to chirp
+It sounds like a sparrow's chirp.
+
+> ; ------------------------------------------------------------------------------
+> ; TEST 'listen' INSIDE THE POOL
+> ; ------------------------------------------------------------------------------
+> enter pool
+You dive savagely into the pool, splashing water everywhere.
+
+Inside The Swimming Pool (in Garden)
+The pool is wide enough to enjoy swimming in it.
+
+> listen
+You can ear a faint chirp.
+
+> listen to chirp
+It sounds like a sparrow's chirp.
+
+> ; ------------------------------------------------------------------------------
+> ; SITE OBJECTS
+> ; ------------------------------------------------------------------------------
+> listen to sky
+
+> listen to ground
+
+> ; ------------------------------------------------------------------------------
+> ; ROOM OBJECTS
+> ; ------------------------------------------------------------------------------
+> ; These are not present at outdoor, but they are at kitchen (indoor), except
+> ; that the indoor is not directly adjacent to garden (kitchen is): 
+> listen to ceiling
+
+> listen to floor
+
+> 
+
+Do you want to RESTART, RESTORE, QUIT or UNDO? 

--- a/tests/house_sounds.a3log
+++ b/tests/house_sounds.a3log
@@ -34,10 +34,13 @@ You hear nothing unusual.
 > ; ROOM OBJECTS
 > ; ------------------------------------------------------------------------------
 > listen to ceiling
+You hear nothing unusual.
 
 > listen to floor
+You hear nothing unusual.
 
 > listen to wall
+You hear nothing unusual.
 
 > ; ------------------------------------------------------------------------------
 > ; SITE OBJECTS
@@ -80,8 +83,10 @@ It sounds like a sparrow's chirp.
 > ; SITE OBJECTS
 > ; ------------------------------------------------------------------------------
 > listen to sky
+You hear nothing unusual.
 
 > listen to ground
+You hear nothing unusual.
 
 > ; ------------------------------------------------------------------------------
 > ; ROOM OBJECTS

--- a/tests/house_sounds.a3sol
+++ b/tests/house_sounds.a3sol
@@ -1,0 +1,50 @@
+; ******************************************************************************
+; *                                                                            *
+; *                                TEST SOUNDS                                 *
+; *                                                                            *
+; ******************************************************************************
+listen
+; ==============================================================================
+; TEST ROOM AND SITE OBJECTS
+; ==============================================================================
+; **ERR!** Room and site objects are not in scope to the 'listen' verb!
+;          This is because the verb checks 'IF obj AT hero', but these objs are
+;          implemented AT outdoor/indoor, which are locations enwrapping the
+;          current hero's location -- i.e., the obj is never AT hero's location,
+;          but the inverse is true, for the hero is always AT obj's location!
+; ------------------------------------------------------------------------------
+; ROOM OBJECTS
+; ------------------------------------------------------------------------------
+listen to ceiling
+listen to floor
+listen to wall
+; ------------------------------------------------------------------------------
+; SITE OBJECTS
+; ------------------------------------------------------------------------------
+; NOTE: 'listen' allows parameters not in current location (!):
+listen to sky
+listen to ground
+; ==============================================================================
+; THE CHIRP (sound AT garden + custom verbs)
+; ==============================================================================
+south
+listen
+listen to chirp
+; ------------------------------------------------------------------------------
+; TEST 'listen' INSIDE THE POOL
+; ------------------------------------------------------------------------------
+enter pool
+listen
+listen to chirp
+; ------------------------------------------------------------------------------
+; SITE OBJECTS
+; ------------------------------------------------------------------------------
+listen to sky
+listen to ground
+; ------------------------------------------------------------------------------
+; ROOM OBJECTS
+; ------------------------------------------------------------------------------
+; These are not present at outdoor, but they are at kitchen (indoor), except
+; that the indoor is not directly adjacent to garden (kitchen is): 
+listen to ceiling
+listen to floor

--- a/tests/house_sounds.a3sol
+++ b/tests/house_sounds.a3sol
@@ -7,11 +7,7 @@ listen
 ; ==============================================================================
 ; TEST ROOM AND SITE OBJECTS
 ; ==============================================================================
-; **ERR!** Room and site objects are not in scope to the 'listen' verb!
-;          This is because the verb checks 'IF obj AT hero', but these objs are
-;          implemented AT outdoor/indoor, which are locations enwrapping the
-;          current hero's location -- i.e., the obj is never AT hero's location,
-;          but the inverse is true, for the hero is always AT obj's location!
+; NOTE: 'listen' allows parameters not in current location (!).
 ; ------------------------------------------------------------------------------
 ; ROOM OBJECTS
 ; ------------------------------------------------------------------------------
@@ -21,7 +17,13 @@ listen to wall
 ; ------------------------------------------------------------------------------
 ; SITE OBJECTS
 ; ------------------------------------------------------------------------------
-; NOTE: 'listen' allows parameters not in current location (!):
+; **PROBLEM** With these site objects we get blank responses because they are
+;             neither at current location nor in an adjecent one (NEARBY).
+;             The reason is that the hero is now at an indoor location, and while
+;             the garden IS NEARBY it's wrapping outdoor location isn't, because
+;             it's not directly adjacent to the kitchen. This is the expected
+;             behavior, but the blank message doesn't look too nice, maybe it
+;             should say something like "XXX is not here or doesn't exisit"?
 listen to sky
 listen to ground
 ; ==============================================================================


### PR DESCRIPTION

## New Tests

The first commit adds new props to the house and new test files. It also uncovers some problems with the `listen` verb.

## Fix Listen

Before merging the second commit, you might want to check that this fix won't create potential problems (which I might have overlooked).

If you look at the `house_sounds.a3log` test, [before] and [after the fix], you'll notice that room and site ojects were not in scope to listen before the fix:

__[before] the fix:__

```
> listen to ceiling

> listen to floor

> listen to wall
```

__[after the fix]:__

```
> listen to ceiling
You hear nothing unusual.

> listen to floor
You hear nothing unusual.

> listen to wall
You hear nothing unusual.
```

In verb `listen`'s `DOES`, I've changed `IF ogg AT hero` into `IF hero AT ogg` in order for the verb to work when hero is in a nested location (eg. in a hole) and to work with room/site objects (which are not AT hero's location because they're in a wrapping location, but on the other hand the hero is AT their location).

Before this fix, trying to listen to the sky or ceiling would produce an empty string, as well as when trying to listen to something from a nested location.

So, basically I've just inverted the check criteria from checking if the object is at the hero's location to checking if the hero is at the object's location. The former was limited in scope to objects which were either at the current location or in locations nested therein, while the latter broadens the scope to include any locations that are nested within the object's location — effectively allowing any objects in wrapping locations to be withing scope, which I think is the whole purpose of putting them in such wrappers in the first place.

Please, let me know if you think this might create unexpected results. Personally, I think this fix is correct — since you can see the ceiling, you should also be able to listen to it, right?

[before]: https://github.com/AnssiR66/AlanStdLib/blob/9ea3cf42/tests/house_sounds.a3log
[after the fix]: https://github.com/AnssiR66/AlanStdLib/blob/ad321c3/tests/house_sounds.a3log

<!-- EOF -->
