### PR TITLE
Clothing

### DIFF
--- a/lib_classes.i
+++ b/lib_classes.i
@@ -603,16 +603,6 @@ END ADD TO.
 
 
 --------------------------------------------------------------------
--- A container used to provide a temporary storage space - ignore!
---------------------------------------------------------------------
-
-THE tempworn ISA OBJECT
-  CONTAINER TAKING CLOTHING.
-  HEADER "You're already wearing"
-END THE tempworn.
-
-
---------------------------------------------------------------------
 -- An event checking that clothing acquired and worn by an actor
 -- mid-game is recognised to be worn by the actor:
 --------------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,8 @@
 # Alan StdLib Test Suite
 
-    Alan SDK: Alan v3.0 beta6
+> Required **Alan SDK**: [Alan v3.0 beta6 build 1866][SDK]
+
+[SDK]: https://www.alanif.se/download-alan-v3/development-snapshots/development-snapshots/build1866 "Go to the download page of this specific Alan SDK release"
 
 This directory tree contains test adventures and automated game commands scripts for testing the Library verbs, messages and features. The purpose of these tests is to check that all library messages are displayed correctly, to detect unexpected edge cases and to track the global impact of code changes on library messages.
 
@@ -136,13 +138,18 @@ Due to scarce reusability of the tests in the `misc/` subfolder (which usually s
 
 All scripts are designed for MS Windows.
 
-In order to use these scripts, make sure that the correct version of the __Alan compiler__ (`alan.exe`) and __Arun interpreter__ (`arun.exe`) are either available on your system PATH or inside this folder.
+In order to use these scripts, make sure that the correct version of the __Alan compiler__ (`alan.exe`) and __Arun interpreter__ (`arun.exe`) are available on your system PATH.
 
 > __IMPORTANT!__ — The Alan SDK version required to run these tests is the one indicated at the very beginning of this document. Using different version (older releases, or developer snapshots) might produce unexpected results.
 > 
 > Tests transcripts obtained with different versions of the Alan SDK should not be commmited to the project, as they might not reflect the correct status of results.
 
-You can safely copy the "`alan.exe`" and "`arun.exe`" executables into this folder, as the repository is configured so that Git will ignore them. Adding a copy of these binaries into the folder has the advantage that you can control which specific version of the executables the scripts should be run with (even if other versions are available on the system PATH); this might be useful if you wish to run the tests using prerelease versions of the compiler and interpreter, or if the Alan SDK on your path is of a different version than the one required for the test suite.
+<!-- sep -->
+
+> __NOTE__ — Just copying the  "`alan.exe`" and "`arun.exe`" executables into this folder wouldn't work because the batch script that runs the tests switches working the directory every time it runs tests in one of the tests subfolders.
+> 
+> A viable workaround to using the system PATH would require you to create symlinks to "`alan.exe`" and "`arun.exe`" in every tests subfoler, making them point to the correct version of the binaries they represent. This would be better than having to add multiple copies (three) of these binaries in every subfolder. You could then place the required binaries inside this folder, and have symlinks in the subfolders point to them, so whenever you override the binaries real the symlinks will reflect the new versions.
+
 
 Both "`alan.exe`" and "`arun.exe`" can be found inside the Alan SDK (Development Kit). Make sure that you are download the appropriate SDK version required by the test suite from Alan website:
 

--- a/tests/clothing/actions_transferring-worn-items.a3log
+++ b/tests/clothing/actions_transferring-worn-items.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 

--- a/tests/clothing/bug_crash.a3log
+++ b/tests/clothing/bug_crash.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -57,22 +58,15 @@ IN WEARING OF: | hero
 
 > give boxers to assistant
 (taking your boxers first)
-You give your boxers to the assistant.
-
-> ; Now comes the crash (using 3.0beta6):
-> dbg boxers
-'boxers' VALUES: | botcover: 2 | 
-DONNED: Yes 
-IN WORN: No. 
-IN WEARING OF: | hero 
+You give your boxers to the assistant. 
 
 As you enter the twilight zone of Adventures, you stumble and fall to
 your knees. In front of you, you can vaguely see the outlines of an
 Adventure that never was.
 
-SYSTEM ERROR: Stack is not empty in main loop
-At source line 722 in 'ega.alan':
-WHEN hero AT dressing_room
+SYSTEM ERROR: Stack is not empty after event execution
+At source line 2053 in '..\..\/lib_classes.i':
+    THEN "the"
 
 <If you are the creator of this piece of Interactive Fiction, please help
 debug this Alan system error. Collect *all* the sources, and, if

--- a/tests/clothing/class_nested-clothes.a3log
+++ b/tests/clothing/class_nested-clothes.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 

--- a/tests/clothing/class_problems.a3log
+++ b/tests/clothing/class_problems.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -16,7 +17,7 @@ clothing item.
 Outside Emporium Alani
 You're standing in front of the Giorgio Alani Emporium entrance. Two
 large brass doors await northward your entrance into the sanctuary of
-fashion consumism.
+fashion consumism. 
 
 > ; ******************************************************************************
 > ; *                                                                            *

--- a/tests/clothing/clothing-unusual.a3log
+++ b/tests/clothing/clothing-unusual.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -16,7 +17,7 @@ clothing item.
 Outside Emporium Alani
 You're standing in front of the Giorgio Alani Emporium entrance. Two
 large brass doors await northward your entrance into the sanctuary of
-fashion consumism. 
+fashion consumism.
 
 > ; ******************************************************************************
 > ; *                                                                            *

--- a/tests/clothing/ega.alan
+++ b/tests/clothing/ega.alan
@@ -20,6 +20,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 

--- a/tests/clothing/test_assistant.a3log
+++ b/tests/clothing/test_assistant.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -54,7 +55,7 @@ The assistant follows you.
 Emporium Alani Main Hall
 This luxurious hall is the crossroad to the various clothing departments
 of the emporium. Two large brass doors lead the way south, out of the
-fashion temple and back into the world of mortal souls.
+fashion temple and back into the world of mortal souls. 
 
 The assistant follows you.
 
@@ -107,7 +108,7 @@ T-shirt here. There is your personal assistant here.
 Emporium Alani Main Hall
 This luxurious hall is the crossroad to the various clothing departments
 of the emporium. Two large brass doors lead the way south, out of the
-fashion temple and back into the world of mortal souls. 
+fashion temple and back into the world of mortal souls.
 
 The assistant follows you.
 
@@ -142,7 +143,7 @@ the womensware dept., where you left her.
 Emporium Alani Main Hall
 This luxurious hall is the crossroad to the various clothing departments
 of the emporium. Two large brass doors lead the way south, out of the
-fashion temple and back into the world of mortal souls. 
+fashion temple and back into the world of mortal souls.
 
 The assistant follows you.
 

--- a/tests/clothing/test_hero.a3log
+++ b/tests/clothing/test_hero.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -16,7 +17,7 @@ clothing item.
 Outside Emporium Alani
 You're standing in front of the Giorgio Alani Emporium entrance. Two
 large brass doors await northward your entrance into the sanctuary of
-fashion consumism. 
+fashion consumism.
 
 > ; ******************************************************************************
 > ; *                                                                            *

--- a/tests/clothing/verbs_wear-remove.a3log
+++ b/tests/clothing/verbs_wear-remove.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -32,7 +33,7 @@ As you move toward the doors they automagically slide open before you.
 Emporium Alani Main Hall
 This luxurious hall is the crossroad to the various clothing departments
 of the emporium. Two large brass doors lead the way south, out of the
-fashion temple and back into the world of mortal souls. There is your
+fashion temple and back into the world of mortal souls.There is your
 personal assistant here.
 
 > north

--- a/tests/clothing/worn-items-listing.a3log
+++ b/tests/clothing/worn-items-listing.a3log
@@ -3,7 +3,8 @@
 Emporium Giorgio Alani 
 An adventure to test clothing. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 
@@ -16,7 +17,7 @@ clothing item.
 Outside Emporium Alani
 You're standing in front of the Giorgio Alani Emporium entrance. Two
 large brass doors await northward your entrance into the sanctuary of
-fashion consumism.
+fashion consumism. 
 
 > ; ******************************************************************************
 > ; *                                                                            *

--- a/tests/house/actions_handling-liquids.a3log
+++ b/tests/house/actions_handling-liquids.a3log
@@ -3,7 +3,8 @@
 The House 
 A rooms & sites setting for various tests. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/house/actions_sitting-and-lying.a3log
+++ b/tests/house/actions_sitting-and-lying.a3log
@@ -3,7 +3,8 @@
 The House 
 A rooms & sites setting for various tests. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/house/class_room-objects.a3log
+++ b/tests/house/class_room-objects.a3log
@@ -3,7 +3,8 @@
 The House 
 A rooms & sites setting for various tests. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/house/class_site-objects.a3log
+++ b/tests/house/class_site-objects.a3log
@@ -3,7 +3,8 @@
 The House 
 A rooms & sites setting for various tests. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/house/class_sounds.a3log
+++ b/tests/house/class_sounds.a3log
@@ -3,7 +3,8 @@
 The House 
 A rooms & sites setting for various tests. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/house/house.alan
+++ b/tests/house/house.alan
@@ -11,6 +11,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 

--- a/tests/misc/actors-compliance.a3log
+++ b/tests/misc/actors-compliance.a3log
@@ -3,7 +3,8 @@
 Actors Compliance Tests 
 An adventure to test actors compliance. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/misc/actors-compliance.alan
+++ b/tests/misc/actors-compliance.alan
@@ -11,6 +11,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 

--- a/tests/misc/liquids.a3log
+++ b/tests/misc/liquids.a3log
@@ -3,7 +3,8 @@
 Liquid Tests 
 Testing liquids behavior. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/misc/liquids.alan
+++ b/tests/misc/liquids.alan
@@ -11,6 +11,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 

--- a/tests/misc/look-verbs-vanilla.a3log
+++ b/tests/misc/look-verbs-vanilla.a3log
@@ -3,7 +3,8 @@
 Test Look Verbs 
 An adventure to test the family of look verbs. 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/misc/look-verbs-vanilla.alan
+++ b/tests/misc/look-verbs-vanilla.alan
@@ -11,6 +11,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 

--- a/tests/misc/meta-verbs.a3log
+++ b/tests/misc/meta-verbs.a3log
@@ -3,7 +3,7 @@
 Meta Verbs Tests 
 Testing out-of-game commands (meta verbs). 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866.
 Standard Library v2.1 
 Version 1 
 All rights reserved.
@@ -383,7 +383,7 @@ Are you sure (press ENTER to confirm)?
 Meta Verbs Tests 
 Testing out-of-game commands (meta verbs). 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866.
 Standard Library v2.1 
 Version 1 
 All rights reserved.
@@ -455,7 +455,7 @@ Do you want to RESTART, RESTORE, QUIT or UNDO? restart
 Meta Verbs Tests 
 Testing out-of-game commands (meta verbs). 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866.
 Standard Library v2.1 
 Version 1 
 All rights reserved.

--- a/tests/misc/meta-verbs.alan
+++ b/tests/misc/meta-verbs.alan
@@ -13,6 +13,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 

--- a/tests/misc/restricted-actions.a3log
+++ b/tests/misc/restricted-actions.a3log
@@ -3,7 +3,8 @@
 Restricted Actions Tests 
 An adventure to test StdLib 2.1 restricted actions 
 (C) 2018 by Tristano Ajmone 
-Programmed with the ALAN Interactive Fiction Language v3.0 beta6.
+Programmed with the ALAN Interactive Fiction Language v3.0beta6 build 1866
+.
 Standard Library v2.1 
 Version 1 
 All rights reserved. 

--- a/tests/misc/restricted-actions.alan
+++ b/tests/misc/restricted-actions.alan
@@ -11,6 +11,7 @@ THE my_game IsA DEFINITION_BLOCK
   HAS author   "Tristano Ajmone".
   HAS year     2018.
   HAS version  "1".
+  HAS AlanV    "v3.0beta6 build 1866".
 
 END THE.
 


### PR DESCRIPTION
These two commits delete the `tempworn` container (firs commit), and then start using Alan v3.0 beta6 build 1866 snapshot for the tests.

The snapshot version is now mentioned explicitly in the README of the tests folder, and some instructions therein where amended accordingly.

Adds to all tests source the Alan SDK version used (via `my_game:AlanV` ).

Re-runs all tests to update logs accordingly.