### PR TITLE
Liquids bug

### DIFF
--- a/lib_classes.i
+++ b/lib_classes.i
@@ -1628,15 +1628,17 @@ EVERY liquid ISA OBJECT
               THEN "You can't carry" SAY THE THIS. "around in your bare hands."
               ELSIF vessel OF THIS IS NOT takeable
                 THEN "You don't have" SAY THE vessel OF THIS. "of" SAY THIS. "."
-              ELSE LOCATE vessel OF THIS IN hero.
-                "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
+                ELSE LOCATE vessel OF THIS IN hero.
+                  "(taking" SAY THE vessel OF THIS. "of" SAY THIS. "first)$n"
             END IF.
         END IF.
         -- end of implicit taking.
 
         IF THIS IN hero
           -- i.e. if the implicit taking was successful
-          THEN "You put" SAY THE vessel OF THIS. "of" SAY THIS. "onto" SAY THE surface. "."
+          THEN
+            "You put" SAY THE vessel OF THIS. "of" SAY THIS. "onto" SAY THE surface. "."
+            LOCATE vessel OF THIS IN surface.
         END IF.
     WHEN surface
       DOES ONLY "It is not possible to $v" SAY obj. "onto" SAY THE THIS. "."

--- a/lib_classes.i
+++ b/lib_classes.i
@@ -1561,14 +1561,6 @@ EVERY liquid ISA OBJECT
   END VERB pour_on.
 
 
-  VERB fill_with
-    -- when something is filled with a liquid, this something becomes the
-    -- vessel of the liquid:
-    WHEN substance
-       DOES SET vessel OF THIS TO cont.
-  END VERB fill_with.
-
-
   VERB put_in
     WHEN obj
       DOES ONLY
@@ -1689,8 +1681,15 @@ EVENT check_vessel
     SET vessel OF liq TO null_vessel.
   END FOR.
   SCHEDULE check_vessel AFTER 1.
-END EVENT.
 
+  FOR EACH lc ISA LISTED_CONTAINER DO
+    FOR EACH liq ISA LIQUID, DIRECTLY IN lc
+      DO SET vessel OF liq TO lc.
+    END FOR.
+  END FOR.
+
+  SCHEDULE check_vessel AFTER 1.
+END EVENT.
 
 
 

--- a/tests/house-handling-liquids.a3log
+++ b/tests/house-handling-liquids.a3log
@@ -1,0 +1,78 @@
+
+
+The House 
+A rooms & sites setting for various tests. 
+(C) 2018 by Tristano Ajmone 
+Programmed with the ALAN Interactive Fiction Language v3.0 beta5
+Standard Library v2.1 
+Version 1 
+All rights reserved.
+
+
+The Kitchen
+The south exit leads to your back garden. There is a chair, a fridge and a 
+table here. On the table you see a bottle, a chips bag, a jar and a basket
+.
+
+> ; ******************************************************************************
+> ; *                                                                            *
+> ; *                           TEST HANDLING LIQUIDS                            *
+> ; *                                                                            *
+> ; ******************************************************************************
+> ; Liquids inside takable containers can be handled by using either the container
+> ; or the liquid itself as the verb object.
+> examine bottle 
+The bottle contains some wine.
+
+> ; ==============================================================================
+> ; TEST HANDLING VIA CONTAINER
+> ; ==============================================================================
+> take bottle
+Taken.
+
+> take bottle
+You already have the bottle.
+
+> put bottle on table
+You put the bottle on the table.
+
+> take bottle from table
+You take the bottle from the table.
+
+> take bottle from table
+You already have the bottle.
+
+> put bottle on table
+You put the bottle on the table.
+
+> ; ==============================================================================
+> ; TEST HANDLING VIA LIQUID
+> ; ==============================================================================
+> take wine
+(the bottle of wine)
+Taken.
+
+> take wine
+You already have the wine.
+
+> put wine on table
+You put the bottle of wine onto the table.
+
+> ; **BUG!** Although the verb 'put_on' (implemented on LIQUID) is reporting that
+> ;          the bottle of wine has been placed on the table, it hasn't:
+> inventory
+You are carrying a bottle.
+
+> ;          The bottle of wine is still held by the player!
+> take wine from table
+The wine is not on the table.
+
+> ;          The bottle of wine is not on the table!
+> x bottle
+The bottle contains some wine.
+
+> 
+
+> 
+
+Do you want to RESTART, RESTORE, QUIT or UNDO? 

--- a/tests/house-handling-liquids.a3log
+++ b/tests/house-handling-liquids.a3log
@@ -21,7 +21,7 @@ table here. On the table you see a bottle, a chips bag, a jar and a basket
 > ; ******************************************************************************
 > ; Liquids inside takable containers can be handled by using either the container
 > ; or the liquid itself as the verb object.
-> examine bottle 
+> x bottle 
 The bottle contains some wine.
 
 > ; ==============================================================================
@@ -58,20 +58,22 @@ You already have the wine.
 > put wine on table
 You put the bottle of wine onto the table.
 
-> ; **BUG!** Although the verb 'put_on' (implemented on LIQUID) is reporting that
-> ;          the bottle of wine has been placed on the table, it hasn't:
 > inventory
-You are carrying a bottle.
+You are empty-handed.
 
-> ;          The bottle of wine is still held by the player!
-> take wine from table
-The wine is not on the table.
+> x table
+You notice nothing unusual about the table. On the table you see a bottle, 
+a chips bag, a jar and a basket.
 
-> ;          The bottle of wine is not on the table!
 > x bottle
 The bottle contains some wine.
 
-> 
+> take wine from table
+(the bottle of wine)
+Taken.
+
+> take wine from table
+The wine is not on the table.
 
 > 
 

--- a/tests/house-handling-liquids.a3sol
+++ b/tests/house-handling-liquids.a3sol
@@ -1,0 +1,31 @@
+; ******************************************************************************
+; *                                                                            *
+; *                           TEST HANDLING LIQUIDS                            *
+; *                                                                            *
+; ******************************************************************************
+; Liquids inside takable containers can be handled by using either the container
+; or the liquid itself as the verb object.
+examine bottle 
+; ==============================================================================
+; TEST HANDLING VIA CONTAINER
+; ==============================================================================
+take bottle
+take bottle
+put bottle on table
+take bottle from table
+take bottle from table
+put bottle on table
+; ==============================================================================
+; TEST HANDLING VIA LIQUID
+; ==============================================================================
+take wine
+take wine
+put wine on table
+; **BUG!** Although the verb 'put_on' (implemented on LIQUID) is reporting that
+;          the bottle of wine has been placed on the table, it hasn't:
+inventory
+;          The bottle of wine is still held by the player!
+take wine from table
+;          The bottle of wine is not on the table!
+x bottle
+

--- a/tests/house-handling-liquids.a3sol
+++ b/tests/house-handling-liquids.a3sol
@@ -5,7 +5,7 @@
 ; ******************************************************************************
 ; Liquids inside takable containers can be handled by using either the container
 ; or the liquid itself as the verb object.
-examine bottle 
+x bottle 
 ; ==============================================================================
 ; TEST HANDLING VIA CONTAINER
 ; ==============================================================================
@@ -21,11 +21,8 @@ put bottle on table
 take wine
 take wine
 put wine on table
-; **BUG!** Although the verb 'put_on' (implemented on LIQUID) is reporting that
-;          the bottle of wine has been placed on the table, it hasn't:
 inventory
-;          The bottle of wine is still held by the player!
-take wine from table
-;          The bottle of wine is not on the table!
+x table
 x bottle
-
+take wine from table
+take wine from table

--- a/tests/house_sounds.a3log
+++ b/tests/house_sounds.a3log
@@ -25,11 +25,7 @@ You hear nothing unusual.
 > ; ==============================================================================
 > ; TEST ROOM AND SITE OBJECTS
 > ; ==============================================================================
-> ; **ERR!** Room and site objects are not in scope to the 'listen' verb!
-> ;          This is because the verb checks 'IF obj AT hero', but these objs are
-> ;          implemented AT outdoor/indoor, which are locations enwrapping the
-> ;          current hero's location -- i.e., the obj is never AT hero's location,
-> ;          but the inverse is true, for the hero is always AT obj's location!
+> ; NOTE: 'listen' allows parameters not in current location (!).
 > ; ------------------------------------------------------------------------------
 > ; ROOM OBJECTS
 > ; ------------------------------------------------------------------------------
@@ -45,7 +41,13 @@ You hear nothing unusual.
 > ; ------------------------------------------------------------------------------
 > ; SITE OBJECTS
 > ; ------------------------------------------------------------------------------
-> ; NOTE: 'listen' allows parameters not in current location (!):
+> ; **PROBLEM** With these site objects we get blank responses because they are
+> ;             neither at current location nor in an adjecent one (NEARBY).
+> ;             The reason is that the hero is now at an indoor location, and while
+> ;             the garden IS NEARBY it's wrapping outdoor location isn't, because
+> ;             it's not directly adjacent to the kitchen. This is the expected
+> ;             behavior, but the blank message doesn't look too nice, maybe it
+> ;             should say something like "XXX is not here or doesn't exisit"?
 > listen to sky
 
 > listen to ground

--- a/tests/liquids.a3log
+++ b/tests/liquids.a3log
@@ -29,12 +29,16 @@ The jar is empty.
 > fill jar with wine
 You can't fill the jar with the wine.
 
-> ; IMPLICIT TAKING REVEALS BUG:
-> pour wine
-(taking the jar of wine first)
+> x bottle
+The bottle contains some wine.
 
-> ; NOTE: The wine has "magically" moved to the jar! This is due to a bug in how
-> ;       'fill_with' is implemented on liquids --- i.e. it always sets the vessel
-> ;       of 'substance' TO 'cont' (regardless if the action failed)!
+> x jar
+The jar is empty.
+
+> pour wine
+(taking the bottle of wine first)
+You pour the wine on the ground.
+
+> 
 
 Do you want to RESTART, RESTORE, QUIT or UNDO? 

--- a/tests/liquids.a3sol
+++ b/tests/liquids.a3sol
@@ -9,8 +9,6 @@ x jar
 ; ==============================================================================
 ; Now we attempt to fill the jar with wine (it will fail by default):
 fill jar with wine
-; IMPLICIT TAKING REVEALS BUG:
+x bottle
+x jar
 pour wine
-; NOTE: The wine has "magically" moved to the jar! This is due to a bug in how
-;       'fill_with' is implemented on liquids --- i.e. it always sets the vessel
-;       of 'substance' TO 'cont' (regardless if the action failed)!


### PR DESCRIPTION
Added a new test file `house-handling-liquids.a3sol` to test handling liquids in containers by either the liquid's name or the container's name.

The test revealed a but with the `put_on` verb implemented on `liquid`, where trying to use this verb with a liquid didn't actually move the liquid to the surface of the parameter.

The bug was fixed — there wasn't a `LOCATE` statement moving the vessel from the hero to the surface.

I've tried to trace the origin of the problem via Git blame (ie, in case a line of code was accidently deleted during other changes), but it seems the bug was there since before the StdLib was published on GitHub,

<!-- EOF -->
