### PR TITLE
Fix Actors Compliance in Liquids

### DIFF
--- a/lib_classes.i
+++ b/lib_classes.i
@@ -997,10 +997,10 @@ EVERY door ISA OBJECT
         THEN "It is"
         ELSE "They are"
       END IF.
-
+      "currently"
       IF THIS IS NOT open
-        THEN "currently closed."
-        ELSE "currently open."
+        THEN "closed."
+        ELSE "open."
       END IF.
   END VERB examine.
 
@@ -1979,22 +1979,16 @@ EVERY window ISA OBJECT
   IS NOT open.
   IS NOT takeable.
 
-
   VERB examine
     DOES
+      IF THIS IS NOT plural
+        THEN "It is"
+        ELSE "They are"
+      END IF.
+      "currently"
       IF THIS IS NOT open
-        THEN
-          IF THIS IS NOT plural
-            THEN "It is"
-            ELSE "They are"
-          END IF.
-          "currently closed."
-        ELSE
-          IF THIS IS NOT plural
-            THEN "It is"
-            ELSE "They are"
-          END IF.
-          "currently open."
+        THEN "closed."
+        ELSE "open."
       END IF.
   END VERB examine.
 

--- a/lib_classes.i
+++ b/lib_classes.i
@@ -1424,8 +1424,20 @@ EVERY liquid ISA OBJECT
 
   VERB ask_for
     DOES ONLY
+      -- Let's preserve the current state of compliance of act:
+      IF act IS compliant
+        THEN MAKE my_game temp_compliant.
+        ELSE MAKE my_game NOT temp_compliant.
+      END IF.
+      MAKE act compliant.
+      -- It is only possible to get something from an NPC
+      -- if the NPC is 'compliant'.
       LOCATE vessel OF THIS IN hero.
       SAY THE act. "gives" SAY THE vessel OF THIS. "of" SAY THIS. "to you."
+      -- Now let's restore act to its original state of compliacne:
+      IF my_game IS NOT temp_compliant
+        THEN MAKE act NOT compliant.
+      END IF.
   END VERB ask_for.
 
 

--- a/tests/actors-compliance.a3log
+++ b/tests/actors-compliance.a3log
@@ -106,16 +106,15 @@ The woman is compliant.
 The man is not compliant.
 
 > ask man for beer
-That seems to belong to the man.
+The man gives the beer can of beer to you.
 
 > inventory
-You are carrying a sword, a wine bottle and a magic mirror.
+You are carrying a sword, a beer can, a wine bottle and a magic mirror.
 
 > test compliance of man
 The man is not compliant.
 
-> 
-
+> ; OK! compliance is as before.
 > 
 
 Do you want to RESTART, RESTORE, QUIT or UNDO? 

--- a/tests/actors-compliance.a3log
+++ b/tests/actors-compliance.a3log
@@ -12,22 +12,33 @@ All rights reserved.
 Beach
 There is a woman here. There is a man here.
 
+> ; ******************************************************************************
+> ; *                                                                            *
+> ; *                          ACTORS COMPLIANCE TESTS                           *
+> ; *                                                                            *
+> ; ******************************************************************************
+> ; Actors can be 'compliant' or not, where compliance affects wether items can be
+> ; removed from their inventory or not. The verb `ask_for` is an exception, for
+> ; it temporarily makes the actor compliant to allow extraction of the item, and
+> ; then restores the original compliance state of the actor.
 > inventory
 You are empty-handed.
 
 > examine woman
-A rather mysterious woman. The woman is carrying a magic mirror.
+A rather mysterious woman. The woman is carrying a wine bottle and a 
+magic mirror.
 
 > examine man
-A serious lookin man. The man is carrying a sword.
+A serious lookin man. The man is carrying a beer can and a sword.
 
 > ; ==============================================================================
-> ;                   Test Compliance Before and After 'ask_for'                  
+> ; Test compliance before and after 'ask_for'                  
 > ; ==============================================================================
-> ; See Issue #18 on the 'ask_for' problem!
-> ;-----------------------
-> ; Woman compliance-test:
-> ;-----------------------
+> ; The 'test compliance of' verb debugs the compliance state of an actor.
+> ; (See Issue #18 on the previous 'ask_for' problem).
+> ; --------------------
+> ; Test Compliant Actor
+> ; --------------------
 > test compliance of woman
 The woman is compliant.
 
@@ -38,9 +49,9 @@ The woman gives the magic mirror to you.
 The woman is compliant.
 
 > ; OK! compliance is as before.
-> ;---------------------
-> ; Man compliance-test:
-> ;---------------------
+> ; ------------------------
+> ; Test Non-Compliant Actor
+> ; ------------------------
 > test compliance of man
 The man is not compliant.
 
@@ -56,10 +67,54 @@ The man is not compliant.
 You are carrying a sword and a magic mirror.
 
 > examine woman
-A rather mysterious woman. The woman is empty-handed.
+A rather mysterious woman. The woman is carrying a wine bottle.
 
 > examine man
-A serious lookin man. The man is empty-handed.
+A serious lookin man. The man is carrying a beer can.
+
+> ; ==============================================================================
+> ; Test 'ask_for' with 'liquid'
+> ; ==============================================================================
+> ; The verb `ask_for` is also present on the 'liquid' class, so that asking for
+> ; a liquid which has a vessel behaves as if the player asked for the vessel.
+> ; It should behave just like 'ask_for' in terms of handling actors compliance.
+> examine wine bottle
+The wine bottle contains a wine.
+
+> examine beer can
+The beer can contains a beer.
+
+> ; --------------------
+> ; Test Compliant Actor
+> ; --------------------
+> test compliance of woman
+The woman is compliant.
+
+> ask woman for wine
+The woman gives the wine bottle of wine to you.
+
+> inventory
+You are carrying a sword, a wine bottle and a magic mirror.
+
+> test compliance of woman
+The woman is compliant.
+
+> ; ------------------------
+> ; Test Non-Compliant Actor
+> ; ------------------------
+> test compliance of man
+The man is not compliant.
+
+> ask man for beer
+That seems to belong to the man.
+
+> inventory
+You are carrying a sword, a wine bottle and a magic mirror.
+
+> test compliance of man
+The man is not compliant.
+
+> 
 
 > 
 

--- a/tests/actors-compliance.a3sol
+++ b/tests/actors-compliance.a3sol
@@ -53,4 +53,6 @@ test compliance of woman
 ; ------------------------
 test compliance of man
 ask man for beer
-; !!!ERROR!!! The 'ask_for' verb is not handling compliance.
+inventory
+test compliance of man
+; OK! compliance is as before.

--- a/tests/actors-compliance.a3sol
+++ b/tests/actors-compliance.a3sol
@@ -1,20 +1,30 @@
+; ******************************************************************************
+; *                                                                            *
+; *                          ACTORS COMPLIANCE TESTS                           *
+; *                                                                            *
+; ******************************************************************************
+; Actors can be 'compliant' or not, where compliance affects wether items can be
+; removed from their inventory or not. The verb `ask_for` is an exception, for
+; it temporarily makes the actor compliant to allow extraction of the item, and
+; then restores the original compliance state of the actor.
 inventory
 examine woman
 examine man
 ; ==============================================================================
-;                   Test Compliance Before and After 'ask_for'                  
+; Test compliance before and after 'ask_for'                  
 ; ==============================================================================
-; See Issue #18 on the 'ask_for' problem!
-;-----------------------
-; Woman compliance-test:
-;-----------------------
+; The 'test compliance of' verb debugs the compliance state of an actor.
+; (See Issue #18 on the previous 'ask_for' problem).
+; --------------------
+; Test Compliant Actor
+; --------------------
 test compliance of woman
 ask woman for mirror
 test compliance of woman
 ; OK! compliance is as before.
-;---------------------
-; Man compliance-test:
-;---------------------
+; ------------------------
+; Test Non-Compliant Actor
+; ------------------------
 test compliance of man
 ask man for sword
 test compliance of man
@@ -23,3 +33,24 @@ test compliance of man
 inventory
 examine woman
 examine man
+; ==============================================================================
+; Test 'ask_for' with 'liquid'
+; ==============================================================================
+; The verb `ask_for` is also present on the 'liquid' class, so that asking for
+; a liquid which has a vessel behaves as if the player asked for the vessel.
+; It should behave just like 'ask_for' in terms of handling actors compliance.
+examine wine bottle
+examine beer can
+; --------------------
+; Test Compliant Actor
+; --------------------
+test compliance of woman
+ask woman for wine
+inventory
+test compliance of woman
+; ------------------------
+; Test Non-Compliant Actor
+; ------------------------
+test compliance of man
+ask man for beer
+; !!!ERROR!!! The 'ask_for' verb is not handling compliance.

--- a/tests/actors-compliance.alan
+++ b/tests/actors-compliance.alan
@@ -54,10 +54,21 @@ THE mirror IsA object IN woman.
   NAME magic mirror.
 END THE mirror.
 
+
+-- ===============
+-- The Wine Bottle
+-- ===============
+THE wine_bottle IsA listed_container IN woman.
+  NAME wine bottle.
+END THE wine_bottle.
+
+THE wine IsA liquid IN wine_bottle.
+END THE wine.
+
 --==============================================================================
 -- The Man (not compliant)
 --==============================================================================
-THE man IsA female AT beach.
+THE man IsA male AT beach.
   IS NOT compliant.
   HAS ex "A serious lookin man.".
 END THE man.
@@ -68,6 +79,16 @@ END THE man.
 THE sword IsA object IN man.
 END THE sword.
 
+
+-- ========
+-- Beer Can
+-- ========
+THE beer_can IsA listed_container IN man.
+  NAME beer 'can'.
+END THE beer_can.
+
+THE beer IsA liquid IN beer_can.
+END THE beer.
 
 --------------------------------------------------------------------------------
 Start at beach.


### PR DESCRIPTION
Add to `ask_for` verb on `liquid` the code to handle temporary actor compliance, just like in the main `ask_for` verb.

As the added tests show in the first commit, "ask for" was not working when asking a non-compliant actor for a liquid.